### PR TITLE
Error during enabling application to tenant if policy already exists

### DIFF
--- a/src/main/resources/reference-data/policies/time-policies.json
+++ b/src/main/resources/reference-data/policies/time-policies.json
@@ -1,6 +1,7 @@
 {
   "policies": [
     {
+      "id": "15f45670-1edf-441e-a247-51f6c000faa3",
       "name": "Business Hours",
       "type": "TIME",
       "timePolicy": {

--- a/src/test/java/org/folio/roles/integration/keyclock/KeycloakPolicyServiceTest.java
+++ b/src/test/java/org/folio/roles/integration/keyclock/KeycloakPolicyServiceTest.java
@@ -24,6 +24,7 @@ import static org.folio.roles.support.PolicyUtils.userPolicy;
 import static org.folio.roles.support.TestConstants.LOGIN_CLIENT_SUFFIX;
 import static org.folio.roles.support.TestConstants.TENANT_ID;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -146,13 +147,12 @@ class KeycloakPolicyServiceTest {
     }
 
     @Test
-    void negative_return_empty_optional_creation_failed() {
+    void positive_return_empty_optional_creation_failed() {
       var policy = createTimePolicy();
 
       doThrow(FeignException.Conflict.class).when(client)
         .create(anyString(), any(), any(), any(), any());
-
-      assertThrows(KeycloakApiException.class, () -> keycloakPolicyService.create(policy));
+      assertDoesNotThrow(() -> keycloakPolicyService.create(policy));
     }
   }
 

--- a/src/test/java/org/folio/roles/integration/keyclock/KeycloakPolicyServiceTest.java
+++ b/src/test/java/org/folio/roles/integration/keyclock/KeycloakPolicyServiceTest.java
@@ -147,7 +147,7 @@ class KeycloakPolicyServiceTest {
     }
 
     @Test
-    void positive_return_empty_optional_creation_failed() {
+    void create_positive_alreadyExists() {
       var policy = createTimePolicy();
 
       doThrow(FeignException.Conflict.class).when(client)


### PR DESCRIPTION
## Purpose

Error during enabling application to the tenant if policy already exists

## Approach

- Do not throw error for 409 status code in keycloak and just proceed with an assignment cause policy already exists

## TODOS and Open Questions

<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

- [ ] Check logging

## Learning

<!-- OPTIONAL
  Help out not only your reviewer but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries, or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
