### PR TITLE
MODROLESKC-206 Remove error on update operation

### DIFF
--- a/src/main/java/org/folio/roles/utils/UpdateOperationHelper.java
+++ b/src/main/java/org/folio/roles/utils/UpdateOperationHelper.java
@@ -1,6 +1,5 @@
 package org.folio.roles.utils;
 
-import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.collections4.CollectionUtils.isEmpty;
 
@@ -15,7 +14,6 @@ import java.util.function.Function;
 import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
 import org.folio.common.utils.CollectionUtils;
-import org.folio.roles.exception.RequestValidationException;
 import org.jetbrains.annotations.NotNull;
 
 @Getter
@@ -32,10 +30,6 @@ public final class UpdateOperationHelper<T> {
     var setOfEntitiesToUpdate = createLinkedHashSet(newEntities);
     var newEntitiesList = subtract(setOfEntitiesToUpdate, foundValuesSet);
     var deprecatedEntitiesList = subtract(foundValuesSet, setOfEntitiesToUpdate);
-
-    if (isEmpty(newEntitiesList) && isEmpty(deprecatedEntitiesList)) {
-      throw new RequestValidationException(format("Nothing to update, %s relations are not changed", entityName));
-    }
 
     this.foundEntities = foundEntities;
     this.newEntities = newEntitiesList;

--- a/src/test/java/org/folio/roles/service/capability/RoleCapabilityServiceTest.java
+++ b/src/test/java/org/folio/roles/service/capability/RoleCapabilityServiceTest.java
@@ -32,7 +32,6 @@ import java.util.Optional;
 import java.util.UUID;
 import org.folio.roles.domain.entity.key.RoleCapabilityKey;
 import org.folio.roles.domain.model.PageResult;
-import org.folio.roles.exception.RequestValidationException;
 import org.folio.roles.mapper.entity.RoleCapabilityEntityMapper;
 import org.folio.roles.repository.RoleCapabilityRepository;
 import org.folio.roles.service.permission.RolePermissionService;
@@ -351,9 +350,8 @@ class RoleCapabilityServiceTest {
       when(roleCapabilityRepository.findAllByRoleId(ROLE_ID)).thenReturn(List.of(roleCapabilityEntity));
 
       var capabilityIds = List.of(capabilityId1);
-      assertThatThrownBy(() -> roleCapabilityService.update(ROLE_ID, capabilityIds))
-        .isInstanceOf(RequestValidationException.class)
-        .hasMessage("Nothing to update, role-capability relations are not changed");
+      roleCapabilityService.update(ROLE_ID, capabilityIds);
+      verifyNoInteractions(rolePermissionService);
     }
 
     @Test

--- a/src/test/java/org/folio/roles/service/capability/RoleCapabilitySetServiceTest.java
+++ b/src/test/java/org/folio/roles/service/capability/RoleCapabilitySetServiceTest.java
@@ -32,7 +32,6 @@ import java.util.Set;
 import java.util.UUID;
 import org.folio.roles.domain.entity.key.RoleCapabilitySetKey;
 import org.folio.roles.domain.model.PageResult;
-import org.folio.roles.exception.RequestValidationException;
 import org.folio.roles.mapper.entity.RoleCapabilitySetEntityMapper;
 import org.folio.roles.repository.RoleCapabilitySetRepository;
 import org.folio.roles.service.permission.RolePermissionService;
@@ -305,9 +304,9 @@ class RoleCapabilitySetServiceTest {
       when(roleService.getById(ROLE_ID)).thenReturn(role());
       when(roleCapabilitySetRepository.findAllByRoleId(ROLE_ID)).thenReturn(List.of(roleCapabilitySetEntity()));
 
-      assertThatThrownBy(() -> roleCapabilitySetService.update(ROLE_ID, capabilityIds))
-        .isInstanceOf(RequestValidationException.class)
-        .hasMessage("Nothing to update, role-capability set relations are not changed");
+      roleCapabilitySetService.update(ROLE_ID, capabilityIds);
+
+      verifyNoInteractions(rolePermissionService);
     }
 
     @Test

--- a/src/test/java/org/folio/roles/service/capability/UserCapabilityServiceTest.java
+++ b/src/test/java/org/folio/roles/service/capability/UserCapabilityServiceTest.java
@@ -32,7 +32,6 @@ import java.util.Optional;
 import java.util.UUID;
 import org.folio.roles.domain.entity.key.UserCapabilityKey;
 import org.folio.roles.domain.model.PageResult;
-import org.folio.roles.exception.RequestValidationException;
 import org.folio.roles.integration.keyclock.KeycloakUserService;
 import org.folio.roles.mapper.entity.UserCapabilityEntityMapper;
 import org.folio.roles.repository.UserCapabilityRepository;
@@ -351,9 +350,9 @@ class UserCapabilityServiceTest {
       when(userCapabilityRepository.findAllByUserId(USER_ID)).thenReturn(List.of(userCapabilityEntity));
 
       var capabilityIds = List.of(capabilityId1);
-      assertThatThrownBy(() -> userCapabilityService.update(USER_ID, capabilityIds))
-        .isInstanceOf(RequestValidationException.class)
-        .hasMessage("Nothing to update, user-capability relations are not changed");
+      userCapabilityService.update(USER_ID, capabilityIds);
+
+      verifyNoInteractions(userPermissionService);
     }
 
     @Test

--- a/src/test/java/org/folio/roles/service/capability/UserCapabilitySetServiceTest.java
+++ b/src/test/java/org/folio/roles/service/capability/UserCapabilitySetServiceTest.java
@@ -32,7 +32,6 @@ import java.util.Set;
 import java.util.UUID;
 import org.folio.roles.domain.entity.key.UserCapabilitySetKey;
 import org.folio.roles.domain.model.PageResult;
-import org.folio.roles.exception.RequestValidationException;
 import org.folio.roles.integration.keyclock.KeycloakUserService;
 import org.folio.roles.mapper.entity.UserCapabilitySetEntityMapper;
 import org.folio.roles.repository.UserCapabilitySetRepository;
@@ -304,10 +303,9 @@ class UserCapabilitySetServiceTest {
 
       when(keycloakUserService.getKeycloakUserByUserId(USER_ID)).thenReturn(keycloakUser());
       when(userCapabilitySetRepository.findAllByUserId(USER_ID)).thenReturn(List.of(userCapabilitySetEntity()));
+      userCapabilitySetService.update(USER_ID, capabilityIds);
 
-      assertThatThrownBy(() -> userCapabilitySetService.update(USER_ID, capabilityIds))
-        .isInstanceOf(RequestValidationException.class)
-        .hasMessage("Nothing to update, user-capability set relations are not changed");
+      verifyNoInteractions(userPermissionService);
     }
 
     @Test

--- a/src/test/java/org/folio/roles/service/role/UserRoleServiceTest.java
+++ b/src/test/java/org/folio/roles/service/role/UserRoleServiceTest.java
@@ -2,20 +2,19 @@ package org.folio.roles.service.role;
 
 import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.folio.roles.support.RoleUtils.ROLE_ID;
 import static org.folio.roles.support.TestConstants.USER_ID;
 import static org.folio.roles.support.UserRoleTestUtils.userRole;
 import static org.folio.roles.support.UserRoleTestUtils.userRoles;
 import static org.folio.roles.support.UserRoleTestUtils.userRolesRequest;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.UUID;
 import org.folio.roles.domain.dto.Role;
-import org.folio.roles.exception.RequestValidationException;
 import org.folio.roles.integration.keyclock.KeycloakRolesUserService;
 import org.folio.test.types.UnitTest;
 import org.junit.jupiter.api.AfterEach;
@@ -140,10 +139,9 @@ class UserRoleServiceTest {
       var rolesUserRequest = userRolesRequest(USER_ID, ROLE_ID);
 
       when(userRoleEntityService.findByUserId(USER_ID)).thenReturn(List.of(existingUserRole));
+      userRoleService.update(rolesUserRequest);
 
-      assertThatThrownBy(() -> userRoleService.update(rolesUserRequest))
-        .isInstanceOf(RequestValidationException.class)
-        .hasMessage("Nothing to update, user-role relations are not changed");
+      verifyNoInteractions(keycloakRolesUserService);
     }
   }
 

