### PR TITLE
MODROLESKC-8 Set updatedBy to the same value as createdBy in migration script

### DIFF
--- a/src/main/resources/changelog/changelog-master.xml
+++ b/src/main/resources/changelog/changelog-master.xml
@@ -26,5 +26,5 @@
   <include file="changes/update-role-deletion-constraints.xml" relativeToChangelogFile="true"/>
   <include file="changes/create-loadable-role-tables.xml" relativeToChangelogFile="true"/>
   <include file="changes/add_permission_to_capability_set_table.xml" relativeToChangelogFile="true"/>
-  <include file="changes/set-default-for-updated-date.xml" relativeToChangelogFile="true"/>
+  <include file="changes/adjust-update-fields-of-auditable-info.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changelog/changes/adjust-update-fields-of-auditable-info.xml
+++ b/src/main/resources/changelog/changes/adjust-update-fields-of-auditable-info.xml
@@ -4,7 +4,7 @@
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
   
-  <changeSet id="MODROLESKC-8@@update-date-with-default-in-user-role" author="dmtkachenko">
+  <changeSet id="MODROLESKC-8@@adjust-update-fields-in-user-role" author="dmtkachenko">
     <addDefaultValue tableName="user_role" columnName="updated_date" defaultValueComputed="CURRENT_TIMESTAMP"/>
 
     <update tableName="user_role">
@@ -13,9 +13,14 @@
     </update>
 
     <addNotNullConstraint tableName="user_role" columnName="updated_date"/>
+
+    <update tableName="user_role">
+      <column name="updated_by" valueComputed="created_by"/>
+      <where>updated_by is NULL</where>
+    </update>
   </changeSet>
 
-  <changeSet id="MODROLESKC-8@@update-date-with-default-in-capability" author="dmtkachenko">
+  <changeSet id="MODROLESKC-8@@adjust-update-fields-in-capability" author="dmtkachenko">
     <addDefaultValue tableName="capability" columnName="updated_date" defaultValueComputed="CURRENT_TIMESTAMP"/>
 
     <update tableName="capability">
@@ -24,9 +29,14 @@
     </update>
 
     <addNotNullConstraint tableName="capability" columnName="updated_date"/>
+
+    <update tableName="capability">
+      <column name="updated_by" valueComputed="created_by"/>
+      <where>updated_by is NULL</where>
+    </update>
   </changeSet>
 
-  <changeSet id="MODROLESKC-8@@update-date-with-default-in-capability-set" author="dmtkachenko">
+  <changeSet id="MODROLESKC-8@@adjust-update-fields-in-capability-set" author="dmtkachenko">
     <addDefaultValue tableName="capability_set" columnName="updated_date" defaultValueComputed="CURRENT_TIMESTAMP"/>
 
     <update tableName="capability_set">
@@ -35,9 +45,14 @@
     </update>
 
     <addNotNullConstraint tableName="capability_set" columnName="updated_date"/>
+
+    <update tableName="capability_set">
+      <column name="updated_by" valueComputed="created_by"/>
+      <where>updated_by is NULL</where>
+    </update>
   </changeSet>
 
-  <changeSet id="MODROLESKC-8@@update-date-with-default-in-policy" author="dmtkachenko">
+  <changeSet id="MODROLESKC-8@@adjust-update-fields-in-policy" author="dmtkachenko">
     <addDefaultValue tableName="policy" columnName="updated_date" defaultValueComputed="CURRENT_TIMESTAMP"/>
 
     <update tableName="policy">
@@ -46,9 +61,14 @@
     </update>
 
     <addNotNullConstraint tableName="policy" columnName="updated_date"/>
+
+    <update tableName="policy">
+      <column name="updated_by" valueComputed="created_by"/>
+      <where>updated_by is NULL</where>
+    </update>
   </changeSet>
 
-  <changeSet id="MODROLESKC-8@@update-date-with-default-in-role" author="dmtkachenko">
+  <changeSet id="MODROLESKC-8@@adjust-update-fields-in-role" author="dmtkachenko">
     <addDefaultValue tableName="role" columnName="updated_date" defaultValueComputed="CURRENT_TIMESTAMP"/>
 
     <update tableName="role">
@@ -57,9 +77,14 @@
     </update>
 
     <addNotNullConstraint tableName="role" columnName="updated_date"/>
+
+    <update tableName="role">
+      <column name="updated_by" valueComputed="created_by"/>
+      <where>updated_by is NULL</where>
+    </update>
   </changeSet>
 
