### PR TITLE
MODROLESKC-145 Remove upper limit for role/user capability assigment

### DIFF
--- a/src/main/resources/swagger.api/schemas/capability/role/roleCapabilitiesRequest.json
+++ b/src/main/resources/swagger.api/schemas/capability/role/roleCapabilitiesRequest.json
@@ -17,8 +17,7 @@
         "description": "Capability identifier",
         "format": "uuid"
       },
-      "minItems": 1,
-      "maxItems": 255
+      "minItems": 1
     }
   },
   "required": [

--- a/src/main/resources/swagger.api/schemas/capability/role/roleCapabilitySetsRequest.json
+++ b/src/main/resources/swagger.api/schemas/capability/role/roleCapabilitySetsRequest.json
@@ -17,8 +17,7 @@
         "description": "Capability set identifier",
         "format": "uuid"
       },
-      "minItems": 1,
-      "maxItems": 255
+      "minItems": 1
     }
   },
   "required": [ "roleId", "capabilitySetIds" ]

--- a/src/main/resources/swagger.api/schemas/capability/user/userCapabilitiesRequest.json
+++ b/src/main/resources/swagger.api/schemas/capability/user/userCapabilitiesRequest.json
@@ -17,8 +17,7 @@
         "description": "Capability identifier",
         "format": "uuid"
       },
-      "minItems": 1,
-      "maxItems": 255
+      "minItems": 1
     }
   },
   "required": [

--- a/src/main/resources/swagger.api/schemas/capability/user/userCapabilitySetsRequest.json
+++ b/src/main/resources/swagger.api/schemas/capability/user/userCapabilitySetsRequest.json
@@ -17,8 +17,7 @@
         "description": "Capability set identifier",
         "format": "uuid"
       },
-      "minItems": 1,
-      "maxItems": 255
+      "minItems": 1
     }
   },
   "required": [ "roleId", "capabilitySetIds" ]

--- a/src/test/java/org/folio/roles/it/RoleCapabilityIT.java
+++ b/src/test/java/org/folio/roles/it/RoleCapabilityIT.java
@@ -194,7 +194,7 @@ class RoleCapabilityIT extends BaseIntegrationTest {
   void assignCapabilities_negative_emptyCapabilities() throws Exception {
     attemptToPostRoleCapabilities(roleCapabilitiesRequest(ROLE_ID, emptyList()))
       .andExpect(status().isBadRequest())
-      .andExpectAll(argumentNotValidErr("size must be between 1 and 255", "capabilityIds", "[]"));
+      .andExpectAll(argumentNotValidErr("size must be between 1 and 2147483647", "capabilityIds", "[]"));
   }
 
   @Test

--- a/src/test/java/org/folio/roles/it/RoleCapabilitySetIT.java
+++ b/src/test/java/org/folio/roles/it/RoleCapabilitySetIT.java
@@ -204,7 +204,7 @@ class RoleCapabilitySetIT extends BaseIntegrationTest {
     var request = roleCapabilitySetsRequest(ROLE_ID, emptyList());
     attemptToPostRoleCapabilitySets(request)
       .andExpect(status().isBadRequest())
-      .andExpectAll(argumentNotValidErr("size must be between 1 and 255", "capabilitySetIds", "[]"));
+      .andExpectAll(argumentNotValidErr("size must be between 1 and 2147483647", "capabilitySetIds", "[]"));
   }
 
   @Test

--- a/src/test/java/org/folio/roles/it/UserCapabilityIT.java
+++ b/src/test/java/org/folio/roles/it/UserCapabilityIT.java
@@ -183,7 +183,7 @@ class UserCapabilityIT extends BaseIntegrationTest {
     var request = userCapabilitiesRequest(USER_ID, emptyList());
     attemptToPostUserCapabilities(request)
       .andExpect(status().isBadRequest())
-      .andExpectAll(argumentNotValidErr("size must be between 1 and 255", "capabilityIds", "[]"));
+      .andExpectAll(argumentNotValidErr("size must be between 1 and 2147483647", "capabilityIds", "[]"));
   }
 
   @Test

--- a/src/test/java/org/folio/roles/it/UserCapabilitySetIT.java
+++ b/src/test/java/org/folio/roles/it/UserCapabilitySetIT.java
@@ -198,7 +198,7 @@ class UserCapabilitySetIT extends BaseIntegrationTest {
     var request = userCapabilitySetsRequest(USER_ID, emptyList());
     attemptToPostUserCapabilitySets(request)
       .andExpect(status().isBadRequest())
-      .andExpectAll(argumentNotValidErr("size must be between 1 and 255", "capabilitySetIds", "[]"));
+      .andExpectAll(argumentNotValidErr("size must be between 1 and 2147483647", "capabilitySetIds", "[]"));
   }
 
   @Test


### PR DESCRIPTION
## Purpose

Remove an upper limit for role/user capability/capability-set assigment.
US: [MODROLESKC-145](https://folio-org.atlassian.net/browse/MODROLESKC-145)
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant Rally issue, add a link directly to the issue URL here.
 -->

## Approach

- Fix validation in the swagger schema
- Adjust integration tests error messages

<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## TODOS and Open Questions

<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

- [ ] Check logging

## Learning

<!-- OPTIONAL
  Help out not only your reviewer but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries, or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