--- a/src/test/java/org/folio/roles/utils/UpdateOperationHelperTest.java
+++ b/src/test/java/org/folio/roles/utils/UpdateOperationHelperTest.java
@@ -2,13 +2,11 @@ package org.folio.roles.utils;
 
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
-import org.folio.roles.exception.RequestValidationException;
 import org.folio.test.types.UnitTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -107,12 +105,18 @@ class UpdateOperationHelperTest {
 
   @Test
   void performUpdate_negative() {
-    var presentValues = List.of("s1", "s2");
-    var newValues = List.of("s1", "s2");
+    var newValuesBucket = new ArrayList<>();
+    var deprecatedValuesBucket = new ArrayList<>();
 
-    assertThatThrownBy(() -> UpdateOperationHelper.create(presentValues, newValues, "string"))
-      .isInstanceOf(RequestValidationException.class)
-      .hasMessage("Nothing to update, string relations are not changed");
+    var presentValues = List.of("s1", "s2");
+    var newValuesList = List.of("s1", "s2");
+
+    UpdateOperationHelper.create(presentValues, newValuesList, "string")
+      .consumeAndCacheNewEntities(newValues -> addToListAndReturn(newValues, newValuesBucket))
+      .consumeDeprecatedEntities((entities, existingEntities) -> deprecatedValuesBucket.addAll(entities));
+
+    assertThat(newValuesBucket).isEmpty();
+    assertThat(deprecatedValuesBucket).isEmpty();
   }
 
   public static Stream<Arguments> performUpdateTestDatasource() {


### PR DESCRIPTION
## Purpose

Removes a BadRequest error when user provides the same data for upgrade operation in user-role, role-capability, user-capability relations.

## Approach

- Remove error on update operation

## TODOS and Open Questions

<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

- [ ] Check logging

## Learning

<!-- OPTIONAL
  Help out not only your reviewer but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries, or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
