### PR TITLE
MODROLESKC-196: Clean default roles in Keycloak during the tenant disable with purge=true

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
-## Version `v1.5.0` (in progress)
+## Version `v1.4.1` (in progress)
+* Clean default roles in Keycloak during the tenant disable with purge=true (MODROLESKC-196)
 
 ## Version `v1.4.0` (25.05.2024)
 ### Changes:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ metadata about who and when created a record.
 | KAFKA_CAPABILITIES_TOPIC_PATTERN | `(${application.environment}\.)(.*\.)mgr-tenant-entitlements.capability` |  false   | Topic pattern for `capability` topic filled by mgr-tenants-entitlement                                                                 |
 | CAPABILITY_TOPIC_RETRY_DELAY     | 1s                                                                       |  false   | `capability` topic retry delay if tenant is not initialized                                                                            |
 | CAPABILITY_TOPIC_RETRY_ATTEMPTS  | 9223372036854775807                                                      |  false   | `capability` topic retry attempts if tenant is not initialized (default value is Long.MAX_VALUE ~= infinite amount of retries)         |
-| TENANT_SERVICE_FORCE_PURGE       | false                                                                    |  false   | Forcing removal of tenant data from DB during tenant disabling. By default the data is retained in DB, ignoring `purge=true` parameter |
 
 ### Secure storage environment variables
 

--- a/src/main/java/org/folio/roles/integration/keyclock/KeycloakRoleService.java
+++ b/src/main/java/org/folio/roles/integration/keyclock/KeycloakRoleService.java
@@ -95,6 +95,14 @@ public class KeycloakRoleService {
     log.debug("Role has been deleted: id = {}", id);
   }
 
