### PR TITLE
[MODROLESKC-211] Implement api to update roleCapabilities and roleCapabilitySets by name

### DIFF
--- a/src/main/java/org/folio/roles/controller/RoleCapabilityController.java
+++ b/src/main/java/org/folio/roles/controller/RoleCapabilityController.java
@@ -53,7 +53,7 @@ public class RoleCapabilityController implements RoleCapabilityApi {
 
   @Override
   public ResponseEntity<Void> updateRoleCapabilities(UUID roleId, CapabilitiesUpdateRequest request) {
-    roleCapabilityService.update(roleId, request.getCapabilityIds());
+    roleCapabilityService.update(roleId, request);
     return ResponseEntity.noContent().build();
   }
 

--- a/src/main/java/org/folio/roles/controller/RoleCapabilitySetController.java
+++ b/src/main/java/org/folio/roles/controller/RoleCapabilitySetController.java
@@ -52,7 +52,7 @@ public class RoleCapabilitySetController implements RoleCapabilitySetApi {
 
   @Override
   public ResponseEntity<Void> updateRoleCapabilitySets(UUID roleId, CapabilitySetsUpdateRequest request) {
-    roleCapabilitySetService.update(roleId, request.getCapabilitySetIds());
+    roleCapabilitySetService.update(roleId, request);
     return ResponseEntity.noContent().build();
   }
 

--- a/src/main/java/org/folio/roles/service/capability/ApiRoleCapabilityService.java
+++ b/src/main/java/org/folio/roles/service/capability/ApiRoleCapabilityService.java
@@ -1,5 +1,7 @@
 package org.folio.roles.service.capability;
 
+import static org.apache.commons.collections4.CollectionUtils.isEmpty;
+
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +31,7 @@ public class ApiRoleCapabilityService implements RoleCapabilityService {
   @Override
   public PageResult<RoleCapability> create(RoleCapabilitiesRequest request, boolean safeCreate) {
     checkRoleIsNotDefault(request.getRoleId());
+    verifyCapabilities(request.getCapabilityIds(), request.getCapabilityNames());
     return delegate.create(request, safeCreate);
   }
 
@@ -46,6 +49,7 @@ public class ApiRoleCapabilityService implements RoleCapabilityService {
   @Override
   public void update(UUID roleId, CapabilitiesUpdateRequest request) {
     checkRoleIsNotDefault(roleId);
+    verifyCapabilities(request.getCapabilityIds(), request.getCapabilityNames());
     delegate.update(roleId, request);
   }
 
@@ -76,6 +80,12 @@ public class ApiRoleCapabilityService implements RoleCapabilityService {
     if (loadableRoleService.isDefaultRole(roleId)) {
       throw new ServiceException("Changes to default role are prohibited: roleId = " + roleId,
         "roleId", roleId.toString());
+    }
+  }
+
+  private void verifyCapabilities(List<UUID> capabilityIds, List<String> capabilityNames) {
+    if (isEmpty(capabilityIds) && isEmpty(capabilityNames)) {
+      throw new IllegalArgumentException("'capabilityIds' or 'capabilityNames' must not be null");
     }
   }
 }

--- a/src/main/java/org/folio/roles/service/capability/ApiRoleCapabilityService.java
+++ b/src/main/java/org/folio/roles/service/capability/ApiRoleCapabilityService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.folio.roles.domain.dto.CapabilitiesUpdateRequest;
 import org.folio.roles.domain.dto.RoleCapabilitiesRequest;
 import org.folio.roles.domain.dto.RoleCapability;
 import org.folio.roles.domain.model.PageResult;
@@ -40,6 +41,12 @@ public class ApiRoleCapabilityService implements RoleCapabilityService {
   public void update(UUID roleId, List<UUID> capabilityIds) {
     checkRoleIsNotDefault(roleId);
     delegate.update(roleId, capabilityIds);
+  }
+
+  @Override
+  public void update(UUID roleId, CapabilitiesUpdateRequest request) {
+    checkRoleIsNotDefault(roleId);
+    delegate.update(roleId, request);
   }
 
   @Override

--- a/src/main/java/org/folio/roles/service/capability/ApiRoleCapabilitySetService.java
+++ b/src/main/java/org/folio/roles/service/capability/ApiRoleCapabilitySetService.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-
 import org.folio.roles.domain.dto.CapabilitySetsUpdateRequest;
 import org.folio.roles.domain.dto.RoleCapabilitySet;
 import org.folio.roles.domain.dto.RoleCapabilitySetsRequest;

--- a/src/main/java/org/folio/roles/service/capability/ApiRoleCapabilitySetService.java
+++ b/src/main/java/org/folio/roles/service/capability/ApiRoleCapabilitySetService.java
@@ -1,5 +1,7 @@
 package org.folio.roles.service.capability;
 
+import static org.apache.commons.collections4.CollectionUtils.isEmpty;
+
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +31,7 @@ public class ApiRoleCapabilitySetService implements RoleCapabilitySetService {
   @Override
   public PageResult<RoleCapabilitySet> create(RoleCapabilitySetsRequest request, boolean safeCreate) {
     checkRoleIsNotDefault(request.getRoleId());
+    verifyCapabilitySets(request.getCapabilitySetIds(), request.getCapabilitySetNames());
     return delegate.create(request, safeCreate);
   }
 
@@ -46,6 +49,7 @@ public class ApiRoleCapabilitySetService implements RoleCapabilitySetService {
   @Override
   public void update(UUID roleId, CapabilitySetsUpdateRequest request) {
     checkRoleIsNotDefault(roleId);
+    verifyCapabilitySets(request.getCapabilitySetIds(), request.getCapabilitySetNames());
     delegate.update(roleId, request);
   }
 
@@ -71,6 +75,12 @@ public class ApiRoleCapabilitySetService implements RoleCapabilitySetService {
     if (loadableRoleService.isDefaultRole(roleId)) {
       throw new ServiceException("Changes to default role are prohibited: roleId = " + roleId,
         "roleId", roleId.toString());
+    }
+  }
+
+  private void verifyCapabilitySets(List<UUID> capabilitySetIds, List<String> capabilitySetNames) {
+    if (isEmpty(capabilitySetIds) && isEmpty(capabilitySetNames)) {
+      throw new IllegalArgumentException("'capabilitySetIds' or 'capabilitySetNames' must not be null");
     }
   }
 }

--- a/src/main/java/org/folio/roles/service/capability/ApiRoleCapabilitySetService.java
+++ b/src/main/java/org/folio/roles/service/capability/ApiRoleCapabilitySetService.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+
+import org.folio.roles.domain.dto.CapabilitySetsUpdateRequest;
 import org.folio.roles.domain.dto.RoleCapabilitySet;
 import org.folio.roles.domain.dto.RoleCapabilitySetsRequest;
 import org.folio.roles.domain.model.PageResult;
@@ -40,6 +42,12 @@ public class ApiRoleCapabilitySetService implements RoleCapabilitySetService {
   public void update(UUID roleId, List<UUID> capabilityIds) {
     checkRoleIsNotDefault(roleId);
     delegate.update(roleId, capabilityIds);
+  }
+
+  @Override
+  public void update(UUID roleId, CapabilitySetsUpdateRequest request) {
+    checkRoleIsNotDefault(roleId);
+    delegate.update(roleId, request);
   }
 
   @Override

--- a/src/main/java/org/folio/roles/service/capability/RoleCapabilityService.java
+++ b/src/main/java/org/folio/roles/service/capability/RoleCapabilityService.java
@@ -52,7 +52,7 @@ public interface RoleCapabilityService {
    * Updates role-capability relations.
    *
    * @param roleId - role identifier as {@link UUID} object
-   * @param request - CapabilitiesUpdateRequest that contains either capability IDs or names
+   * @param request - CapabilitiesUpdateRequest that contains either capability IDs or names, to be assigned to a role
    */
   void update(UUID roleId, CapabilitiesUpdateRequest request);
 

--- a/src/main/java/org/folio/roles/service/capability/RoleCapabilityService.java
+++ b/src/main/java/org/folio/roles/service/capability/RoleCapabilityService.java
@@ -3,6 +3,7 @@ package org.folio.roles.service.capability;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
 import java.util.UUID;
+import org.folio.roles.domain.dto.CapabilitiesUpdateRequest;
 import org.folio.roles.domain.dto.RoleCapabilitiesRequest;
 import org.folio.roles.domain.dto.RoleCapability;
 import org.folio.roles.domain.model.PageResult;
@@ -46,6 +47,14 @@ public interface RoleCapabilityService {
    * @param capabilityIds - list of capabilities that must be assigned to a role
    */
   void update(UUID roleId, List<UUID> capabilityIds);
+
+  /**
+   * Updates role-capability relations.
+   *
+   * @param roleId - role identifier as {@link UUID} object
+   * @param request - CapabilitiesUpdateRequest that contains either capability IDs or names
+   */
+  void update(UUID roleId, CapabilitiesUpdateRequest request);
 
   /**
    * Removes role-capability relations by role identifier.

--- a/src/main/java/org/folio/roles/service/capability/RoleCapabilityServiceImpl.java
+++ b/src/main/java/org/folio/roles/service/capability/RoleCapabilityServiceImpl.java
@@ -8,6 +8,7 @@ import static org.apache.commons.collections4.ListUtils.intersection;
 import static org.apache.commons.collections4.ListUtils.subtract;
 import static org.folio.common.utils.CollectionUtils.mapItems;
 import static org.folio.roles.domain.entity.RoleCapabilityEntity.DEFAULT_ROLE_CAPABILITY_SORT;
+import static org.folio.roles.utils.CapabilityUtils.verifyRequest;
 import static org.folio.roles.utils.CollectionUtils.difference;
 
 import jakarta.persistence.EntityExistsException;
@@ -116,6 +117,13 @@ public class RoleCapabilityServiceImpl implements RoleCapabilityService {
       .consumeDeprecatedEntities((deprecatedIds, createdIds) -> removeCapabilities(roleId, deprecatedIds, createdIds));
   }
 
+
+  /**
+   * Updates role-capability relations.
+   *
+   * @param roleId - role identifier as {@link UUID} object
+   * @param request - CapabilitiesUpdateRequest that contains either capability IDs or names, to be assigned to a role
+   */
   @Override
   public void update(UUID roleId, CapabilitiesUpdateRequest request) {
     verifyRequest(request);
@@ -261,19 +269,5 @@ public class RoleCapabilityServiceImpl implements RoleCapabilityService {
   private List<UUID> getAssignedCapabilityIds(UUID roleId) {
     var capabilitySets = capabilitySetService.findByRoleId(roleId, MAX_VALUE, 0);
     return CapabilityUtils.getCapabilitySetIds(capabilitySets);
-  }
-
-  private void verifyRequest(RoleCapabilitiesRequest request) {
-    verifyRequest(request.getCapabilityIds(), request.getCapabilityNames());
-  }
-
-  private void verifyRequest(CapabilitiesUpdateRequest request) {
-    verifyRequest(request.getCapabilityIds(), request.getCapabilityNames());
-  }
-
-  private void verifyRequest(List<UUID> capabilityIds, List<String> capabilityNames ) {
-    if (isEmpty(capabilityIds) && isEmpty(capabilityNames)) {
-      throw new IllegalArgumentException("'capabilityIds' or 'capabilityNames' must not be null");
-    }
   }
 }

--- a/src/main/java/org/folio/roles/service/capability/RoleCapabilitySetService.java
+++ b/src/main/java/org/folio/roles/service/capability/RoleCapabilitySetService.java
@@ -2,6 +2,7 @@ package org.folio.roles.service.capability;
 
 import java.util.List;
 import java.util.UUID;
+import org.folio.roles.domain.dto.CapabilitySetsUpdateRequest;
 import org.folio.roles.domain.dto.RoleCapabilitySet;
 import org.folio.roles.domain.dto.RoleCapabilitySetsRequest;
 import org.folio.roles.domain.model.PageResult;
@@ -44,6 +45,14 @@ public interface RoleCapabilitySetService {
    * @param capabilityIds - list with new capabilitySets, that should be assigned to a role
    */
   void update(UUID roleId, List<UUID> capabilityIds);
+
+  /**
+   * Updates a list of assigned to a role capabilitySets.
+   *
+   * @param roleId - role identifier as {@link UUID} object
+   * @param request - CapabilitySetsUpdateRequest that contains either capability IDs or names, to be assigned to a role
+   */
+  void update(UUID roleId, CapabilitySetsUpdateRequest request);
 
   /**
    * Removes role assigned capabilities using role identifier.

--- a/src/main/java/org/folio/roles/utils/CapabilityUtils.java
+++ b/src/main/java/org/folio/roles/utils/CapabilityUtils.java
@@ -8,6 +8,10 @@ import java.util.List;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import org.folio.roles.domain.dto.CapabilitiesUpdateRequest;
+import org.folio.roles.domain.dto.CapabilitySetsUpdateRequest;
+import org.folio.roles.domain.dto.RoleCapabilitiesRequest;
+import org.folio.roles.domain.dto.RoleCapabilitySetsRequest;
 import org.apache.commons.collections4.CollectionUtils;
 import org.folio.common.utils.permission.model.PermissionAction;
 import org.folio.common.utils.permission.model.PermissionData;
@@ -86,5 +90,27 @@ public class CapabilityUtils {
 
   public static boolean isTechnicalCapability(Capability capability) {
     return isEmpty(capability.getEndpoints());
+  }
+
+  public static void verifyRequest(RoleCapabilitiesRequest request) {
+    verifyRequest(request.getCapabilityIds(), request.getCapabilityNames());
+  }
+
+  public static void verifyRequest(CapabilitiesUpdateRequest request) {
+    verifyRequest(request.getCapabilityIds(), request.getCapabilityNames());
+  }
+
+  public static void verifyRequest(RoleCapabilitySetsRequest request) {
+    verifyRequest(request.getCapabilitySetIds(), request.getCapabilitySetNames());
+  }
+
+  public static void verifyRequest(CapabilitySetsUpdateRequest request) {
+    verifyRequest(request.getCapabilitySetIds(), request.getCapabilitySetNames());
+  }
+
+  private static void verifyRequest(List<UUID> capabilityIds, List<String> capabilityNames ) {
+    if (isEmpty(capabilityIds) && isEmpty(capabilityNames)) {
+      throw new IllegalArgumentException("'capabilityIds' or 'capabilityNames' must not be null");
+    }
   }
 }

--- a/src/main/java/org/folio/roles/utils/CapabilityUtils.java
+++ b/src/main/java/org/folio/roles/utils/CapabilityUtils.java
@@ -8,17 +8,17 @@ import java.util.List;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
-import org.folio.roles.domain.dto.CapabilitiesUpdateRequest;
-import org.folio.roles.domain.dto.CapabilitySetsUpdateRequest;
-import org.folio.roles.domain.dto.RoleCapabilitiesRequest;
-import org.folio.roles.domain.dto.RoleCapabilitySetsRequest;
 import org.apache.commons.collections4.CollectionUtils;
 import org.folio.common.utils.permission.model.PermissionAction;
 import org.folio.common.utils.permission.model.PermissionData;
+import org.folio.roles.domain.dto.CapabilitiesUpdateRequest;
 import org.folio.roles.domain.dto.Capability;
 import org.folio.roles.domain.dto.CapabilityAction;
 import org.folio.roles.domain.dto.CapabilitySet;
+import org.folio.roles.domain.dto.CapabilitySetsUpdateRequest;
 import org.folio.roles.domain.dto.Endpoint;
+import org.folio.roles.domain.dto.RoleCapabilitiesRequest;
+import org.folio.roles.domain.dto.RoleCapabilitySetsRequest;
 import org.folio.roles.domain.model.PageResult;
 
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
@@ -108,7 +108,7 @@ public class CapabilityUtils {
     verifyRequest(request.getCapabilitySetIds(), request.getCapabilitySetNames());
   }
 
-  private static void verifyRequest(List<UUID> capabilityIds, List<String> capabilityNames ) {
+  private static void verifyRequest(List<UUID> capabilityIds, List<String> capabilityNames) {
     if (isEmpty(capabilityIds) && isEmpty(capabilityNames)) {
       throw new IllegalArgumentException("'capabilityIds' or 'capabilityNames' must not be null");
     }

--- a/src/main/java/org/folio/roles/utils/CapabilityUtils.java
+++ b/src/main/java/org/folio/roles/utils/CapabilityUtils.java
@@ -93,24 +93,30 @@ public class CapabilityUtils {
   }
 
   public static void verifyRequest(RoleCapabilitiesRequest request) {
-    verifyRequest(request.getCapabilityIds(), request.getCapabilityNames());
+    verifyCapabilities(request.getCapabilityIds(), request.getCapabilityNames());
   }
 
   public static void verifyRequest(CapabilitiesUpdateRequest request) {
-    verifyRequest(request.getCapabilityIds(), request.getCapabilityNames());
+    verifyCapabilities(request.getCapabilityIds(), request.getCapabilityNames());
   }
 
   public static void verifyRequest(RoleCapabilitySetsRequest request) {
-    verifyRequest(request.getCapabilitySetIds(), request.getCapabilitySetNames());
+    verifyCapabilitySets(request.getCapabilitySetIds(), request.getCapabilitySetNames());
   }
 
   public static void verifyRequest(CapabilitySetsUpdateRequest request) {
-    verifyRequest(request.getCapabilitySetIds(), request.getCapabilitySetNames());
+    verifyCapabilitySets(request.getCapabilitySetIds(), request.getCapabilitySetNames());
   }
 
-  private static void verifyRequest(List<UUID> capabilityIds, List<String> capabilityNames) {
+  private static void verifyCapabilities(List<UUID> capabilityIds, List<String> capabilityNames) {
     if (isEmpty(capabilityIds) && isEmpty(capabilityNames)) {
       throw new IllegalArgumentException("'capabilityIds' or 'capabilityNames' must not be null");
+    }
+  }
+
+  private static void verifyCapabilitySets(List<UUID> capabilitySetIds, List<String> capabilitySetNames) {
+    if (isEmpty(capabilitySetIds) && isEmpty(capabilitySetNames)) {
+      throw new IllegalArgumentException("'capabilitySetIds' or 'capabilitySetNames' must not be null");
     }
   }
 }

--- a/src/main/java/org/folio/roles/utils/CapabilityUtils.java
+++ b/src/main/java/org/folio/roles/utils/CapabilityUtils.java
@@ -11,14 +11,10 @@ import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.CollectionUtils;
 import org.folio.common.utils.permission.model.PermissionAction;
 import org.folio.common.utils.permission.model.PermissionData;
-import org.folio.roles.domain.dto.CapabilitiesUpdateRequest;
 import org.folio.roles.domain.dto.Capability;
 import org.folio.roles.domain.dto.CapabilityAction;
 import org.folio.roles.domain.dto.CapabilitySet;
-import org.folio.roles.domain.dto.CapabilitySetsUpdateRequest;
 import org.folio.roles.domain.dto.Endpoint;
-import org.folio.roles.domain.dto.RoleCapabilitiesRequest;
-import org.folio.roles.domain.dto.RoleCapabilitySetsRequest;
 import org.folio.roles.domain.model.PageResult;
 
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
@@ -90,33 +86,5 @@ public class CapabilityUtils {
 
   public static boolean isTechnicalCapability(Capability capability) {
     return isEmpty(capability.getEndpoints());
-  }
-
-  public static void verifyRequest(RoleCapabilitiesRequest request) {
-    verifyCapabilities(request.getCapabilityIds(), request.getCapabilityNames());
-  }
-
-  public static void verifyRequest(CapabilitiesUpdateRequest request) {
-    verifyCapabilities(request.getCapabilityIds(), request.getCapabilityNames());
-  }
-
-  public static void verifyRequest(RoleCapabilitySetsRequest request) {
-    verifyCapabilitySets(request.getCapabilitySetIds(), request.getCapabilitySetNames());
-  }
-
-  public static void verifyRequest(CapabilitySetsUpdateRequest request) {
-    verifyCapabilitySets(request.getCapabilitySetIds(), request.getCapabilitySetNames());
-  }
-
-  private static void verifyCapabilities(List<UUID> capabilityIds, List<String> capabilityNames) {
-    if (isEmpty(capabilityIds) && isEmpty(capabilityNames)) {
-      throw new IllegalArgumentException("'capabilityIds' or 'capabilityNames' must not be null");
-    }
-  }
-
-  private static void verifyCapabilitySets(List<UUID> capabilitySetIds, List<String> capabilitySetNames) {
-    if (isEmpty(capabilitySetIds) && isEmpty(capabilitySetNames)) {
-      throw new IllegalArgumentException("'capabilitySetIds' or 'capabilitySetNames' must not be null");
-    }
   }
 }

--- a/src/main/resources/swagger.api/schemas/capability/capabilitiesUpdateRequest.json
+++ b/src/main/resources/swagger.api/schemas/capability/capabilitiesUpdateRequest.json
@@ -1,6 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "roleCapabilitiesUpdateRequest.json.json",
   "title": "Capability Relation Update Request Schema",
   "description": "Request body to update capabilities assigned to entity (role, user, etc.)",
   "type": "object",
@@ -13,7 +12,14 @@
         "description": "Capability identifier",
         "format": "uuid"
       }
+    },
+    "capabilityNames": {
+      "description": "List of capability names",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "description": "Capability names"
+      }
     }
-  },
-  "required": [ "capabilityIds" ]
+  }
 }

--- a/src/main/resources/swagger.api/schemas/capability/capabilitySetsUpdateRequest.json
+++ b/src/main/resources/swagger.api/schemas/capability/capabilitySetsUpdateRequest.json
@@ -12,7 +12,14 @@
         "description": "Capability identifier",
         "format": "uuid"
       }
+    },
+    "capabilityNames": {
+      "description": "List of capability names",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "description": "Capability names"
+      }
     }
-  },
-  "required": [ "capabilitySetIds" ]
+  }
 }

--- a/src/main/resources/swagger.api/schemas/capability/capabilitySetsUpdateRequest.json
+++ b/src/main/resources/swagger.api/schemas/capability/capabilitySetsUpdateRequest.json
@@ -13,7 +13,7 @@
         "format": "uuid"
       }
     },
-    "capabilityNames": {
+    "capabilitySetNames": {
       "description": "List of capability names",
       "type": "array",
       "items": {

--- a/src/test/java/org/folio/roles/controller/RoleCapabilityControllerTest.java
+++ b/src/test/java/org/folio/roles/controller/RoleCapabilityControllerTest.java
@@ -2,6 +2,7 @@ package org.folio.roles.controller;
 
 import static org.folio.roles.domain.model.PageResult.asSinglePage;
 import static org.folio.roles.support.CapabilitySetUtils.CAPABILITY_SET_ID;
+import static org.folio.roles.support.CapabilitySetUtils.CAPABILITY_SET_NAME;
 import static org.folio.roles.support.CapabilityUtils.CAPABILITY_ID;
 import static org.folio.roles.support.CapabilityUtils.CAPABILITY_NAME;
 import static org.folio.roles.support.CapabilityUtils.capabilities;
@@ -168,7 +169,19 @@ class RoleCapabilityControllerTest {
         .header(TENANT, TENANT_ID))
       .andExpect(status().isNoContent());
 
-    verify(roleCapabilityService).update(ROLE_ID, List.of(CAPABILITY_SET_ID));
+    verify(roleCapabilityService).update(ROLE_ID, updateRequest);
+  }
+
+  @Test
+  void updateRoleCapabilitiesByNames_positive() throws Exception {
+    var updateRequest = new CapabilitiesUpdateRequest().addCapabilityNamesItem(CAPABILITY_SET_NAME);
+    mockMvc.perform(put("/roles/{id}/capabilities", ROLE_ID)
+        .contentType(APPLICATION_JSON)
+        .content(asJsonString(updateRequest))
+        .header(TENANT, TENANT_ID))
+      .andExpect(status().isNoContent());
+
+    verify(roleCapabilityService).update(ROLE_ID, updateRequest);
   }
 
   @Test

--- a/src/test/java/org/folio/roles/controller/RoleCapabilityControllerTest.java
+++ b/src/test/java/org/folio/roles/controller/RoleCapabilityControllerTest.java
@@ -24,7 +24,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.util.List;
 import org.folio.roles.domain.dto.CapabilitiesUpdateRequest;
 import org.folio.roles.domain.dto.RoleCapabilitiesRequest;
 import org.folio.roles.service.capability.CapabilityService;

--- a/src/test/java/org/folio/roles/controller/RoleCapabilitySetControllerTest.java
+++ b/src/test/java/org/folio/roles/controller/RoleCapabilitySetControllerTest.java
@@ -22,7 +22,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.util.List;
 import org.folio.roles.domain.dto.CapabilitySetsUpdateRequest;
 import org.folio.roles.domain.dto.RoleCapabilitySetsRequest;
 import org.folio.roles.service.capability.CapabilitySetService;

--- a/src/test/java/org/folio/roles/controller/RoleCapabilitySetControllerTest.java
+++ b/src/test/java/org/folio/roles/controller/RoleCapabilitySetControllerTest.java
@@ -153,7 +153,19 @@ class RoleCapabilitySetControllerTest {
         .header(TENANT, TENANT_ID))
       .andExpect(status().isNoContent());
 
-    verify(roleCapabilitySetService).update(ROLE_ID, List.of(CAPABILITY_SET_ID));
+    verify(roleCapabilitySetService).update(ROLE_ID, updateRequest);
+  }
+
+  @Test
+  void updateRoleCapabilitiesByNames_positive() throws Exception {
+    var updateRequest = new CapabilitySetsUpdateRequest().addCapabilitySetNamesItem(CAPABILITY_SET_NAME);
+    mockMvc.perform(put("/roles/{id}/capability-sets", ROLE_ID)
+        .contentType(APPLICATION_JSON)
+        .content(asJsonString(updateRequest))
+        .header(TENANT, TENANT_ID))
+      .andExpect(status().isNoContent());
+
+    verify(roleCapabilitySetService).update(ROLE_ID, updateRequest);
   }
 
   @Test

--- a/src/test/java/org/folio/roles/it/RoleCapabilityIT.java
+++ b/src/test/java/org/folio/roles/it/RoleCapabilityIT.java
@@ -451,8 +451,7 @@ class RoleCapabilityIT extends BaseIntegrationTest {
       .header(TENANT, TENANT_ID)
       .header(USER_ID, USER_ID_HEADER)
       .contentType(APPLICATION_JSON)
-      .content(asJsonString(request)))
-      .andExpect(content().contentType(APPLICATION_JSON));
+      .content(asJsonString(request)));
   }
 
   static ResultActions postRoleCapabilities(RoleCapabilitiesRequest request) throws Exception {

--- a/src/test/java/org/folio/roles/it/RoleCapabilitySetIT.java
+++ b/src/test/java/org/folio/roles/it/RoleCapabilitySetIT.java
@@ -18,12 +18,9 @@ import static org.folio.roles.support.CapabilitySetUtils.capabilitySets;
 import static org.folio.roles.support.CapabilitySetUtils.capabilitySetsUpdateRequest;
 import static org.folio.roles.support.CapabilityUtils.FOO_CREATE_CAPABILITY;
 import static org.folio.roles.support.CapabilityUtils.FOO_DELETE_CAPABILITY;
-import static org.folio.roles.support.CapabilityUtils.FOO_DELETE_CAPABILITY_NAME;
 import static org.folio.roles.support.CapabilityUtils.FOO_EDIT_CAPABILITY;
-import static org.folio.roles.support.CapabilityUtils.FOO_EDIT_CAPABILITY_NAME;
 import static org.folio.roles.support.CapabilityUtils.FOO_RESOURCE;
 import static org.folio.roles.support.CapabilityUtils.FOO_VIEW_CAPABILITY;
-import static org.folio.roles.support.CapabilityUtils.INVALID_CAPABILITY_NAME;
 import static org.folio.roles.support.CapabilityUtils.capabilitiesUpdateRequest;
 import static org.folio.roles.support.EndpointUtils.fooItemDeleteEndpoint;
 import static org.folio.roles.support.EndpointUtils.fooItemGetEndpoint;
@@ -357,6 +354,7 @@ class RoleCapabilitySetIT extends BaseIntegrationTest {
       .andExpect(jsonPath("$.errors[0].parameters[0].key").value("capabilityNames"))
       .andExpect(jsonPath("$.errors[0].parameters[0].value").value("[boo_item.create]"));
   }
+
   @Test
   @KeycloakRealms("/json/keycloak/role-capability-realm.json")
   @Sql(scripts = {

--- a/src/test/java/org/folio/roles/it/RoleCapabilitySetIT.java
+++ b/src/test/java/org/folio/roles/it/RoleCapabilitySetIT.java
@@ -326,15 +326,18 @@ class RoleCapabilitySetIT extends BaseIntegrationTest {
     "classpath:/sql/populate-test-role.sql",
     "classpath:/sql/populate-role-policy.sql",
     "classpath:/sql/capabilities/populate-capabilities.sql",
-    "classpath:/sql/capabilities/populate-role-capability-relations.sql"
+    "classpath:/sql/capability-sets/populate-capability-sets.sql",
+    "classpath:/sql/capability-sets/populate-role-capability-set-relations.sql"
   })
   void update_positiveByName() throws Exception {
     var request = capabilitySetsUpdateRequest(FOO_CREATE_CAPABILITY_SET_NAME, FOO_EDIT_CAPABILITY_SET_NAME);
     updateRoleCapabilitySets(request);
 
+    var fooItemCreateCapabilitySet = roleCapabilitySet(ROLE_ID, FOO_CREATE_CAPABILITY_SET);
     var fooItemEditCapabilitySet = roleCapabilitySet(ROLE_ID, FOO_EDIT_CAPABILITY_SET);
+    var expected = roleCapabilitySets(fooItemCreateCapabilitySet, fooItemEditCapabilitySet);
     doGet("/roles/capability-sets")
-      .andExpect(content().json(asJsonString(roleCapabilitySets(fooItemEditCapabilitySet))));
+      .andExpect(content().json(asJsonString(expected)));
 
     assertThat(kcTestClient.getPermissionNames()).containsAll(List.of(
       kcPermissionName(fooItemPostEndpoint()),
@@ -348,10 +351,10 @@ class RoleCapabilitySetIT extends BaseIntegrationTest {
     attemptUpdateRoleCapabilitySets(request)
       .andExpect(status().isBadRequest())
       .andExpect(jsonPath("$.errors[0].message")
-        .value("Capabilities by name are not found"))
+        .value("Capability sets by name are not found"))
       .andExpect(jsonPath("$.errors[0].type").value("RequestValidationException"))
       .andExpect(jsonPath("$.errors[0].code").value("validation_error"))
-      .andExpect(jsonPath("$.errors[0].parameters[0].key").value("capabilityNames"))
+      .andExpect(jsonPath("$.errors[0].parameters[0].key").value("capabilitySetNames"))
       .andExpect(jsonPath("$.errors[0].parameters[0].value").value("[boo_item.create]"));
   }
 

--- a/src/test/java/org/folio/roles/support/CapabilitySetUtils.java
+++ b/src/test/java/org/folio/roles/support/CapabilitySetUtils.java
@@ -38,6 +38,7 @@ public class CapabilitySetUtils {
   public static final UUID CAPABILITY_SET_ID = UUID.randomUUID();
 
   public static final String CAPABILITY_SET_NAME = "test-resource_item.create";
+  public static final String CAPABILITY_SET_NAME_2 = "test-resource_item.create-2";
   public static final String INVALID_CAPABILITY_SET_NAME = "boo_item.create";
 
   public static final UUID FOO_MANAGE_CAPABILITY_SET = fromString("a1002e06-a2bc-4ce4-9d71-e25db1250e09");
@@ -162,11 +163,11 @@ public class CapabilitySetUtils {
     return entity;
   }
 
-  public static CapabilitySetsUpdateRequest capabilitySetsUpdateRequest(UUID... capabilityIds) {
-    return new CapabilitySetsUpdateRequest().capabilitySetIds(List.of(capabilityIds));
+  public static CapabilitySetsUpdateRequest capabilitySetsUpdateRequest(UUID... capabilitySetIds) {
+    return new CapabilitySetsUpdateRequest().capabilitySetIds(List.of(capabilitySetIds));
   }
 
-  public static CapabilitySetsUpdateRequest capabilitySetsUpdateRequest(List<UUID> ids) {
-    return new CapabilitySetsUpdateRequest().capabilitySetIds(ids);
+  public static CapabilitySetsUpdateRequest capabilitySetsUpdateRequest(String... capabilitySetNames) {
+    return new CapabilitySetsUpdateRequest().capabilitySetNames(List.of(capabilitySetNames));
   }
 }

--- a/src/test/java/org/folio/roles/support/CapabilityUtils.java
+++ b/src/test/java/org/folio/roles/support/CapabilityUtils.java
@@ -29,6 +29,7 @@ public class CapabilityUtils {
   public static final String APPLICATION_ID_V2 = "test-application-0.0.2";
   public static final String PERMISSION_NAME = "test-resource.item.create";
   public static final String CAPABILITY_NAME = "test-resource_item.create";
+  public static final String CAPABILITY_NAME_2 = "test-resource_item.create-2";
   public static final String INVALID_CAPABILITY_NAME = "boo_item.create";
 
   public static final UUID CAPABILITY_ID = UUID.randomUUID();
@@ -145,7 +146,7 @@ public class CapabilityUtils {
     return new CapabilitiesUpdateRequest().capabilityIds(List.of(capabilityIds));
   }
 
-  public static CapabilitiesUpdateRequest capabilitiesUpdateRequest(List<UUID> ids) {
-    return new CapabilitiesUpdateRequest().capabilityIds(ids);
+  public static CapabilitiesUpdateRequest capabilitiesUpdateRequest(String... capabilityNames) {
+    return new CapabilitiesUpdateRequest().capabilityNames(List.of(capabilityNames));
   }
 }


### PR DESCRIPTION
## Purpose
[[MODROLESKC-211] Implement api to update roleCapabilities and roleCapabilitySets by name](https://folio-org.atlassian.net/browse/MODROLESKC-211)

## Approach
- Refactor update endpoint payloads to accept both capability and capabilitySet ids and names
- Update unit and integraton tests