-  <changeSet id="MODROLESKC-8@@update-date-with-default-in-role-capability" author="dmtkachenko">
+  <changeSet id="MODROLESKC-8@@adjust-update-fields-in-role-capability" author="dmtkachenko">
     <addDefaultValue tableName="role_capability" columnName="updated_date" defaultValueComputed="CURRENT_TIMESTAMP"/>
 
     <update tableName="role_capability">
@@ -68,9 +93,14 @@
     </update>
 
     <addNotNullConstraint tableName="role_capability" columnName="updated_date"/>
+
+    <update tableName="role_capability">
+      <column name="updated_by" valueComputed="created_by"/>
+      <where>updated_by is NULL</where>
+    </update>
   </changeSet>
 
-  <changeSet id="MODROLESKC-8@@update-date-with-default-in-role-capability-set" author="dmtkachenko">
+  <changeSet id="MODROLESKC-8@@adjust-update-fields-in-role-capability-set" author="dmtkachenko">
     <addDefaultValue tableName="role_capability_set" columnName="updated_date"
         defaultValueComputed="CURRENT_TIMESTAMP"/>
 
@@ -80,9 +110,14 @@
     </update>
 
     <addNotNullConstraint tableName="role_capability_set" columnName="updated_date"/>
+
+    <update tableName="role_capability_set">
+      <column name="updated_by" valueComputed="created_by"/>
+      <where>updated_by is NULL</where>
+    </update>
   </changeSet>
 
-  <changeSet id="MODROLESKC-8@@update-date-with-default-in-user-capability" author="dmtkachenko">
+  <changeSet id="MODROLESKC-8@@adjust-update-fields-in-user-capability" author="dmtkachenko">
     <addDefaultValue tableName="user_capability" columnName="updated_date" defaultValueComputed="CURRENT_TIMESTAMP"/>
 
     <update tableName="user_capability">
@@ -91,9 +126,14 @@
     </update>
 
     <addNotNullConstraint tableName="user_capability" columnName="updated_date"/>
+
+    <update tableName="user_capability">
+      <column name="updated_by" valueComputed="created_by"/>
+      <where>updated_by is NULL</where>
+    </update>
   </changeSet>
 
-  <changeSet id="MODROLESKC-8@@update-date-with-default-in-user-capability-set" author="dmtkachenko">
+  <changeSet id="MODROLESKC-8@@adjust-update-fields-in-user-capability-set" author="dmtkachenko">
     <addDefaultValue tableName="user_capability_set" columnName="updated_date"
         defaultValueComputed="CURRENT_TIMESTAMP"/>
 
@@ -103,6 +143,11 @@
     </update>
 
     <addNotNullConstraint tableName="user_capability_set" columnName="updated_date"/>
+
+    <update tableName="user_capability_set">
+      <column name="updated_by" valueComputed="created_by"/>
+      <where>updated_by is NULL</where>
+    </update>
   </changeSet>
 
   <changeSet id="MODROLESKC-8@@role-loadable-permission-date-columns-as-timestamptz" author="dmtkachenko">
@@ -110,7 +155,7 @@
     <modifyDataType tableName="role_loadable_permission" columnName="updated_date" newDataType="timestamptz"/>
   </changeSet>
 
-  <changeSet id="MODROLESKC-8@@update-date-with-default-in-role-loadable-permission" author="dmtkachenko">
+  <changeSet id="MODROLESKC-8@@adjust-update-fields-in-role-loadable-permission" author="dmtkachenko">
     <addDefaultValue tableName="role_loadable_permission" columnName="updated_date"
       defaultValueComputed="CURRENT_TIMESTAMP"/>
 
@@ -120,6 +165,11 @@
     </update>
 
     <addNotNullConstraint tableName="role_loadable_permission" columnName="updated_date"/>
+
+    <update tableName="role_loadable_permission">
+      <column name="updated_by" valueComputed="created_by"/>
+      <where>updated_by is NULL</where>
+    </update>
   </changeSet>
 
 </databaseChangeLog>

--- a/src/test/java/org/folio/roles/repository/BasePolicyEntityRepositoryIT.java
+++ b/src/test/java/org/folio/roles/repository/BasePolicyEntityRepositoryIT.java
@@ -27,7 +27,7 @@ class BasePolicyEntityRepositoryIT extends BaseRepositoryTest {
   }
 
   @Test
