### PR TITLE
EUREKA-96: add permission mapping

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
 ## Version `v1.4.0` (in progress)
+### Changes:
+* Added permission mapping for `invoices.bypass-acquisition-units` (EUREKA-96)
 
 ## Version `v1.3.0` (16.04.2024)
 ### Changes:

--- a/src/main/resources/folio-permissions/mappings-overrides.json
+++ b/src/main/resources/folio-permissions/mappings-overrides.json
@@ -804,5 +804,10 @@
     "resource": "UI-Users Loans Add Staff-Info",
     "action": "edit",
     "type": "data"
+  },
+  "invoices.bypass-acquisition-units": {
+    "resource": "Bypass acquisition units checks",
+    "action": "manage",
+    "type": "data"
   }
 }

--- a/src/test/java/org/folio/roles/integration/kafka/CapabilityEventProcessorTest.java
+++ b/src/test/java/org/folio/roles/integration/kafka/CapabilityEventProcessorTest.java
@@ -41,7 +41,6 @@ import org.folio.roles.support.TestUtils;
 import org.folio.test.types.UnitTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -75,22 +74,6 @@ class CapabilityEventProcessorTest {
     var result = capabilityEventProcessor.process(event);
 
     assertThat(result).isEqualTo(expectedResult);
-  }
-
-  @Test
-  void process_parameterizeda() {
-
-    var event = new CapabilityEvent()
-      .moduleId("test-module-0.0.1")
-      .moduleType(MODULE)
-      .applicationId(APPLICATION_ID)
-      .resources(asList(
-        new FolioResource().permission(new Permission().permissionName("invoices.bypass-acquisition-units"))
-      ));
-
-    var result = capabilityEventProcessor.process(event);
-
-    assertThat(result).isNotNull();
   }
 
   private static Stream<Arguments> capabilityEventDataProvider() {

--- a/src/test/java/org/folio/roles/integration/kafka/CapabilityEventProcessorTest.java
+++ b/src/test/java/org/folio/roles/integration/kafka/CapabilityEventProcessorTest.java
@@ -41,6 +41,7 @@ import org.folio.roles.support.TestUtils;
 import org.folio.test.types.UnitTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -74,6 +75,22 @@ class CapabilityEventProcessorTest {
     var result = capabilityEventProcessor.process(event);
 
     assertThat(result).isEqualTo(expectedResult);
+  }
+
+  @Test
+  void process_parameterizeda() {
+
+    var event = new CapabilityEvent()
+      .moduleId("test-module-0.0.1")
+      .moduleType(MODULE)
+      .applicationId(APPLICATION_ID)
+      .resources(asList(
+        new FolioResource().permission(new Permission().permissionName("invoices.bypass-acquisition-units"))
+      ));
+
+    var result = capabilityEventProcessor.process(event);
+
+    assertThat(result).isNotNull();
   }
 
   private static Stream<Arguments> capabilityEventDataProvider() {


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/EUREKA-96
`invoices.bypass-acquisition-units` permission cannot be resolved.
## Approach

- add mapping for the permission

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
