### PR TITLE
MODROLESKC-172 Add folio-permission name to capability-set

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -139,32 +139,12 @@
     },
     {
       "id": "capability-sets",
-      "version": "1.0",
+      "version": "2.0",
       "handlers": [
         {
           "methods": [ "GET" ],
           "pathPattern": "/capability-sets/{id}",
           "permissionsRequired": [ "capability-sets.item.get" ]
-        },
-        {
-          "methods": [ "PUT"],
-          "pathPattern": "/capability-sets/{id}",
-          "permissionsRequired": [ "capability-sets.item.put" ]
-        },
-        {
-          "methods": [ "DELETE" ],
-          "pathPattern": "/capability-sets/{id}",
-          "permissionsRequired": [ "capability-sets.item.delete" ]
-        },
-        {
-          "methods": [ "POST" ],
-          "pathPattern": "/capability-sets",
-          "permissionsRequired": [ "capability-sets.item.post" ]
-        },
-        {
-          "methods": [ "POST" ],
-          "pathPattern": "/capability-sets/batch",
-          "permissionsRequired": [ "capability-sets.collection.post" ]
         },
         {
           "methods": [ "GET" ],
@@ -493,26 +473,6 @@
       "description": "Searching capabilities"
     },
     {
-      "permissionName": "capability-sets.item.post",
-      "displayName": "Capability Set - create record",
-      "description": "Create a capability set record"
-    },
-    {
-      "permissionName": "capability-sets.item.put",
-      "displayName": "Capability Set - update record by ID",
-      "description": "Update capability set record"
-    },
-    {
-      "permissionName": "capability-sets.item.delete",
-      "displayName": "Capability Set - delete record by ID",
-      "description": "Delete capability set record"
-    },
-    {
-      "permissionName": "capability-sets.collection.post",
-      "displayName": "Capability Set - create batch of records",
-      "description": "Create one or more capability set records"
-    },
-    {
       "permissionName": "capabilities.all",
       "displayName": "Capabilities - all permissions",
       "description": "All permissions for capability management",
@@ -520,11 +480,7 @@
         "capabilities.item.get",
         "capabilities.collection.get",
         "capability-sets.capabilities.collection.get",
-        "capability-sets.item.get",
         "capability-sets.collection.get",
-        "capability-sets.item.put",
-        "capability-sets.item.delete",
-        "capability-sets.item.post",
         "capability-sets.collection.post"
       ]
     },

--- a/src/main/java/org/folio/roles/controller/CapabilitySetController.java
+++ b/src/main/java/org/folio/roles/controller/CapabilitySetController.java
@@ -1,7 +1,5 @@
 package org.folio.roles.controller;
 
-import static org.springframework.http.HttpStatus.CREATED;
-
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.folio.roles.domain.dto.CapabilitySet;
@@ -18,20 +16,6 @@ public class CapabilitySetController implements CapabilitySetApi {
   private final CapabilitySetService capabilitySetService;
 
   @Override
-  public ResponseEntity<CapabilitySet> createCapabilitySet(CapabilitySet capability) {
-    var createdCapability = capabilitySetService.create(capability);
-    return ResponseEntity.status(CREATED).body(createdCapability);
-  }
-
-  @Override
-  public ResponseEntity<CapabilitySets> createCapabilitySets(CapabilitySets capabilitySets) {
-    var createdCapabilitySets = capabilitySetService.create(capabilitySets.getCapabilitySets());
-    return ResponseEntity.status(CREATED).body(new CapabilitySets()
-      .capabilitySets(createdCapabilitySets)
-      .totalRecords((long) createdCapabilitySets.size()));
-  }
-
-  @Override
   public ResponseEntity<CapabilitySet> getCapabilitySetById(UUID id) {
     var result = capabilitySetService.get(id);
     return ResponseEntity.ok(result);
@@ -43,17 +27,5 @@ public class CapabilitySetController implements CapabilitySetApi {
     return ResponseEntity.ok(new CapabilitySets()
       .capabilitySets(pageResult.getRecords())
       .totalRecords(pageResult.getTotalRecords()));
-  }
-
-  @Override
-  public ResponseEntity<Void> updateCapabilitySet(UUID id, CapabilitySet capabilitySet) {
-    capabilitySetService.update(id, capabilitySet);
-    return ResponseEntity.noContent().build();
-  }
-
-  @Override
-  public ResponseEntity<Void> deleteCapabilitySet(UUID id) {
-    capabilitySetService.delete(id);
-    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/org/folio/roles/domain/entity/CapabilitySetEntity.java
+++ b/src/main/java/org/folio/roles/domain/entity/CapabilitySetEntity.java
@@ -59,6 +59,9 @@ public class CapabilitySetEntity extends Auditable {
   @Column(name = "type", columnDefinition = "capability_type")
   private EntityCapabilityType type;
 
+  @Column(name = "folio_permission")
+  private String permission;
+
   @Fetch(FetchMode.SUBSELECT)
   @ElementCollection(fetch = EAGER)
   @CollectionTable(name = "capability_set_capability", joinColumns = @JoinColumn(name = "capability_set_id"))

--- a/src/main/java/org/folio/roles/integration/kafka/CapabilityEventProcessor.java
+++ b/src/main/java/org/folio/roles/integration/kafka/CapabilityEventProcessor.java
@@ -124,6 +124,7 @@ public class CapabilityEventProcessor {
       .resource(rawCapability.getResource())
       .description(permission.getDescription())
       .applicationId(event.getApplicationId())
+      .permission(permission.getPermissionName())
       .capabilities(capabilities);
   }
 

--- a/src/main/java/org/folio/roles/integration/kafka/CapabilitySetDescriptorService.java
+++ b/src/main/java/org/folio/roles/integration/kafka/CapabilitySetDescriptorService.java
@@ -2,7 +2,6 @@ package org.folio.roles.integration.kafka;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
-import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static org.apache.commons.collections4.CollectionUtils.isEmpty;
 import static org.folio.common.utils.CollectionUtils.mapItems;
@@ -106,13 +105,13 @@ public class CapabilitySetDescriptorService {
     return capabilityNames.stream()
       .map(capabilityName -> getCapabilityId(capabilityIdsMap, capabilityName))
       .flatMap(Optional::stream)
-      .collect(toList());
+      .toList();
   }
 
   private static List<String> getAllCapabilityNames(Map<String, List<String>> requiredCapabilityNames) {
     return requiredCapabilityNames.values().stream()
       .flatMap(Collection::stream)
-      .collect(toList());
+      .toList();
   }
 
   private Optional<UUID> getCapabilityId(Map<String, UUID> existingCapabilityIdsMap, String capabilityName) {
@@ -135,7 +134,7 @@ public class CapabilitySetDescriptorService {
       .map(entry -> getCapabilityNames(descriptor, entry))
       .flatMap(Collection::stream)
       .distinct()
-      .collect(toList());
+      .toList();
   }
 
   private static Collection<String> getCapabilityNames(CapabilitySetDescriptor descriptor,

--- a/src/main/java/org/folio/roles/integration/kafka/KafkaMessageListener.java
+++ b/src/main/java/org/folio/roles/integration/kafka/KafkaMessageListener.java
@@ -1,6 +1,5 @@
 package org.folio.roles.integration.kafka;
 
-import static java.util.stream.Collectors.toList;
 import static org.folio.common.utils.CollectionUtils.toStream;
 import static org.folio.spring.integration.XOkapiHeaders.TENANT;
 
@@ -59,6 +58,6 @@ public class KafkaMessageListener {
     return toStream(event.getResources())
       .map(FolioResource::getPermission)
       .filter(Objects::nonNull)
-      .collect(toList());
+      .toList();
   }
 }

--- a/src/main/java/org/folio/roles/integration/kafka/model/CapabilitySetDescriptor.java
+++ b/src/main/java/org/folio/roles/integration/kafka/model/CapabilitySetDescriptor.java
@@ -25,6 +25,11 @@ public class CapabilitySetDescriptor {
   private String resource;
 
   /**
+   * A Folio permission name.
+   */
+  private String permission;
+
+  /**
    * Capability set action.
    */
   private CapabilityAction action;
@@ -112,6 +117,16 @@ public class CapabilitySetDescriptor {
   public CapabilitySetDescriptor capabilities(
     Map<String, List<CapabilityAction>> capabilities) {
     this.capabilities = capabilities;
+    return this;
+  }
+
+  /**
+   * Sets permission field and returns {@link CapabilitySetDescriptor}.
+   *
+   * @return modified {@link CapabilitySetDescriptor} value
+   */
+  public CapabilitySetDescriptor permission(String permission) {
+    this.permission = permission;
     return this;
   }
 }

--- a/src/main/java/org/folio/roles/integration/keyclock/KeycloakRoleService.java
+++ b/src/main/java/org/folio/roles/integration/keyclock/KeycloakRoleService.java
@@ -65,9 +65,8 @@ public class KeycloakRoleService {
 
   public Roles search(String query, Integer offset, Integer limit) {
     try {
-      var keycloakRoles = roleClient.find(context.getTenantId(), tokenService.getToken(), offset, limit,
-        query);
-      var roles = keycloakRoles.stream().map(roleMapper::toRole).collect(toList());
+      var keycloakRoles = roleClient.find(context.getTenantId(), tokenService.getToken(), offset, limit, query);
+      var roles = keycloakRoles.stream().map(roleMapper::toRole).toList();
       log.debug("Roles have been found: names = {}", () -> extractRolesNames(roles));
       return buildRoles(roles);
     } catch (FeignException e) {

--- a/src/main/java/org/folio/roles/service/capability/CapabilityService.java
+++ b/src/main/java/org/folio/roles/service/capability/CapabilityService.java
@@ -1,15 +1,14 @@
 package org.folio.roles.service.capability;
 
+import static java.util.Arrays.stream;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toList;
 import static org.apache.commons.collections4.CollectionUtils.isEmpty;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.folio.roles.utils.CapabilityUtils.getCapabilityName;
 
 import jakarta.persistence.EntityNotFoundException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -213,7 +212,7 @@ public class CapabilityService {
   public List<Capability> findByIds(Collection<UUID> capabilityIds) {
     return capabilityRepository.findAllById(capabilityIds).stream()
       .map(capabilityEntityMapper::convert)
-      .collect(toList());
+      .toList();
   }
 
   /**
@@ -229,8 +228,7 @@ public class CapabilityService {
       return capabilityRepository.findAllFolioPermissions(userId);
     }
 
-    String permissionPrefixesParam = Arrays.stream(visiblePermissionPrefixes)
-      .collect(joining(", ", "{", "}"));
+    var permissionPrefixesParam = stream(visiblePermissionPrefixes).collect(joining(", ", "{", "}"));
 
     return capabilityRepository.findVisibleFolioPermissions(userId, permissionPrefixesParam);
   }

--- a/src/main/java/org/folio/roles/utils/CapabilityUtils.java
+++ b/src/main/java/org/folio/roles/utils/CapabilityUtils.java
@@ -1,6 +1,5 @@
 package org.folio.roles.utils;
 
-import static java.util.stream.Collectors.toList;
 import static org.folio.common.utils.CollectionUtils.toStream;
 
 import java.util.Collection;
@@ -55,7 +54,7 @@ public class CapabilityUtils {
       .filter(CollectionUtils::isNotEmpty)
       .flatMap(Collection::stream)
       .distinct()
-      .collect(toList());
+      .toList();
   }
 
   /**
@@ -70,6 +69,6 @@ public class CapabilityUtils {
       .filter(CollectionUtils::isNotEmpty)
       .flatMap(Collection::stream)
       .distinct()
-      .collect(toList());
+      .toList();
   }
 }

--- a/src/main/java/org/folio/roles/utils/UpdateOperationHelper.java
+++ b/src/main/java/org/folio/roles/utils/UpdateOperationHelper.java
@@ -124,6 +124,10 @@ public final class UpdateOperationHelper<T> {
     return isEmpty(values) ? new LinkedHashSet<>() : new LinkedHashSet<>(values);
   }
 
+  /**
+   * Result of subtraction must be mutable.
+   */
+  @SuppressWarnings("java:S6204")
   private static <T> List<T> subtract(Set<T> a, Set<T> b) {
     return CollectionUtils.toStream(a)
       .filter(value -> !b.contains(value))

--- a/src/main/resources/changelog/changelog-master.xml
+++ b/src/main/resources/changelog/changelog-master.xml
@@ -25,4 +25,5 @@
   <include file="changes/update_timestamp_fields_to_timestamp_with_zone.xml" relativeToChangelogFile="true"/>
   <include file="changes/update-role-deletion-constraints.xml" relativeToChangelogFile="true"/>
   <include file="changes/create-loadable-role-tables.xml" relativeToChangelogFile="true"/>
+  <include file="changes/add_permission_to_capability_set_table.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changelog/changes/add_permission_to_capability_set_table.xml
+++ b/src/main/resources/changelog/changes/add_permission_to_capability_set_table.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+               http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+  <changeSet id="update-capability-set-table" author="Pavel Filippov">
+    <addColumn tableName="capability_set">
+      <column name="folio_permission" type="text"/>
+    </addColumn>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/swagger.api/mod-roles-keycloak.yaml
+++ b/src/main/resources/swagger.api/mod-roles-keycloak.yaml
@@ -660,32 +660,6 @@ paths:
           $ref: '#/components/responses/internalServerErrorResponse'
 
   /capability-sets:
-    post:
-      description: Create a capability set
-      operationId: createCapabilitySet
-      tags:
-        - capability-set
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/capabilitySet'
-            example:
-              $ref: '#/components/examples/capabilitySetRequest'
-      responses:
-        '201':
-          description: Created capability set object
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/capabilitySet'
-              example:
-                $ref: '#/components/examples/capabilitySetResponse'
-        '400':
-          $ref: '#/components/responses/badRequestResponse'
-        '500':
-          $ref: '#/components/responses/internalServerErrorResponse'
     get:
       description: Get capabilities by query
       operationId: findCapabilitySets
@@ -698,34 +672,6 @@ paths:
       responses:
         '200':
           description: A collection of capabilities
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/capabilitySets'
-              example:
-                $ref: '#/components/examples/capabilitySetsResponse'
-        '400':
-          $ref: '#/components/responses/badRequestResponse'
-        '500':
-          $ref: '#/components/responses/internalServerErrorResponse'
-
-  /capability-sets/batch:
-    post:
-      description: Create one or more capability sets
-      operationId: createCapabilitySets
-      tags:
-        - capability-set
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/capabilitySets'
-            example:
-              $ref: '#/components/examples/capabilitySetsRequest'
-      responses:
-        '201':
-          description: Array of created capability set(s)
           content:
             application/json:
               schema:
@@ -754,42 +700,6 @@ paths:
                 $ref: '#/components/schemas/capabilitySet'
               example:
                 $ref: '#/components/examples/capabilitySetResponse'
-        '404':
-          $ref: '#/components/responses/notFoundResponse'
-        '500':
-          $ref: '#/components/responses/internalServerErrorResponse'
-    put:
-      description: Update a capability set
-      operationId: updateCapabilitySet
-      tags:
-        - capability-set
-      parameters:
-        - $ref: '#/components/parameters/pathEntityId'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/capabilitySet'
-            example:
-              $ref: '#/components/examples/capabilitySetRequest'
-      responses:
-        '204':
-          description: Update existing capability
-        '404':
-          $ref: '#/components/responses/notFoundResponse'
-        '500':
-          $ref: '#/components/responses/internalServerErrorResponse'
-    delete:
-      description: Delete a capability set
-      operationId: deleteCapabilitySet
-      tags:
-        - capability-set
-      parameters:
-        - $ref: '#/components/parameters/pathEntityId'
-      responses:
-        '204':
-          description: Delete a capability set
         '404':
           $ref: '#/components/responses/notFoundResponse'
         '500':

--- a/src/main/resources/swagger.api/schemas/capability/capabilitySet.json
+++ b/src/main/resources/swagger.api/schemas/capability/capabilitySet.json
@@ -35,6 +35,10 @@
       "description": "The type of capability",
       "$ref": "capabilityType.json"
     },
+    "permission": {
+      "description": "Folio permission name",
+      "type": "string"
+    },
     "capabilities": {
       "description": "List with assigned capability ids",
       "type": "array",

--- a/src/test/java/org/folio/roles/controller/CapabilitySetControllerTest.java
+++ b/src/test/java/org/folio/roles/controller/CapabilitySetControllerTest.java
@@ -7,17 +7,12 @@ import static org.folio.roles.support.CapabilitySetUtils.capabilitySets;
 import static org.folio.roles.support.TestConstants.TENANT_ID;
 import static org.folio.spring.integration.XOkapiHeaders.TENANT;
 import static org.folio.test.TestUtils.asJsonString;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.util.List;
 import org.folio.roles.service.capability.CapabilitySetService;
 import org.folio.test.types.UnitTest;
 import org.junit.jupiter.api.Test;
@@ -34,35 +29,6 @@ class CapabilitySetControllerTest {
 
   @Autowired private MockMvc mockMvc;
   @MockBean private CapabilitySetService capabilitySetService;
-
-  @Test
-  void createCapabilitySet_positive() throws Exception {
-    var capabilitySet = capabilitySet();
-    when(capabilitySetService.create(capabilitySet)).thenReturn(capabilitySet);
-
-    mockMvc.perform(post("/capability-sets")
-        .contentType(APPLICATION_JSON)
-        .content(asJsonString(capabilitySet))
-        .header(TENANT, TENANT_ID))
-      .andExpect(status().isCreated())
-      .andExpect(content().contentType(APPLICATION_JSON))
-      .andExpect(content().json(asJsonString(capabilitySet), true));
-  }
-
-  @Test
-  void createCapabilitySets_positive() throws Exception {
-    var capabilitySet = capabilitySet();
-    var capabilitySets = capabilitySets(capabilitySet);
-    when(capabilitySetService.create(List.of(capabilitySet))).thenReturn(List.of(capabilitySet));
-
-    mockMvc.perform(post("/capability-sets/batch")
-        .contentType(APPLICATION_JSON)
-        .content(asJsonString(capabilitySets))
-        .header(TENANT, TENANT_ID))
-      .andExpect(status().isCreated())
-      .andExpect(content().contentType(APPLICATION_JSON))
-      .andExpect(content().json(asJsonString(capabilitySets), true));
-  }
 
   @Test
   void getCapabilitySetById_positive() throws Exception {
@@ -92,26 +58,5 @@ class CapabilitySetControllerTest {
       .andExpect(status().isOk())
       .andExpect(content().contentType(APPLICATION_JSON))
       .andExpect(content().json(asJsonString(capabilitySets(capabilitySet)), true));
-  }
-
-  @Test
-  void updateCapabilitySet_positive() throws Exception {
-    var capabilitySet = capabilitySet();
-    doNothing().when(capabilitySetService).update(CAPABILITY_SET_ID, capabilitySet);
-
-    mockMvc.perform(put("/capability-sets/{id}", CAPABILITY_SET_ID)
-        .contentType(APPLICATION_JSON)
-        .content(asJsonString(capabilitySet))
-        .header(TENANT, TENANT_ID))
-      .andExpect(status().isNoContent());
-  }
-
-  @Test
-  void deleteCapabilitySet_positive() throws Exception {
-    doNothing().when(capabilitySetService).delete(CAPABILITY_SET_ID);
-    mockMvc.perform(delete("/capability-sets/{id}", CAPABILITY_SET_ID)
-        .contentType(APPLICATION_JSON)
-        .header(TENANT, TENANT_ID))
-      .andExpect(status().isNoContent());
   }
 }

--- a/src/test/java/org/folio/roles/integration/kafka/CapabilityEventProcessorTest.java
+++ b/src/test/java/org/folio/roles/integration/kafka/CapabilityEventProcessorTest.java
@@ -85,7 +85,7 @@ class CapabilityEventProcessorTest {
     var csDescription = csResource + " - permission set description";
     var capability = capability(null, resource, VIEW, itemGetPermName).description(description);
     var uiCapability = capability(null, csResource, VIEW, itemViewPermName).description(csDescription);
-    var capabilitySetDesc = capabilitySetDescriptor(csResource, Map.of(resource, List.of(VIEW)));
+    var capabilitySetDesc = capabilitySetDescriptor(csResource, itemViewPermName, Map.of(resource, List.of(VIEW)));
     var permission = permission(itemGetPermName).description(description);
     var permissionSet = permission(itemViewPermName, itemGetPermName).description(csDescription);
 
@@ -194,11 +194,12 @@ class CapabilityEventProcessorTest {
     return new CapabilityResultHolder(capabilities, sets);
   }
 
-  private static CapabilitySetDescriptor capabilitySetDescriptor(String resource,
+  private static CapabilitySetDescriptor capabilitySetDescriptor(String resource, String permissionName,
     Map<String, List<CapabilityAction>> capabilities) {
     return new CapabilitySetDescriptor()
       .name(getCapabilityName(resource, CapabilityAction.VIEW))
       .resource(resource)
+      .permission(permissionName)
       .action(CapabilityAction.VIEW)
       .type(DATA)
       .applicationId(APPLICATION_ID)

--- a/src/test/java/org/folio/roles/it/CapabilitySetIT.java
+++ b/src/test/java/org/folio/roles/it/CapabilitySetIT.java
@@ -1,6 +1,5 @@
 package org.folio.roles.it;
 
-import static java.util.Collections.emptyList;
 import static java.util.UUID.fromString;
 import static org.folio.roles.domain.dto.CapabilityAction.CREATE;
 import static org.folio.roles.domain.dto.CapabilityAction.EDIT;
@@ -17,35 +16,22 @@ import static org.folio.roles.support.CapabilitySetUtils.UI_FOO_EDIT_CAPABILITIE
 import static org.folio.roles.support.CapabilitySetUtils.UI_FOO_EDIT_CAPABILITY_SET;
 import static org.folio.roles.support.CapabilitySetUtils.capabilitySet;
 import static org.folio.roles.support.CapabilitySetUtils.capabilitySets;
-import static org.folio.roles.support.CapabilityUtils.FOO_CREATE_CAPABILITY;
-import static org.folio.roles.support.CapabilityUtils.FOO_DELETE_CAPABILITY;
-import static org.folio.roles.support.CapabilityUtils.FOO_EDIT_CAPABILITY;
 import static org.folio.roles.support.CapabilityUtils.FOO_RESOURCE;
-import static org.folio.roles.support.CapabilityUtils.UI_FOO_CREATE_CAPABILITY;
-import static org.folio.roles.support.CapabilityUtils.UI_FOO_DELETE_CAPABILITY;
-import static org.folio.roles.support.CapabilityUtils.UI_FOO_EDIT_CAPABILITY;
 import static org.folio.roles.support.CapabilityUtils.UI_FOO_RESOURCE;
-import static org.folio.roles.support.CapabilityUtils.UI_FOO_VIEW_CAPABILITY;
 import static org.folio.roles.support.TestConstants.TENANT_ID;
 import static org.folio.roles.support.TestConstants.USER_ID_HEADER;
 import static org.folio.spring.integration.XOkapiHeaders.TENANT;
 import static org.folio.spring.integration.XOkapiHeaders.USER_ID;
 import static org.folio.test.TestUtils.asJsonString;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
 import static org.springframework.test.context.jdbc.SqlMergeMode.MergeMode.MERGE;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.util.List;
 import java.util.UUID;
 import org.folio.roles.base.BaseIntegrationTest;
 import org.folio.test.types.IntegrationTest;
@@ -151,189 +137,6 @@ class CapabilitySetIT extends BaseIntegrationTest {
       .andExpect(content().contentType(APPLICATION_JSON))
       .andExpect(jsonPath("$.errors[0].type", is("EntityNotFoundException")))
       .andExpect(jsonPath("$.errors[0].message", is(capabilitySetNotFoundErrorMessage(capabilitySetId))))
-      .andExpect(jsonPath("$.errors[0].code", is("not_found_error")));
-  }
-
-  @Test
-  @Sql("classpath:/sql/capabilities/populate-capabilities.sql")
-  void createCapabilitySet_positive() throws Exception {
-    var capabilitySet = capabilitySet(List.of(FOO_EDIT_CAPABILITY, FOO_DELETE_CAPABILITY));
-    mockMvc.perform(post("/capability-sets")
-        .content(asJsonString(capabilitySet))
-        .header(TENANT, TENANT_ID)
-        .header(USER_ID, USER_ID_HEADER)
-        .contentType(APPLICATION_JSON))
-      .andExpect(status().isCreated())
-      .andExpect(content().json(asJsonString(capabilitySet)))
-      .andExpect(jsonPath("$.id").value(notNullValue()))
-      .andExpect(jsonPath("$.metadata.createdBy").value(equalTo(USER_ID_HEADER)))
-      .andExpect(jsonPath("$.metadata.createdDate").value(notNullValue()))
-      .andExpect(jsonPath("$.metadata.modifiedBy").doesNotExist())
-      .andExpect(jsonPath("$.metadata.modifiedDate").doesNotExist());
-  }
-
-  @Test
-  void createCapabilitySets_negative_capabilityIdsAreNotFound() throws Exception {
-    var capabilityIds = List.of(FOO_EDIT_CAPABILITY, FOO_DELETE_CAPABILITY);
-    var capabilitySet = capabilitySet(capabilityIds);
-    mockMvc.perform(post("/capability-sets")
-        .content(asJsonString(capabilitySet))
-        .header(TENANT, TENANT_ID)
-        .header(USER_ID, USER_ID_HEADER)
-        .contentType(APPLICATION_JSON))
-      .andExpect(status().isNotFound())
-      .andExpect(jsonPath("$.total_records").value(1))
-      .andExpect(jsonPath("$.errors[0].message").value("Capabilities not found by ids: " + capabilityIds))
-      .andExpect(jsonPath("$.errors[0].type").value("EntityNotFoundException"))
-      .andExpect(jsonPath("$.errors[0].code").value("not_found_error"));
-  }
-
-  @Test
-  @Sql("classpath:/sql/capabilities/populate-capabilities.sql")
-  void createCapabilitySets_positive() throws Exception {
-    var capabilitySet = capabilitySet(List.of(FOO_EDIT_CAPABILITY, FOO_DELETE_CAPABILITY));
-    mockMvc.perform(post("/capability-sets/batch")
-        .content(asJsonString(capabilitySets(capabilitySet)))
-        .header(TENANT, TENANT_ID)
-        .header(USER_ID, USER_ID_HEADER)
-        .contentType(APPLICATION_JSON))
-      .andExpect(status().isCreated())
-      .andExpect(content().json(asJsonString(capabilitySets(capabilitySet))))
-      .andExpect(jsonPath("$.capabilitySets[0].metadata.createdBy", is(USER_ID_HEADER)))
-      .andExpect(jsonPath("$.capabilitySets[0].metadata.createdDate", notNullValue()))
-      .andExpect(jsonPath("$.capabilitySets[0].metadata.modifiedBy").doesNotExist())
-      .andExpect(jsonPath("$.capabilitySets[0].metadata.modifiedDate").doesNotExist());
-  }
-
-  @Test
-  void createCapabilitySets_negative_emptyCapabilityIds() throws Exception {
-    var capabilitySet = capabilitySet(emptyList());
-    mockMvc.perform(post("/capability-sets/batch")
-        .content(asJsonString(capabilitySets(capabilitySet)))
-        .header(TENANT, TENANT_ID)
-        .header(USER_ID, USER_ID_HEADER)
-        .contentType(APPLICATION_JSON))
-      .andExpect(status().isBadRequest())
-      .andExpect(jsonPath("$.total_records").value(1))
-      .andExpect(jsonPath("$.errors[0].message").value("size must be between 1 and 2147483647"))
-      .andExpect(jsonPath("$.errors[0].type").value("MethodArgumentNotValidException"))
-      .andExpect(jsonPath("$.errors[0].code").value("validation_error"))
-      .andExpect(jsonPath("$.errors[0].parameters[0].key").value("capabilitySets[0].capabilities"))
-      .andExpect(jsonPath("$.errors[0].parameters[0].value").value("[]"));
-  }
-
-  @Test
-  @Sql(scripts = {
-    "classpath:/sql/capabilities/populate-capabilities.sql",
-    "classpath:/sql/capability-sets/populate-capability-sets.sql",
-  })
-  void creatCapabilitySets_negative_duplicateName() throws Exception {
-    var capabilitySet = capabilitySet(null, FOO_RESOURCE, CREATE, List.of(FOO_CREATE_CAPABILITY));
-    mockMvc.perform(post("/capability-sets/batch")
-        .header(TENANT, TENANT_ID)
-        .header(USER_ID, USER_ID_HEADER)
-        .content(asJsonString(capabilitySets(capabilitySet)))
-        .contentType(APPLICATION_JSON))
-      .andExpect(status().isCreated())
-      .andExpect(content().contentType(APPLICATION_JSON))
-      .andExpect(content().json(asJsonString(capabilitySets())));
-  }
-
-  @Test
-  @Sql(scripts = {
-    "classpath:/sql/capabilities/populate-capabilities.sql",
-    "classpath:/sql/capability-sets/populate-capability-sets.sql",
-  })
-  void creatCapabilitySet_negative_duplicateName() throws Exception {
-    var capabilitySet = capabilitySet(null, FOO_RESOURCE, CREATE, List.of(FOO_CREATE_CAPABILITY));
-    mockMvc.perform(post("/capability-sets")
-        .header(TENANT, TENANT_ID)
-        .header(USER_ID, USER_ID_HEADER)
-        .content(asJsonString(capabilitySet))
-        .contentType(APPLICATION_JSON))
-      .andExpect(content().contentType(APPLICATION_JSON))
-      .andExpect(status().isBadRequest())
-      .andExpect(jsonPath("$.total_records").value(1))
-      .andExpect(jsonPath("$.errors[0].message").value("Capability set name is already taken"))
-      .andExpect(jsonPath("$.errors[0].type").value("RequestValidationException"))
-      .andExpect(jsonPath("$.errors[0].code").value("validation_error"))
-      .andExpect(jsonPath("$.errors[0].parameters[0].key").value("name"))
-      .andExpect(jsonPath("$.errors[0].parameters[0].value").value("foo_item.create"));
-  }
-
-  @Test
-  void createCapabilitySets_negative_validationError() throws Exception {
-    mockMvc.perform(post("/capability-sets/batch")
-        .header(TENANT, TENANT_ID)
-        .contentType(APPLICATION_JSON))
-      .andExpect(status().isBadRequest());
-  }
-
-  @Test
-  @Sql(scripts = {
-    "classpath:/sql/capabilities/populate-capabilities.sql",
-    "classpath:/sql/capability-sets/populate-capability-sets.sql",
-  })
-  void deleteCapabilitySetById_positive() throws Exception {
-    mockMvc.perform(delete("/capability-sets/{id}", FOO_EDIT_CAPABILITY_SET)
-        .header(TENANT, TENANT_ID)
-        .header(USER_ID, USER_ID_HEADER))
-      .andExpect(status().isNoContent());
-
-    attemptGet("/capability-sets/{id}", FOO_EDIT_CAPABILITY_SET)
-      .andExpect(status().isNotFound())
-      .andExpect(content().contentType(APPLICATION_JSON))
-      .andExpect(jsonPath("$.total_records", is(1)))
-      .andExpect(jsonPath("$.errors[0].type", is("EntityNotFoundException")))
-      .andExpect(jsonPath("$.errors[0].message", is(capabilitySetNotFoundErrorMessage(FOO_EDIT_CAPABILITY_SET))))
-      .andExpect(jsonPath("$.errors[0].code", is("not_found_error")));
-  }
-
-  @Test
-  void deleteCapabilitySetById_negative_notFoundError() throws Exception {
-    mockMvc.perform(delete("/capability-sets/{id}", UUID.randomUUID())
-        .header(TENANT, TENANT_ID)
-        .header(USER_ID, USER_ID_HEADER))
-      .andExpect(status().isNotFound());
-  }
-
-  @Test
-  @Sql(scripts = {
-    "classpath:/sql/capabilities/populate-capabilities.sql",
-    "classpath:/sql/capability-sets/populate-capability-sets.sql",
-  })
-  void updateCapabilityById_positive() throws Exception {
-    var capabilitySet = capabilitySet(UI_FOO_EDIT_CAPABILITY_SET, UI_FOO_RESOURCE, MANAGE, List.of(
-      UI_FOO_VIEW_CAPABILITY, UI_FOO_CREATE_CAPABILITY, UI_FOO_EDIT_CAPABILITY, UI_FOO_DELETE_CAPABILITY));
-
-    mockMvc.perform(put("/capability-sets/{id}", UI_FOO_EDIT_CAPABILITY_SET)
-        .header(TENANT, TENANT_ID)
-        .header(USER_ID, UPDATED_BY_USER_ID)
-        .content(asJsonString(capabilitySet))
-        .contentType(APPLICATION_JSON))
-      .andExpect(status().isNoContent());
-
-    doGet("/capability-sets/{id}", UI_FOO_EDIT_CAPABILITY_SET)
-      .andExpect(content().json(asJsonString(capabilitySet)))
-      .andExpect(jsonPath("$.metadata.createdDate", notNullValue()))
-      .andExpect(jsonPath("$.metadata.modifiedDate", notNullValue()))
-      .andExpect(jsonPath("$.metadata.createdBy", is(CREATED_BY_USER_ID.toString())))
-      .andExpect(jsonPath("$.metadata.modifiedBy", is(UPDATED_BY_USER_ID.toString())));
-  }
-
-  @Test
-  void updateCapabilityById_negative_notFoundError() throws Exception {
-    var capabilityId = UUID.randomUUID();
-    var capability = capabilitySet(capabilityId);
-    mockMvc.perform(put("/capability-sets/{id}", capabilityId)
-        .header(TENANT, TENANT_ID)
-        .header(USER_ID, USER_ID_HEADER)
-        .content(asJsonString(capability))
-        .contentType(APPLICATION_JSON))
-      .andExpect(status().isNotFound())
-      .andExpect(content().contentType(APPLICATION_JSON))
-      .andExpect(jsonPath("$.errors[0].message", is(capabilitySetNotFoundErrorMessage(capabilityId))))
-      .andExpect(jsonPath("$.errors[0].type", is("EntityNotFoundException")))
       .andExpect(jsonPath("$.errors[0].code", is("not_found_error")));
   }
 

--- a/src/test/java/org/folio/roles/it/KafkaMessageListenerIT.java
+++ b/src/test/java/org/folio/roles/it/KafkaMessageListenerIT.java
@@ -31,7 +31,6 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.testcontainers.shaded.org.awaitility.Durations.FIVE_HUNDRED_MILLISECONDS;
@@ -117,8 +116,8 @@ class KafkaMessageListenerIT extends BaseIntegrationTest {
     var uiCapabilityEvent = readValue("json/kafka-events/ui-capability-event.json", ResourceEvent.class);
     kafkaTemplate.send(FOLIO_IT_CAPABILITIES_TOPIC, uiCapabilityEvent);
 
-    await().untilAsserted(() -> doGet("/capabilities").andDo(print()).andExpect(jsonPath("$.totalRecords", is(8))));
-    await().untilAsserted(() -> doGet("/capability-sets").andDo(print()).andExpect(jsonPath("$.totalRecords", is(7))));
+    await().untilAsserted(() -> doGet("/capabilities").andExpect(jsonPath("$.totalRecords", is(8))));
+    await().untilAsserted(() -> doGet("/capability-sets").andExpect(jsonPath("$.totalRecords", is(7))));
 
     var searchResult = doGet(get("/capability-sets")
       .queryParam("query", "name == \"ui-test_foo.create\"")

--- a/src/test/resources/sql/capability-sets/populate-capability-sets.sql
+++ b/src/test/resources/sql/capability-sets/populate-capability-sets.sql
@@ -1,9 +1,9 @@
 SET SEARCH_PATH = 'test_mod_roles_keycloak';
 
 -- Foo Item | Manage
-INSERT INTO capability_set(id, name, description, resource, action, type, application_id, created_by)
+INSERT INTO capability_set(id, name, description, resource, action, type, folio_permission, application_id, created_by)
 VALUES ('a1002e06-a2bc-4ce4-9d71-e25db1250e09', 'foo_item.manage', 'Capability set to manage a foo item',
-        'Foo Item', 'MANAGE', 'DATA', 'test-application-0.0.1', '11111111-1111-4011-1111-0d121a11111e');
+        'Foo Item', 'MANAGE', 'DATA', 'foo.item.all', 'test-application-0.0.1', '11111111-1111-4011-1111-0d121a11111e');
 
 INSERT INTO capability_set_capability(capability_set_id, capability_id)
 VALUES ('a1002e06-a2bc-4ce4-9d71-e25db1250e09', 'e2628d7d-059a-46a1-a5ea-10a5a37b1af2'),
@@ -12,36 +12,39 @@ VALUES ('a1002e06-a2bc-4ce4-9d71-e25db1250e09', 'e2628d7d-059a-46a1-a5ea-10a5a37
        ('a1002e06-a2bc-4ce4-9d71-e25db1250e09', 'ff2c8ad0-2b82-4b87-bafe-43a55ae7f4db');
 
 -- Foo Item | Edit
-INSERT INTO capability_set(id, name, description, resource, action, type, application_id)
+INSERT INTO capability_set(id, name, description, resource, action, type, folio_permission, application_id)
 VALUES ('6532d4f8-3e97-4d8b-886f-4ec2a2adc4a3', 'foo_item.edit', 'Capability set to edit a foo item',
-        'Foo Item', 'EDIT', 'DATA', 'test-application-0.0.1');
+        'Foo Item', 'EDIT', 'DATA', 'foo.item.edit', 'test-application-0.0.1');
 
 INSERT INTO capability_set_capability(capability_set_id, capability_id)
 VALUES ('6532d4f8-3e97-4d8b-886f-4ec2a2adc4a3', 'e2628d7d-059a-46a1-a5ea-10a5a37b1af2'),
        ('6532d4f8-3e97-4d8b-886f-4ec2a2adc4a3', '78d6a59f-90ab-46a1-a349-4d25d0798763');
 
 -- Foo Item | Create
-INSERT INTO capability_set(id, name, description, resource, action, type, application_id, created_by)
+INSERT INTO capability_set(id, name, description, resource, action, type, folio_permission, application_id, created_by)
 VALUES ('55a910de-cecf-4e0e-9d35-2e8e2ecf699e', 'foo_item.create', 'Capability set to create a foo item',
-        'Foo Item', 'CREATE', 'DATA', 'test-application-0.0.1', '11111111-1111-4011-1111-0d121a11111e');
+        'Foo Item', 'CREATE', 'DATA', 'foo.item.create',
+        'test-application-0.0.1', '11111111-1111-4011-1111-0d121a11111e');
 
 INSERT INTO capability_set_capability(capability_set_id, capability_id)
 VALUES ('55a910de-cecf-4e0e-9d35-2e8e2ecf699e', 'e2628d7d-059a-46a1-a5ea-10a5a37b1af2'),
        ('55a910de-cecf-4e0e-9d35-2e8e2ecf699e', '8d2da27c-1d56-48b6-958d-2bfae6d79dc8');
 
 -- Bar Item | Create
-INSERT INTO capability_set(id, name, description, resource, action, type, application_id, created_by)
+INSERT INTO capability_set(id, name, description, resource, action, type, folio_permission, application_id, created_by)
 VALUES ('4fdc76d8-efdf-4ffa-b231-8c7bbbb62939', 'ui_foo_item.create', 'Capability set to create a ui foo item',
-        'UI Foo Item', 'CREATE', 'DATA', 'test-application-0.0.1', '11111111-1111-4011-1111-0d121a11111e');
+        'UI Foo Item', 'CREATE', 'DATA', 'ui-foo.item.create',
+        'test-application-0.0.1', '11111111-1111-4011-1111-0d121a11111e');
 
 INSERT INTO capability_set_capability(capability_set_id, capability_id)
 VALUES ('4fdc76d8-efdf-4ffa-b231-8c7bbbb62939', '48e57f3b-3622-43db-b437-5d30ebe8f867'),
        ('4fdc76d8-efdf-4ffa-b231-8c7bbbb62939', 'f491047c-32eb-4736-815c-ebb8e94dffac');
 
 -- UI Foo Item | Edit
-INSERT INTO capability_set(id, name, description, resource, action, type, application_id, created_by)
+INSERT INTO capability_set(id, name, description, resource, action, type, folio_permission, application_id, created_by)
 VALUES ('ec87daa4-47e5-48da-beae-603dfaaa128a', 'ui_foo_item.edit', 'Capability set to edit a ui foo item',
-        'UI Foo Item', 'EDIT', 'DATA', 'test-application-0.0.1', '11111111-1111-4011-1111-0d121a11111e');
+        'UI Foo Item', 'EDIT', 'DATA', 'ui-foo.item.edit',
+        'test-application-0.0.1', '11111111-1111-4011-1111-0d121a11111e');
 
 INSERT INTO capability_set_capability(capability_set_id, capability_id)
 VALUES ('ec87daa4-47e5-48da-beae-603dfaaa128a', '48e57f3b-3622-43db-b437-5d30ebe8f867'),

--- a/src/test/resources/sql/kafka-message-listener-it/all-capabilities.sql
+++ b/src/test/resources/sql/kafka-message-listener-it/all-capabilities.sql
@@ -16,14 +16,16 @@ VALUES ('366240cd-fb38-42c1-9e72-1694532ecf06', '/foo/items/{id}', 'GET'),
        ('dbc35c91-c086-43ec-8a42-1bf8779817fc', '/foo/items/{id}', 'PATCH'),
        ('ebdef33e-2958-4401-bf20-2bf2d3f61bd2', '/foo/items/{id}', 'DELETE');
 
-INSERT INTO test_mod_roles_keycloak.capability_set(id, name, description, resource, created_by, created_date,
-                                                   action, type, application_id)
+INSERT INTO test_mod_roles_keycloak.capability_set(id, name, description, resource, folio_permission,
+                                                   created_by, created_date, action, type, application_id)
 VALUES ('60a691b2-d5ee-4845-84f7-b3f68ab6ec13', 'foo_item.view', 'foo_item.view - description', 'Foo Item',
-        NULL, '2023-10-24 13:39:50.924454', 'VIEW', 'DATA', 'test-application-0.0.1'),
+        'foo.item.view', NULL, '2023-10-24 13:39:50.924454', 'VIEW', 'DATA', 'test-application-0.0.1'),
        ('3d159575-2533-4351-94b0-2a4255c05c2c', 'foo_item.edit', 'foo_item.edit - description', 'Foo Item',
-        NULL, '2023-10-24 13:39:50.942142', 'EDIT', 'DATA', 'test-application-0.0.1'),
-       ('12277da3-d05d-41de-ae74-0e8ec59f1dcc', 'foo_item.create', 'foo_item.create - description',
-        'Foo Item', NULL, '2023-10-24 13:39:50.947999', 'CREATE', 'DATA', 'test-application-0.0.1');
+        'foo.item.edit', NULL, '2023-10-24 13:39:50.942142', 'EDIT', 'DATA', 'test-application-0.0.1'),
+       ('12277da3-d05d-41de-ae74-0e8ec59f1dcc', 'foo_item.create', 'foo_item.create - description', 'Foo Item',
+        'foo.item.create', NULL, '2023-10-24 13:39:50.947999', 'CREATE', 'DATA', 'test-application-0.0.1'),
+       ('8b117697-ecf3-47d8-84c9-d5d1734e0237', 'foo_item.manage', 'foo_item.manage - description', 'Foo Item',
+        'foo.item.all', NULL, '2023-10-24 13:39:50.947999', 'MANAGE', 'DATA', 'test-application-0.0.1');;
 
 INSERT INTO test_mod_roles_keycloak.capability_set_capability(capability_set_id, capability_id)
 VALUES ('60a691b2-d5ee-4845-84f7-b3f68ab6ec13', '366240cd-fb38-42c1-9e72-1694532ecf06'),
@@ -31,5 +33,8 @@ VALUES ('60a691b2-d5ee-4845-84f7-b3f68ab6ec13', '366240cd-fb38-42c1-9e72-1694532
        ('3d159575-2533-4351-94b0-2a4255c05c2c', 'dbc35c91-c086-43ec-8a42-1bf8779817fc'),
        ('12277da3-d05d-41de-ae74-0e8ec59f1dcc', '366240cd-fb38-42c1-9e72-1694532ecf06'),
        ('12277da3-d05d-41de-ae74-0e8ec59f1dcc', '35137e56-2689-4245-9588-ca2ef43d7aff'),
-       ('12277da3-d05d-41de-ae74-0e8ec59f1dcc', 'dbc35c91-c086-43ec-8a42-1bf8779817fc');
-
+       ('12277da3-d05d-41de-ae74-0e8ec59f1dcc', 'dbc35c91-c086-43ec-8a42-1bf8779817fc'),
+       ('8b117697-ecf3-47d8-84c9-d5d1734e0237', '366240cd-fb38-42c1-9e72-1694532ecf06'),
+       ('8b117697-ecf3-47d8-84c9-d5d1734e0237', 'dbc35c91-c086-43ec-8a42-1bf8779817fc'),
+       ('8b117697-ecf3-47d8-84c9-d5d1734e0237', '35137e56-2689-4245-9588-ca2ef43d7aff'),
+       ('8b117697-ecf3-47d8-84c9-d5d1734e0237', 'ebdef33e-2958-4401-bf20-2bf2d3f61bd2');

--- a/src/test/resources/sql/kafka-message-listener-it/partial-capabilities.sql
+++ b/src/test/resources/sql/kafka-message-listener-it/partial-capabilities.sql
@@ -13,10 +13,10 @@ VALUES ('366240cd-fb38-42c1-9e72-1694532ecf06', '/foo/items/{id}', 'GET'),
        ('dbc35c91-c086-43ec-8a42-1bf8779817fc', '/foo/items/{id}', 'PATCH'),
        ('ebdef33e-2958-4401-bf20-2bf2d3f61bd2', '/foo/items/{id}', 'DELETE');
 
-INSERT INTO test_mod_roles_keycloak.capability_set (id, name, description, resource, created_by, created_date,
-                                                    action, type, application_id)
+INSERT INTO test_mod_roles_keycloak.capability_set (id, name, description, resource, folio_permission,
+                                                    created_by, created_date, action, type, application_id)
 VALUES ('60a691b2-d5ee-4845-84f7-b3f68ab6ec13', 'foo_item.view', 'foo_item.view - description', 'Foo Item',
-        NULL, '2023-10-24 13:39:50.924454', 'VIEW', 'DATA', 'test-application-0.0.1');
+        'foo.item.view', NULL, '2023-10-24 13:39:50.924454', 'VIEW', 'DATA', 'test-application-0.0.1');
 
 INSERT INTO test_mod_roles_keycloak.capability_set_capability(capability_set_id, capability_id)
 VALUES ('60a691b2-d5ee-4845-84f7-b3f68ab6ec13', '366240cd-fb38-42c1-9e72-1694532ecf06');


### PR DESCRIPTION
## Purpose

Provides an ability to find capaiblity-set by permission name

## Approach

- Add permission name to the capability set module and entity
- Upgrade database script to include this field to the `capability_set` table
- Fix minor sonarcloud code-smells
- Remove update/delete/create endpoints for `capability-set`
- Raise the version of capability-set API to 2.0 because of removed APIs

## TODOS and Open Questions

<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

- [ ] Check logging

## Learning

<!-- OPTIONAL
  Help out not only your reviewer but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries, or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
