### PR TITLE
[MODROLESKC-150]: fix loading reference data multiple times

### DIFF
--- a/src/main/java/org/folio/roles/integration/keyclock/KeycloakRoleService.java
+++ b/src/main/java/org/folio/roles/integration/keyclock/KeycloakRoleService.java
@@ -41,7 +41,7 @@ public class KeycloakRoleService {
   public Optional<Role> findByName(String name) {
     try {
       var keycloakRole = roleClient.findByName(context.getTenantId(), tokenService.getToken(), name);
-      log.info("Role has been found by name: name = {}", name);
+      log.debug("Role has been found by name: name = {}", name);
       return of(roleMapper.toRole(keycloakRole));
     } catch (FeignException.NotFound e) {
       log.info("Role not found by name: name = {}", name);

--- a/src/main/java/org/folio/roles/integration/keyclock/KeycloakRoleService.java
+++ b/src/main/java/org/folio/roles/integration/keyclock/KeycloakRoleService.java
@@ -44,7 +44,7 @@ public class KeycloakRoleService {
       log.debug("Role has been found by name: name = {}", name);
       return of(roleMapper.toRole(keycloakRole));
     } catch (FeignException.NotFound e) {
-      log.info("Role not found by name: name = {}", name);
+      log.debug("Role not found by name: name = {}", name);
       return empty();
     } catch (FeignException e) {
       throw new KeycloakApiException("Failed to find role by name: name = " + name, e, e.status());

--- a/src/main/java/org/folio/roles/service/reference/RolesDataLoader.java
+++ b/src/main/java/org/folio/roles/service/reference/RolesDataLoader.java
@@ -29,16 +29,8 @@ public class RolesDataLoader implements ReferenceDataLoader {
       .collect(toSet());
 
     for (var role : preparedRoles) {
-      if (role.getName() != null) {
-        keycloakRoleService.findByName(role.getName())
-          .ifPresentOrElse(foundRole -> {
-            var updatedRole = roleService.updateByName(foundRole);
-            log.info("Role has been updated: id = {}, name = {}", updatedRole.getId(), updatedRole.getName());
-          }, () -> {
-            var createdRole = roleService.create(role);
-            log.info("Role has been created: id = {}, name = {}", createdRole.getId(), createdRole.getName());
-          });
-      }
+      keycloakRoleService.findByName(role.getName())
+        .ifPresentOrElse(roleService::updateFoundByName, () -> roleService.create(role));
     }
   }
 }

--- a/src/main/java/org/folio/roles/service/role/RoleService.java
+++ b/src/main/java/org/folio/roles/service/role/RoleService.java
@@ -125,6 +125,25 @@ public class RoleService {
   }
 
   /**
+   * Update one role by name.
+   *
+   * @param role - role for updating
+   * @return updated role {@link Role}
+   */
+  @Transactional
+  public Role updateByName(Role role) {
+    Assert.notNull(role.getId(), "Role should have ID");
+    var actualRole = keycloakService.update(role);
+    try {
+      return entityService.create(role);
+    } catch (Exception e) {
+      log.debug("Rollback role state in Keycloak: id = {}, name = {}", actualRole.getId(), actualRole.getName());
+      keycloakService.update(actualRole);
+      throw e;
+    }
+  }
+
+  /**
    * Delete role by ID.
    *
    * @param id - role identifier

--- a/src/main/java/org/folio/roles/service/role/RoleService.java
+++ b/src/main/java/org/folio/roles/service/role/RoleService.java
@@ -82,7 +82,9 @@ public class RoleService {
   public Role create(Role role) {
     var createdRole = keycloakService.create(role);
     try {
-      return entityService.create(createdRole);
+      Role savedRole = entityService.create(createdRole);
+      log.debug("Role has been created: id = {}, name = {}", savedRole.getId(), savedRole.getName());
+      return savedRole;
     } catch (Exception exception) {
       keycloakService.deleteById(createdRole.getId());
       throw new ServiceException("Failed to create role", "cause", exception.getMessage());
@@ -125,21 +127,21 @@ public class RoleService {
   }
 
   /**
-   * Update one role by name.
+   * Update one role found by name.
    *
    * @param role - role for updating
    * @return updated role {@link Role}
    */
   @Transactional
-  public Role updateByName(Role role) {
+  public Role updateFoundByName(Role role) {
     Assert.notNull(role.getId(), "Role should have ID");
-    var actualRole = keycloakService.update(role);
+    keycloakService.update(role);
     try {
-      return entityService.create(role);
+      Role updatedRole = entityService.create(role);
+      log.debug("Role has been updated: id = {}, name = {}", updatedRole.getId(), updatedRole.getName());
+      return updatedRole;
     } catch (Exception e) {
-      log.debug("Rollback role state in Keycloak: id = {}, name = {}", actualRole.getId(), actualRole.getName());
-      keycloakService.update(actualRole);
-      throw e;
+      throw new ServiceException("Failed to update role found by name", "cause", e.getMessage());
     }
   }
 

--- a/src/test/java/org/folio/roles/integration/keyclock/KeycloakRoleServiceTest.java
+++ b/src/test/java/org/folio/roles/integration/keyclock/KeycloakRoleServiceTest.java
@@ -97,7 +97,7 @@ class KeycloakRoleServiceTest {
   class FindByName {
 
     @Test
-    void positive_returns_role() {
+    void positive_returnsRole() {
       var role = role();
       var keycloakRole = keycloakRole();
 
@@ -110,7 +110,7 @@ class KeycloakRoleServiceTest {
     }
 
     @Test
-    void positive_returns_empty_role_when_not_found() {
+    void positive_returnsEmptyRoleWhenNotFound() {
       when(roleClient.findByName(anyString(), anyString(), anyString())).thenThrow(FeignException.NotFound.class);
 
       var actual = roleService.findByName(ROLE_NAME);
@@ -118,7 +118,7 @@ class KeycloakRoleServiceTest {
     }
 
     @Test
-    void negative_throws_keycloak_api_exception_while_feign_exception() {
+    void negative_throwsKeycloakApiExceptionWhileFeignException() {
       when(roleClient.findByName(anyString(), anyString(), anyString())).thenThrow(FeignException.class);
 
       assertThrows(KeycloakApiException.class, () -> roleService.findByName(ROLE_NAME));

--- a/src/test/java/org/folio/roles/integration/keyclock/KeycloakRoleServiceTest.java
+++ b/src/test/java/org/folio/roles/integration/keyclock/KeycloakRoleServiceTest.java
@@ -2,6 +2,7 @@ package org.folio.roles.integration.keyclock;
 
 import static org.folio.roles.support.KeycloakUtils.ACCESS_TOKEN;
 import static org.folio.roles.support.RoleUtils.ROLE_ID;
+import static org.folio.roles.support.RoleUtils.ROLE_NAME;
 import static org.folio.roles.support.RoleUtils.keycloakRole;
 import static org.folio.roles.support.RoleUtils.role;
 import static org.folio.roles.support.RoleUtils.role2;
@@ -92,6 +93,39 @@ class KeycloakRoleServiceTest {
   }
 
   @Nested
+  @DisplayName("findByName")
+  class FindByName {
+
+    @Test
+    void positive_returns_role() {
+      var role = role();
+      var keycloakRole = keycloakRole();
+
+      when(roleClient.findByName(anyString(), anyString(), eq(role.getName()))).thenReturn(keycloakRole);
+
+      var actual = roleService.findByName(role.getName());
+
+      assertTrue(actual.isPresent());
+      assertEquals(actual.get(), role());
+    }
+
+    @Test
+    void positive_returns_empty_role_when_not_found() {
+      when(roleClient.findByName(anyString(), anyString(), anyString())).thenThrow(FeignException.NotFound.class);
+
+      var actual = roleService.findByName(ROLE_NAME);
+      assertTrue(actual.isEmpty());
+    }
+
+    @Test
+    void negative_throws_keycloak_api_exception_while_feign_exception() {
+      when(roleClient.findByName(anyString(), anyString(), anyString())).thenThrow(FeignException.class);
+
+      assertThrows(KeycloakApiException.class, () -> roleService.findByName(ROLE_NAME));
+    }
+  }
+
+  @Nested
   @DisplayName("create")
   class Create {
 
@@ -99,8 +133,6 @@ class KeycloakRoleServiceTest {
     void positive_returns_optional_of_created_roles() {
       var keycloakRole = keycloakRole();
       var role = role();
-      var roles = new Roles().addRolesItem(role);
-      roles.setTotalRecords(roles.getRoles().size());
       var token = tokenService.getToken();
 
       when(roleClient.findByName(anyString(), eq(token), eq(keycloakRole.getName()))).thenReturn(keycloakRole);

--- a/src/test/java/org/folio/roles/service/reference/RolesDataLoaderTest.java
+++ b/src/test/java/org/folio/roles/service/reference/RolesDataLoaderTest.java
@@ -36,7 +36,6 @@ class RolesDataLoaderTest {
 
     when(resourceHelper.readObjectsFromDirectory("reference-data/roles", Roles.class))
       .thenReturn(of(roles));
-    when(roleService.create(role)).thenReturn(role);
 
     rolesDataLoader.loadReferenceData();
 
@@ -52,12 +51,11 @@ class RolesDataLoaderTest {
     when(resourceHelper.readObjectsFromDirectory("reference-data/roles", Roles.class))
       .thenReturn(of(roles));
     when(keycloakRoleService.findByName("role1")).thenReturn(Optional.of(role));
-    when(roleService.updateByName(role)).thenReturn(role);
 
     rolesDataLoader.loadReferenceData();
 
     verify(resourceHelper).readObjectsFromDirectory("reference-data/roles", Roles.class);
-    verify(roleService).updateByName(role);
+    verify(roleService).updateFoundByName(role);
     verify(keycloakRoleService).findByName(role.getName());
   }
 
@@ -69,7 +67,6 @@ class RolesDataLoaderTest {
     when(resourceHelper.readObjectsFromDirectory("reference-data/roles", Roles.class))
       .thenReturn(of(roles));
     when(keycloakRoleService.findByName("role1")).thenReturn(Optional.empty());
-    when(roleService.create(role)).thenReturn(role);
 
     rolesDataLoader.loadReferenceData();
 

--- a/src/test/java/org/folio/roles/service/reference/RolesDataLoaderTest.java
+++ b/src/test/java/org/folio/roles/service/reference/RolesDataLoaderTest.java
@@ -7,8 +7,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
 import org.folio.roles.domain.dto.Role;
 import org.folio.roles.domain.dto.Roles;
+import org.folio.roles.integration.keyclock.KeycloakRoleService;
 import org.folio.roles.service.role.RoleService;
 import org.folio.roles.utils.ResourceHelper;
 import org.folio.test.types.UnitTest;
@@ -24,6 +26,7 @@ class RolesDataLoaderTest {
 
   @InjectMocks private RolesDataLoader rolesDataLoader;
   @Mock private RoleService roleService;
+  @Mock private KeycloakRoleService keycloakRoleService;
   @Mock private ResourceHelper resourceHelper;
 
   @Test
@@ -48,14 +51,14 @@ class RolesDataLoaderTest {
 
     when(resourceHelper.readObjectsFromDirectory("reference-data/roles", Roles.class))
       .thenReturn(of(roles));
-    when(roleService.update(role)).thenReturn(role);
-    when(roleService.existById(role.getId())).thenReturn(true);
+    when(keycloakRoleService.findByName("role1")).thenReturn(Optional.of(role));
+    when(roleService.updateByName(role)).thenReturn(role);
 
     rolesDataLoader.loadReferenceData();
 
     verify(resourceHelper).readObjectsFromDirectory("reference-data/roles", Roles.class);
-    verify(roleService).update(role);
-    verify(roleService).existById(role.getId());
+    verify(roleService).updateByName(role);
+    verify(keycloakRoleService).findByName(role.getName());
   }
 
   @Test
@@ -65,14 +68,14 @@ class RolesDataLoaderTest {
 
     when(resourceHelper.readObjectsFromDirectory("reference-data/roles", Roles.class))
       .thenReturn(of(roles));
+    when(keycloakRoleService.findByName("role1")).thenReturn(Optional.empty());
     when(roleService.create(role)).thenReturn(role);
-    when(roleService.existById(role.getId())).thenReturn(false);
 
     rolesDataLoader.loadReferenceData();
 
     verify(resourceHelper).readObjectsFromDirectory("reference-data/roles", Roles.class);
     verify(roleService).create(role);
-    verify(roleService).existById(role.getId());
+    verify(keycloakRoleService).findByName(role.getName());
   }
 
   @Test

--- a/src/test/java/org/folio/roles/service/role/RoleServiceTest.java
+++ b/src/test/java/org/folio/roles/service/role/RoleServiceTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.when;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
 import java.util.Optional;
+import org.folio.roles.exception.ServiceException;
 import org.folio.roles.integration.keyclock.KeycloakRoleService;
 import org.folio.test.types.UnitTest;
 import org.junit.jupiter.api.DisplayName;
@@ -56,8 +57,29 @@ class RoleServiceTest {
   }
 
   @Nested
-  @DisplayName("update")
+  @DisplayName("create")
   class Create {
+
+    @Test
+    void create() {
+      var role = role();
+      when(keycloakService.create(role)).thenReturn(role);
+
+      facade.create(role);
+
+      verify(keycloakService).create(role);
+      verify(entityService).create(role);
+    }
+
+    @Test
+    void negative_create() {
+      var role = role();
+      when(keycloakService.create(role)).thenReturn(role);
+      when(entityService.create(role)).thenThrow(RuntimeException.class);
+
+      assertThrows(ServiceException.class, () -> facade.create(role));
+      verify(keycloakService, times(1)).deleteById(role.getId());
+    }
 
     @Test
     void positive() {
@@ -110,6 +132,32 @@ class RoleServiceTest {
       when(entityService.update(role)).thenThrow(RuntimeException.class);
 
       assertThrows(RuntimeException.class, () -> facade.update(role));
+      verify(keycloakService, times(2)).update(any());
+    }
+  }
+
+  @Nested
+  @DisplayName("updateByName")
+  class UpdateByName {
+
+    @Test
+    void positive() {
+      var role = role();
+
+      facade.updateByName(role);
+
+      verify(keycloakService).update(role);
+      verify(entityService).create(role);
+    }
+
+    @Test
+    void negative_repositoryThrowsException() {
+      var role = role();
+
+      when(keycloakService.update(any())).thenReturn(role);
+      when(entityService.create(role)).thenThrow(RuntimeException.class);
+
+      assertThrows(RuntimeException.class, () -> facade.updateByName(role));
       verify(keycloakService, times(2)).update(any());
     }
   }

--- a/src/test/java/org/folio/roles/service/role/RoleServiceTest.java
+++ b/src/test/java/org/folio/roles/service/role/RoleServiceTest.java
@@ -64,6 +64,7 @@ class RoleServiceTest {
     void create() {
       var role = role();
       when(keycloakService.create(role)).thenReturn(role);
+      when(entityService.create(role)).thenReturn(role);
 
       facade.create(role);
 
@@ -78,7 +79,7 @@ class RoleServiceTest {
       when(entityService.create(role)).thenThrow(RuntimeException.class);
 
       assertThrows(ServiceException.class, () -> facade.create(role));
-      verify(keycloakService, times(1)).deleteById(role.getId());
+      verify(keycloakService).deleteById(role.getId());
     }
 
     @Test
@@ -137,14 +138,15 @@ class RoleServiceTest {
   }
 
   @Nested
-  @DisplayName("updateByName")
+  @DisplayName("updateFoundByName")
   class UpdateByName {
 
     @Test
     void positive() {
       var role = role();
+      when(entityService.create(role)).thenReturn(role);
 
-      facade.updateByName(role);
+      facade.updateFoundByName(role);
 
       verify(keycloakService).update(role);
       verify(entityService).create(role);
@@ -157,8 +159,8 @@ class RoleServiceTest {
       when(keycloakService.update(any())).thenReturn(role);
       when(entityService.create(role)).thenThrow(RuntimeException.class);
 
-      assertThrows(RuntimeException.class, () -> facade.updateByName(role));
-      verify(keycloakService, times(2)).update(any());
+      assertThrows(ServiceException.class, () -> facade.updateFoundByName(role));
+      verify(keycloakService).update(any());
     }
   }
 


### PR DESCRIPTION
## Purpose
Fix loading reference data multiple times
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant Rally issue, add a link directly to the issue URL here.
 -->

## Approach
Role on the Keycloak side is created with new generated ID in any case, therefore check for existence is by role name

<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## TODOS and Open Questions

<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

- [ ] Check logging

## Learning
Tested locally.

Before:
![image](https://github.com/folio-org/mod-roles-keycloak/assets/159446370/4a1651fb-cb60-436a-a843-13ea2ba99257)


After:
![image](https://github.com/folio-org/mod-roles-keycloak/assets/159446370/7e60b8d4-0259-4c8e-9d36-d701cd5cc7bb)




<!-- OPTIONAL
  Help out not only your reviewer but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries, or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