+  public void deleteByIdSafe(UUID id) {
+    try {
+      roleClient.deleteById(context.getTenantId(), tokenService.getToken(), id);
+    } catch (Exception e) {
+      log.debug("Failed to delete Role in Keycloak: id = {}", id);
+    }
+  }
+
   public Role create(Role role) {
     try {
       var keycloakRole = roleMapper.toKeycloakRole(role);

--- a/src/main/java/org/folio/roles/repository/LoadableRoleRepository.java
+++ b/src/main/java/org/folio/roles/repository/LoadableRoleRepository.java
@@ -2,6 +2,7 @@ package org.folio.roles.repository;
 
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.folio.roles.domain.entity.LoadableRoleEntity;
 import org.folio.roles.domain.entity.type.EntityLoadableRoleType;
 import org.springframework.stereotype.Repository;
@@ -14,4 +15,6 @@ public interface LoadableRoleRepository extends BaseCqlJpaRepository<LoadableRol
   boolean existsByIdAndType(UUID id, EntityLoadableRoleType type);
 
   int countAllByType(EntityLoadableRoleType type);
+
+  Stream<LoadableRoleEntity> findAllByType(EntityLoadableRoleType type);
 }

--- a/src/main/java/org/folio/roles/repository/RoleEntityRepository.java
+++ b/src/main/java/org/folio/roles/repository/RoleEntityRepository.java
@@ -1,6 +1,7 @@
 package org.folio.roles.repository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.folio.roles.domain.entity.RoleEntity;
 import org.folio.spring.cql.JpaCqlRepository;
@@ -10,4 +11,6 @@ import org.springframework.stereotype.Repository;
 public interface RoleEntityRepository extends JpaCqlRepository<RoleEntity, UUID> {
 
   List<RoleEntity> findByIdIn(List<UUID> ids);
+
+  Optional<RoleEntity> findByName(String name);
 }

--- a/src/main/java/org/folio/roles/service/CustomTenantService.java
+++ b/src/main/java/org/folio/roles/service/CustomTenantService.java
@@ -25,8 +25,9 @@ public class CustomTenantService extends TenantService {
   private final LoadableRoleService loadableRoleService;
 
   public CustomTenantService(JdbcTemplate jdbcTemplate, FolioExecutionContext context,
-                             FolioSpringLiquibase folioSpringLiquibase, KafkaAdminService kafkaAdminService,
-                             List<ReferenceDataLoader> referenceDataLoaders, LoadableRoleService loadableRoleService) {
+    FolioSpringLiquibase folioSpringLiquibase, KafkaAdminService kafkaAdminService,
+    List<ReferenceDataLoader> referenceDataLoaders, LoadableRoleService loadableRoleService) {
+
     super(jdbcTemplate, context, folioSpringLiquibase);
     this.kafkaAdminService = kafkaAdminService;
     this.referenceDataLoaders = referenceDataLoaders;
@@ -53,7 +54,7 @@ public class CustomTenantService extends TenantService {
 
   @Override
   public void deleteTenant(TenantAttributes tenantAttributes) {
-    if (tenantExists() && tenantAttributes.getPurge()) {
+    if (tenantExists() && tenantAttributes.getPurge().equals(Boolean.TRUE)) {
       try {
         loadableRoleService.cleanupDefaultRolesFromKeycloak();
       } catch (Exception e) {

--- a/src/main/java/org/folio/roles/service/CustomTenantService.java
+++ b/src/main/java/org/folio/roles/service/CustomTenantService.java
@@ -5,12 +5,12 @@ import static org.folio.common.utils.CollectionUtils.toStream;
 import java.util.List;
 import lombok.extern.log4j.Log4j2;
 import org.folio.roles.integration.kafka.KafkaAdminService;
+import org.folio.roles.service.loadablerole.LoadableRoleService;
 import org.folio.roles.service.reference.ReferenceDataLoader;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.liquibase.FolioSpringLiquibase;
 import org.folio.spring.service.TenantService;
 import org.folio.tenant.domain.dto.TenantAttributes;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Primary;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
@@ -22,16 +22,15 @@ public class CustomTenantService extends TenantService {
 
   private final KafkaAdminService kafkaAdminService;
   private final List<ReferenceDataLoader> referenceDataLoaders;
-  private final boolean forcePurge;
+  private final LoadableRoleService loadableRoleService;
 
   public CustomTenantService(JdbcTemplate jdbcTemplate, FolioExecutionContext context,
-    FolioSpringLiquibase folioSpringLiquibase, KafkaAdminService kafkaAdminService,
-    List<ReferenceDataLoader> referenceDataLoaders,
-    @Value("${application.tenant-service.force-purge}") boolean forcePurge) {
+                             FolioSpringLiquibase folioSpringLiquibase, KafkaAdminService kafkaAdminService,
+                             List<ReferenceDataLoader> referenceDataLoaders, LoadableRoleService loadableRoleService) {
     super(jdbcTemplate, context, folioSpringLiquibase);
     this.kafkaAdminService = kafkaAdminService;
     this.referenceDataLoaders = referenceDataLoaders;
-    this.forcePurge = forcePurge;
+    this.loadableRoleService = loadableRoleService;
   }
 
   @Override
@@ -54,12 +53,15 @@ public class CustomTenantService extends TenantService {
 
   @Override
   public void deleteTenant(TenantAttributes tenantAttributes) {
-    if (tenantExists()) {
-      if (forcePurge) {
+    if (tenantExists() && tenantAttributes.getPurge()) {
+      try {
+        loadableRoleService.cleanupDefaultRolesFromKeycloak();
+      } catch (Exception e) {
+        log.warn("Unable to delete all Default Roles in Keycloak. "
+          + "Tenant data will be purged from the DB anyway. "
+          + "Data consistency should be checked manually.", e);
+      } finally {
         super.deleteTenant(tenantAttributes);
-      } else {
-        log.warn("Tenant's data cannot be deleted to avoid inconsistency between the module and Keycloak. "
-          + "Please manually drop the schema if it's really necessary: schema = {}", getSchemaName());
       }
     }
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -95,5 +95,3 @@ application:
     capability-event:
       retry-attempts: ${CAPABILITY_TOPIC_RETRY_ATTEMPTS:9223372036854775807}
       retry-delay: ${CAPABILITY_TOPIC_RETRY_DELAY:1s}
-  tenant-service:
-    force-purge: ${TENANT_SERVICE_FORCE_PURGE:false}

--- a/src/test/java/org/folio/roles/integration/keyclock/KeycloakRoleServiceTest.java
+++ b/src/test/java/org/folio/roles/integration/keyclock/KeycloakRoleServiceTest.java
@@ -217,6 +217,29 @@ class KeycloakRoleServiceTest {
   }
 
   @Nested
+  @DisplayName("deleteByIdSafe")
+  class DeleteByIdSafe {
+
+    @Test
+    void positive() {
+      roleService.deleteByIdSafe(ROLE_ID);
+
+      var token = tokenService.getToken();
+      verify(roleClient).deleteById(anyString(), eq(token), eq(ROLE_ID));
+    }
+
+    @Test
+    void positive_throws_api_exception() {
+      var token = tokenService.getToken();
+
+      doThrow(FeignException.class).when(roleClient).deleteById(anyString(), eq(token), eq(ROLE_ID));
+
+      roleService.deleteByIdSafe(ROLE_ID);
+      verify(roleClient).deleteById(anyString(), any(), any());
+    }
+  }
+
+  @Nested
   @DisplayName("updateById")
   class UpdateById {
 

--- a/src/test/resources/application-it.yml
+++ b/src/test/resources/application-it.yml
@@ -19,8 +19,6 @@ application:
     ephemeral:
       content:
         it-test_master_folio-backend-admin-client: ${KC_ADMIN_CLIENT_SECRET}
-  tenant-service:
-    force-purge: true
   keycloak:
     tls:
       enabled: true


### PR DESCRIPTION
## Purpose
[MODROLESKC-196](https://folio-org.atlassian.net/browse/MODROLESKC-196)

Mod-Roles-Keycloak creates default roles during the tenant enabling with load ref enabled. Roles stored on the realm realm in Keycloak can't be automatically cleaned during the application disabled with flag purge=true. It can bring to the inconsistent state in Keycloak and a situation when roles exist in Keycloak but modules DB is purged.

<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant Rally issue, add a link directly to the issue URL here.
 -->

## Approach

- Extend tenant service and clean related roles in Keycloak during the disabling with flag purge=true
- Update tests

<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## TODOS and Open Questions

<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

- [x] Check logging

## Learning

<!-- OPTIONAL
  Help out not only your reviewer but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries, or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