-  void create_positive_updateDateAndCreatedDateNotNull() {
+  void create_positive_updatedAndCreatedFieldsNotNull() {
     var entity = Instancio.of(BasePolicyEntity.class)
       .ignore(field(Auditable::getCreatedDate))
       .ignore(field(Auditable::getUpdatedDate))
@@ -39,6 +39,8 @@ class BasePolicyEntityRepositoryIT extends BaseRepositoryTest {
 
     var stored = entityManager.find(BasePolicyEntity.class, saved.getId());
     assertThat(stored.getCreatedDate()).isCloseTo(now, within(1, MINUTES));
+    assertThat(stored.getCreatedBy()).isEqualTo(USER_ID);
     assertThat(stored.getUpdatedDate()).isCloseTo(now, within(1, MINUTES));
+    assertThat(stored.getUpdatedBy()).isEqualTo(USER_ID);
   }
 }

--- a/src/test/java/org/folio/roles/repository/CapabilityRepositoryIT.java
+++ b/src/test/java/org/folio/roles/repository/CapabilityRepositoryIT.java
@@ -25,7 +25,7 @@ class CapabilityRepositoryIT extends BaseRepositoryTest {
   }
 
   @Test
-  void create_positive_updateDateAndCreatedDateNotNull() {
+  void create_positive_updatedAndCreatedFieldsNotNull() {
     var entity = capabilityEntity();
     entity.setId(null);
     var now = OffsetDateTime.now();
@@ -34,6 +34,8 @@ class CapabilityRepositoryIT extends BaseRepositoryTest {
 
     var stored = entityManager.find(CapabilityEntity.class, saved.getId());
     assertThat(stored.getCreatedDate()).isCloseTo(now, within(1, MINUTES));
+    assertThat(stored.getCreatedBy()).isEqualTo(USER_ID);
     assertThat(stored.getUpdatedDate()).isCloseTo(now, within(1, MINUTES));
+    assertThat(stored.getUpdatedBy()).isEqualTo(USER_ID);
   }
 }

--- a/src/test/java/org/folio/roles/repository/CapabilitySetRepositoryIT.java
+++ b/src/test/java/org/folio/roles/repository/CapabilitySetRepositoryIT.java
@@ -25,7 +25,7 @@ class CapabilitySetRepositoryIT extends BaseRepositoryTest {
   }
 
   @Test
-  void create_positive_updateDateAndCreatedDateNotNull() {
+  void create_positive_updatedAndCreatedFieldsNotNull() {
     var entity = capabilitySetEntity();
     entity.setId(null);
     var now = OffsetDateTime.now();
@@ -34,6 +34,8 @@ class CapabilitySetRepositoryIT extends BaseRepositoryTest {
 
     var stored = entityManager.find(CapabilitySetEntity.class, saved.getId());
     assertThat(stored.getCreatedDate()).isCloseTo(now, within(1, MINUTES));
+    assertThat(stored.getCreatedBy()).isEqualTo(USER_ID);
     assertThat(stored.getUpdatedDate()).isCloseTo(now, within(1, MINUTES));
+    assertThat(stored.getUpdatedBy()).isEqualTo(USER_ID);
   }
 }

--- a/src/test/java/org/folio/roles/repository/LoadablePermissionRepositoryIT.java
+++ b/src/test/java/org/folio/roles/repository/LoadablePermissionRepositoryIT.java
@@ -28,7 +28,7 @@ class LoadablePermissionRepositoryIT extends BaseRepositoryTest {
   }
 
   @Test
-  void create_positive_updateDateAndCreatedDateNotNull() {
+  void create_positive_updatedAndCreatedFieldsNotNull() {
     var perm = loadablePermission();
     perm.setMetadata(null);
 
@@ -41,6 +41,8 @@ class LoadablePermissionRepositoryIT extends BaseRepositoryTest {
     var stored = entityManager.find(LoadablePermissionEntity.class, LoadablePermissionKey.of(roleId,
       perm.getPermissionName()));
     assertThat(stored.getCreatedDate()).isCloseTo(now, within(1, MINUTES));
+    assertThat(stored.getCreatedBy()).isEqualTo(USER_ID);
     assertThat(stored.getUpdatedDate()).isCloseTo(now, within(1, MINUTES));
+    assertThat(stored.getUpdatedBy()).isEqualTo(USER_ID);
   }
 }

--- a/src/test/java/org/folio/roles/repository/LoadableRoleRepositoryIT.java
+++ b/src/test/java/org/folio/roles/repository/LoadableRoleRepositoryIT.java
@@ -27,7 +27,7 @@ class LoadableRoleRepositoryIT extends BaseRepositoryTest {
   }
 
   @Test
-  void create_positive_updateDateAndCreatedDateNotNull() {
+  void create_positive_updatedAndCreatedFieldsNotNull() {
     var role = loadableRole();
     role.setMetadata(null);
     role.setPermissions(List.of());
@@ -39,6 +39,8 @@ class LoadableRoleRepositoryIT extends BaseRepositoryTest {
 
     var stored = entityManager.find(LoadableRoleEntity.class, saved.getId());
     assertThat(stored.getCreatedDate()).isCloseTo(now, within(1, MINUTES));
+    assertThat(stored.getCreatedBy()).isEqualTo(USER_ID);
     assertThat(stored.getUpdatedDate()).isCloseTo(now, within(1, MINUTES));
+    assertThat(stored.getUpdatedBy()).isEqualTo(USER_ID);
   }
 }

--- a/src/test/java/org/folio/roles/repository/RoleCapabilityRepositoryIT.java
+++ b/src/test/java/org/folio/roles/repository/RoleCapabilityRepositoryIT.java
@@ -26,7 +26,7 @@ class RoleCapabilityRepositoryIT extends BaseRepositoryTest {
   }
 
   @Test
-  void create_positive_updateDateAndCreatedDateNotNull() {
+  void create_positive_updatedAndCreatedFieldsNotNull() {
     var entity = roleCapabilityEntity();
     var now = OffsetDateTime.now();
 
@@ -35,6 +35,8 @@ class RoleCapabilityRepositoryIT extends BaseRepositoryTest {
     var stored = entityManager.find(RoleCapabilityEntity.class,
       RoleCapabilityKey.of(entity.getRoleId(), entity.getCapabilityId()));
     assertThat(stored.getCreatedDate()).isCloseTo(now, within(1, MINUTES));
+    assertThat(stored.getCreatedBy()).isEqualTo(USER_ID);
     assertThat(stored.getUpdatedDate()).isCloseTo(now, within(1, MINUTES));
+    assertThat(stored.getUpdatedBy()).isEqualTo(USER_ID);
   }
 }

--- a/src/test/java/org/folio/roles/repository/RoleCapabilitySetRepositoryIT.java
+++ b/src/test/java/org/folio/roles/repository/RoleCapabilitySetRepositoryIT.java
@@ -26,7 +26,7 @@ class RoleCapabilitySetRepositoryIT extends BaseRepositoryTest {
   }
 
   @Test
-  void create_positive_updateDateAndCreatedDateNotNull() {
+  void create_positive_updatedAndCreatedFieldsNotNull() {
     var entity = roleCapabilitySetEntity();
     var now = OffsetDateTime.now();
 
@@ -35,6 +35,8 @@ class RoleCapabilitySetRepositoryIT extends BaseRepositoryTest {
     var stored = entityManager.find(RoleCapabilitySetEntity.class,
       RoleCapabilitySetKey.of(entity.getRoleId(), entity.getCapabilitySetId()));
     assertThat(stored.getCreatedDate()).isCloseTo(now, within(1, MINUTES));
+    assertThat(stored.getCreatedBy()).isEqualTo(USER_ID);
     assertThat(stored.getUpdatedDate()).isCloseTo(now, within(1, MINUTES));
+    assertThat(stored.getUpdatedBy()).isEqualTo(USER_ID);
   }
 }

--- a/src/test/java/org/folio/roles/repository/RoleEntityRepositoryIT.java
+++ b/src/test/java/org/folio/roles/repository/RoleEntityRepositoryIT.java
@@ -27,7 +27,7 @@ class RoleEntityRepositoryIT extends BaseRepositoryTest {
   }
 
   @Test
-  void create_positive_updateDateAndCreatedDateNotNull() {
+  void create_positive_updatedAndCreatedFieldsNotNull() {
     var entity = Instancio.of(RoleEntity.class)
       .ignore(field(Auditable::getCreatedDate))
       .ignore(field(Auditable::getUpdatedDate))
@@ -38,6 +38,8 @@ class RoleEntityRepositoryIT extends BaseRepositoryTest {
 
     var stored = entityManager.find(RoleEntity.class, entity.getId());
     assertThat(stored.getCreatedDate()).isCloseTo(now, within(1, MINUTES));
+    assertThat(stored.getCreatedBy()).isEqualTo(USER_ID);
     assertThat(stored.getUpdatedDate()).isCloseTo(now, within(1, MINUTES));
+    assertThat(stored.getUpdatedBy()).isEqualTo(USER_ID);
   }
 }

--- a/src/test/java/org/folio/roles/repository/UserCapabilityRepositoryIT.java
+++ b/src/test/java/org/folio/roles/repository/UserCapabilityRepositoryIT.java
@@ -26,7 +26,7 @@ class UserCapabilityRepositoryIT extends BaseRepositoryTest {
   }
 
   @Test
-  void create_positive_updateDateAndCreatedDateNotNull() {
+  void create_positive_updatedAndCreatedFieldsNotNull() {
     var entity = userCapabilityEntity();
     var now = OffsetDateTime.now();
 
@@ -35,6 +35,8 @@ class UserCapabilityRepositoryIT extends BaseRepositoryTest {
     var stored = entityManager.find(UserCapabilityEntity.class,
       UserCapabilityKey.of(entity.getUserId(), entity.getCapabilityId()));
     assertThat(stored.getCreatedDate()).isCloseTo(now, within(1, MINUTES));
+    assertThat(stored.getCreatedBy()).isEqualTo(USER_ID);
     assertThat(stored.getUpdatedDate()).isCloseTo(now, within(1, MINUTES));
+    assertThat(stored.getUpdatedBy()).isEqualTo(USER_ID);
   }
 }

--- a/src/test/java/org/folio/roles/repository/UserCapabilitySetRepositoryIT.java
+++ b/src/test/java/org/folio/roles/repository/UserCapabilitySetRepositoryIT.java
@@ -26,7 +26,7 @@ class UserCapabilitySetRepositoryIT extends BaseRepositoryTest {
   }
 
   @Test
-  void create_positive_updateDateAndCreatedDateNotNull() {
+  void create_positive_updatedAndCreatedFieldsNotNull() {
     var entity = userCapabilitySetEntity();
     var now = OffsetDateTime.now();
 
@@ -35,6 +35,8 @@ class UserCapabilitySetRepositoryIT extends BaseRepositoryTest {
     var stored = entityManager.find(UserCapabilitySetEntity.class,
       UserCapabilitySetKey.of(entity.getUserId(), entity.getCapabilitySetId()));
     assertThat(stored.getCreatedDate()).isCloseTo(now, within(1, MINUTES));
+    assertThat(stored.getCreatedBy()).isEqualTo(USER_ID);
     assertThat(stored.getUpdatedDate()).isCloseTo(now, within(1, MINUTES));
+    assertThat(stored.getUpdatedBy()).isEqualTo(USER_ID);
   }
 }

--- a/src/test/java/org/folio/roles/repository/UserRoleRepositoryIT.java
+++ b/src/test/java/org/folio/roles/repository/UserRoleRepositoryIT.java
@@ -28,7 +28,7 @@ class UserRoleRepositoryIT extends BaseRepositoryTest {
   }
 
   @Test
-  void create_positive_updateDateAndCreatedDateNotNull() {
+  void create_positive_updatedAndCreatedFieldsNotNull() {
     var entity = Instancio.of(UserRoleEntity.class)
       .ignore(field(Auditable::getCreatedDate))
       .ignore(field(Auditable::getUpdatedDate))
@@ -40,6 +40,8 @@ class UserRoleRepositoryIT extends BaseRepositoryTest {
     var stored = entityManager.find(UserRoleEntity.class,
       UserRoleKey.of(entity.getUserId(), entity.getRoleId()));
     assertThat(stored.getCreatedDate()).isCloseTo(now, within(1, MINUTES));
+    assertThat(stored.getCreatedBy()).isEqualTo(USER_ID);
     assertThat(stored.getUpdatedDate()).isCloseTo(now, within(1, MINUTES));
+    assertThat(stored.getUpdatedBy()).isEqualTo(USER_ID);
   }
 }


### PR DESCRIPTION
## Purpose
Set `updatedBy` to the same value as `createdBy` in migration script
[MODROLESKC-8](https://folio-org.atlassian.net/browse/MODROLESKC-8)

## Approach
* add a command to migration script to set `updatedBy` to the same value as `createdBy`
* adjust repository tests accordingly

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
