### PR TITLE
EUREKA-338 (evrk2) Cannot enable app-platform-minimal with reference data on a new tenant

### DIFF
--- a/src/test/java/org/folio/roles/it/LoadableRoleProcessingIT.java
+++ b/src/test/java/org/folio/roles/it/LoadableRoleProcessingIT.java
@@ -38,7 +38,9 @@ import org.folio.test.extensions.KeycloakRealms;
 import org.folio.test.types.IntegrationTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.Keycloak;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -63,6 +65,7 @@ class LoadableRoleProcessingIT extends BaseIntegrationTest {
 
   @Autowired private KafkaTemplate<String, Object> kafkaTemplate;
   @Autowired private JdbcTemplate jdbcTemplate;
+  @Autowired private Keycloak keycloak;
 
   @BeforeAll
   static void beforeAll() {
@@ -72,6 +75,11 @@ class LoadableRoleProcessingIT extends BaseIntegrationTest {
   @AfterAll
   static void afterAll() {
     removeTenant(TENANT_ID);
+  }
+
+  @BeforeEach
+  void setUp() {
+    keycloak.tokenManager().grantToken();
   }
 
   @Test

--- a/src/test/java/org/folio/roles/it/MigrationIT.java
+++ b/src/test/java/org/folio/roles/it/MigrationIT.java
@@ -27,7 +27,10 @@ import org.folio.test.extensions.WireMockStub;
 import org.folio.test.types.IntegrationTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.Keycloak;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.jdbc.Sql;
 
@@ -40,6 +43,8 @@ import org.springframework.test.context.jdbc.Sql;
 })
 class MigrationIT extends BaseIntegrationTest {
 
+  @Autowired private Keycloak keycloak;
+
   @BeforeAll
   static void beforeAll() {
     enableTenant(TENANT_ID);
@@ -48,6 +53,11 @@ class MigrationIT extends BaseIntegrationTest {
   @AfterAll
   static void afterAll() {
     removeTenant(TENANT_ID);
+  }
+
+  @BeforeEach
+  void setUp() {
+    keycloak.tokenManager().grantToken();
   }
 
   @Test

--- a/src/test/java/org/folio/roles/it/PolicyIT.java
+++ b/src/test/java/org/folio/roles/it/PolicyIT.java
@@ -48,7 +48,10 @@ import org.folio.test.extensions.KeycloakRealms;
 import org.folio.test.types.IntegrationTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.Keycloak;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlMergeMode;
 
@@ -63,6 +66,7 @@ class PolicyIT extends BaseIntegrationTest {
   private static final String NOT_EXISTED_POLICY_ID = "1e222e11-e9ca-401c-ad8e-0d121a11111e";
 
   @Resource private ObjectMapper objectMapper;
+  @Autowired private Keycloak keycloak;
 
   @BeforeAll
   static void beforeAll() {
@@ -72,6 +76,11 @@ class PolicyIT extends BaseIntegrationTest {
   @AfterAll
   static void afterAll() {
     removeTenant(TENANT_ID);
+  }
+
+  @BeforeEach
+  void setUp() {
+    keycloak.tokenManager().grantToken();
   }
 
   @Test

--- a/src/test/java/org/folio/roles/it/ReferenceDataIT.java
+++ b/src/test/java/org/folio/roles/it/ReferenceDataIT.java
@@ -17,7 +17,10 @@ import org.folio.tenant.domain.dto.TenantAttributes;
 import org.folio.test.extensions.KeycloakRealms;
 import org.folio.test.types.IntegrationTest;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.Keycloak;
+import org.springframework.beans.factory.annotation.Autowired;
 
 @IntegrationTest
 class ReferenceDataIT extends BaseIntegrationTest {
@@ -26,6 +29,13 @@ class ReferenceDataIT extends BaseIntegrationTest {
     .addParametersItem(new Parameter()
       .key("loadReference")
       .value("true"));
+
+  @Autowired private Keycloak keycloak;
+
+  @BeforeEach
+  void setUp() {
+    keycloak.tokenManager().grantToken();
+  }
 
   @AfterEach
   void afterEach() {

--- a/src/test/java/org/folio/roles/it/ReferenceRoleLoadingIT.java
+++ b/src/test/java/org/folio/roles/it/ReferenceRoleLoadingIT.java
@@ -31,6 +31,8 @@ import org.folio.test.types.IntegrationTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.Keycloak;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
 @IntegrationTest
@@ -49,6 +51,7 @@ class ReferenceRoleLoadingIT extends BaseIntegrationTest {
   private PlainLoadableRoles circObserverRole;
   private PlainLoadableRoles circStaffRole;
   private PlainLoadableRoles circStudentRole;
+  @Autowired private Keycloak keycloak;
 
   @BeforeEach
   void setUp() {
@@ -57,6 +60,7 @@ class ReferenceRoleLoadingIT extends BaseIntegrationTest {
     circObserverRole = readRole("circ-observer-role.json");
     circStaffRole = readRole("circ-staff-role.json");
     circStudentRole = readRole("circ-student-role.json");
+    keycloak.tokenManager().grantToken();
   }
 
   @AfterEach

--- a/src/test/java/org/folio/roles/it/RoleCapabilityIT.java
+++ b/src/test/java/org/folio/roles/it/RoleCapabilityIT.java
@@ -57,7 +57,9 @@ import org.folio.test.extensions.KeycloakRealms;
 import org.folio.test.types.IntegrationTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.Keycloak;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.jdbc.Sql;
@@ -78,6 +80,7 @@ class RoleCapabilityIT extends BaseIntegrationTest {
   private static final UUID ROLE_ID = fromString("1e985e76-e9ca-401c-ad8e-0d121a11111e");
 
   @Autowired private KeycloakTestClient kcTestClient;
+  @Autowired private Keycloak keycloak;
 
   @BeforeAll
   static void beforeAll() {
@@ -87,6 +90,11 @@ class RoleCapabilityIT extends BaseIntegrationTest {
   @AfterAll
   static void afterAll() {
     removeTenant(TENANT_ID);
+  }
+
+  @BeforeEach
+  void setUp() {
+    keycloak.tokenManager().grantToken();
   }
 
   @Test

--- a/src/test/java/org/folio/roles/it/RoleCapabilitySetIT.java
+++ b/src/test/java/org/folio/roles/it/RoleCapabilitySetIT.java
@@ -61,7 +61,9 @@ import org.folio.test.extensions.KeycloakRealms;
 import org.folio.test.types.IntegrationTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.Keycloak;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.jdbc.Sql;
@@ -82,6 +84,7 @@ class RoleCapabilitySetIT extends BaseIntegrationTest {
   private static final UUID ROLE_ID = fromString("1e985e76-e9ca-401c-ad8e-0d121a11111e");
 
   @Autowired private KeycloakTestClient kcTestClient;
+  @Autowired private Keycloak keycloak;
 
   @BeforeAll
   static void beforeAll() {
@@ -91,6 +94,11 @@ class RoleCapabilitySetIT extends BaseIntegrationTest {
   @AfterAll
   static void afterAll() {
     removeTenant(TENANT_ID);
+  }
+
+  @BeforeEach
+  void setUp() {
+    keycloak.tokenManager().grantToken();
   }
 
   @Test

--- a/src/test/java/org/folio/roles/it/RoleCapabilitySetUpdateIT.java
+++ b/src/test/java/org/folio/roles/it/RoleCapabilitySetUpdateIT.java
@@ -52,7 +52,9 @@ import org.folio.test.extensions.KeycloakRealms;
 import org.folio.test.types.IntegrationTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.Keycloak;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -76,6 +78,7 @@ class RoleCapabilitySetUpdateIT extends BaseIntegrationTest {
 
   @Autowired private KeycloakTestClient kcTestClient;
   @Autowired private KafkaTemplate<String, Object> kafkaTemplate;
+  @Autowired private Keycloak keycloak;
 
   @BeforeAll
   static void beforeAll() {
@@ -85,6 +88,11 @@ class RoleCapabilitySetUpdateIT extends BaseIntegrationTest {
   @AfterAll
   static void afterAll() {
     removeTenant(TENANT_ID);
+  }
+
+  @BeforeEach
+  void setUp() {
+    keycloak.tokenManager().grantToken();
   }
 
   @Test

--- a/src/test/java/org/folio/roles/it/RoleCapabilityUpdateIT.java
+++ b/src/test/java/org/folio/roles/it/RoleCapabilityUpdateIT.java
@@ -50,7 +50,9 @@ import org.folio.test.extensions.KeycloakRealms;
 import org.folio.test.types.IntegrationTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.Keycloak;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -74,6 +76,7 @@ class RoleCapabilityUpdateIT extends BaseIntegrationTest {
 
   @Autowired private KeycloakTestClient kcTestClient;
   @Autowired private KafkaTemplate<String, Object> kafkaTemplate;
+  @Autowired private Keycloak keycloak;
 
   @BeforeAll
   static void beforeAll() {
@@ -83,6 +86,11 @@ class RoleCapabilityUpdateIT extends BaseIntegrationTest {
   @AfterAll
   static void afterAll() {
     removeTenant(TENANT_ID);
+  }
+
+  @BeforeEach
+  void setUp() {
+    keycloak.tokenManager().grantToken();
   }
 
   @Test

--- a/src/test/java/org/folio/roles/it/RoleKeycloakIT.java
+++ b/src/test/java/org/folio/roles/it/RoleKeycloakIT.java
@@ -38,7 +38,10 @@ import org.folio.test.extensions.KeycloakRealms;
 import org.folio.test.types.IntegrationTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.Keycloak;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlMergeMode;
 
@@ -62,6 +65,8 @@ class RoleKeycloakIT extends BaseIntegrationTest {
     .name("role3")
     .description("role3_description");
 
+  @Autowired private Keycloak keycloak;
+
   @BeforeAll
   static void beforeAll() {
     enableTenant(TENANT_ID);
@@ -70,6 +75,11 @@ class RoleKeycloakIT extends BaseIntegrationTest {
   @AfterAll
   static void afterAll() {
     removeTenant(TENANT_ID);
+  }
+
+  @BeforeEach
+  void setUp() {
+    keycloak.tokenManager().grantToken();
   }
 
   @Test

--- a/src/test/java/org/folio/roles/it/UserCapabilityIT.java
+++ b/src/test/java/org/folio/roles/it/UserCapabilityIT.java
@@ -51,7 +51,9 @@ import org.folio.test.extensions.WireMockStub;
 import org.folio.test.types.IntegrationTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.Keycloak;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.jdbc.Sql;
@@ -71,6 +73,7 @@ class UserCapabilityIT extends BaseIntegrationTest {
   private static final UUID USER_ID = fromString("3e8647ee-2a23-4ca4-896b-95476559c567");
 
   @Autowired private KeycloakTestClient kcTestClient;
+  @Autowired private Keycloak keycloak;
 
   @BeforeAll
   static void beforeAll() {
@@ -80,6 +83,11 @@ class UserCapabilityIT extends BaseIntegrationTest {
   @AfterAll
   static void afterAll() {
     removeTenant(TENANT_ID);
+  }
+
+  @BeforeEach
+  void setUp() {
+    keycloak.tokenManager().grantToken();
   }
 
   @Test

--- a/src/test/java/org/folio/roles/it/UserCapabilitySetIT.java
+++ b/src/test/java/org/folio/roles/it/UserCapabilitySetIT.java
@@ -59,7 +59,9 @@ import org.folio.test.extensions.WireMockStub;
 import org.folio.test.types.IntegrationTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.Keycloak;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.jdbc.Sql;
@@ -79,6 +81,7 @@ class UserCapabilitySetIT extends BaseIntegrationTest {
   private static final UUID USER_ID = fromString("3e8647ee-2a23-4ca4-896b-95476559c567");
 
   @Autowired private KeycloakTestClient kcTestClient;
+  @Autowired private Keycloak keycloak;
 
   @BeforeAll
   static void beforeAll() {
@@ -88,6 +91,11 @@ class UserCapabilitySetIT extends BaseIntegrationTest {
   @AfterAll
   static void afterAll() {
     removeTenant(TENANT_ID);
+  }
+
+  @BeforeEach
+  void setUp() {
+    keycloak.tokenManager().grantToken();
   }
 
   @Test

--- a/src/test/java/org/folio/roles/it/UserCapabilitySetUpdateIT.java
+++ b/src/test/java/org/folio/roles/it/UserCapabilitySetUpdateIT.java
@@ -53,7 +53,9 @@ import org.folio.test.extensions.WireMockStub;
 import org.folio.test.types.IntegrationTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.Keycloak;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -76,6 +78,7 @@ class UserCapabilitySetUpdateIT extends BaseIntegrationTest {
 
   @Autowired private KeycloakTestClient kcTestClient;
   @Autowired private KafkaTemplate<String, Object> kafkaTemplate;
+  @Autowired private Keycloak keycloak;
 
   @BeforeAll
   static void beforeAll() {
@@ -85,6 +88,11 @@ class UserCapabilitySetUpdateIT extends BaseIntegrationTest {
   @AfterAll
   static void afterAll() {
     removeTenant(TENANT_ID);
+  }
+
+  @BeforeEach
+  void setUp() {
+    keycloak.tokenManager().grantToken();
   }
 
   @Test

--- a/src/test/java/org/folio/roles/it/UserCapabilityUpdateIT.java
+++ b/src/test/java/org/folio/roles/it/UserCapabilityUpdateIT.java
@@ -51,7 +51,9 @@ import org.folio.test.extensions.WireMockStub;
 import org.folio.test.types.IntegrationTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.Keycloak;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -74,6 +76,7 @@ class UserCapabilityUpdateIT extends BaseIntegrationTest {
 
   @Autowired private KeycloakTestClient kcTestClient;
   @Autowired private KafkaTemplate<String, Object> kafkaTemplate;
+  @Autowired private Keycloak keycloak;
 
   @BeforeAll
   static void beforeAll() {
@@ -83,6 +86,11 @@ class UserCapabilityUpdateIT extends BaseIntegrationTest {
   @AfterAll
   static void afterAll() {
     removeTenant(TENANT_ID);
+  }
+
+  @BeforeEach
+  void setUp() {
+    keycloak.tokenManager().grantToken();
   }
 
   @Test

--- a/src/test/java/org/folio/roles/it/UserRolesIT.java
+++ b/src/test/java/org/folio/roles/it/UserRolesIT.java
@@ -32,7 +32,10 @@ import org.folio.test.extensions.WireMockStub;
 import org.folio.test.types.IntegrationTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.Keycloak;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlMergeMode;
 
@@ -46,6 +49,8 @@ class UserRolesIT extends BaseIntegrationTest {
   public static final UUID ROLE_UUID_1 = fromString("5f2492dd-adcd-445b-9118-bcfa9b406c95");
   public static final UUID ROLE_UUID_2 = fromString("5f2492dd-adcd-445b-9118-bcfa9b406c22");
 
+  @Autowired private Keycloak keycloak;
+
   @BeforeAll
   static void beforeAll() {
     enableTenant(TENANT_ID);
@@ -54,6 +59,11 @@ class UserRolesIT extends BaseIntegrationTest {
   @AfterAll
   static void afterAll() {
     removeTenant(TENANT_ID);
+  }
+
+  @BeforeEach
+  void setUp() {
+    keycloak.tokenManager().grantToken();
   }
 
   @Test

--- a/src/test/java/org/folio/roles/service/CustomTenantServiceTest.java
+++ b/src/test/java/org/folio/roles/service/CustomTenantServiceTest.java
@@ -20,6 +20,7 @@ import org.folio.test.types.UnitTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.keycloak.admin.client.Keycloak;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -42,13 +43,15 @@ class CustomTenantServiceTest {
   private FolioExecutionContext context;
   @Mock
   private LoadableRoleService loadableRoleService;
+  @Mock
+  private Keycloak keycloak;
   private CustomTenantService customTenantService;
 
   @BeforeEach
   void setUp() {
     var referenceDataLoader = of(rolesDataLoader, policiesDataLoader);
     customTenantService = new TestCustomTenantService(jdbcTemplate, context, folioSpringLiquibase, kafkaAdminService,
-      referenceDataLoader, loadableRoleService);
+      referenceDataLoader, loadableRoleService, keycloak);
   }
 
   @Test
@@ -110,9 +113,10 @@ class CustomTenantServiceTest {
   public static class TestCustomTenantService extends CustomTenantService {
     TestCustomTenantService(JdbcTemplate jdbcTemplate, FolioExecutionContext context,
       FolioSpringLiquibase folioSpringLiquibase, KafkaAdminService kafkaAdminService,
-      List<ReferenceDataLoader> referenceDataLoaders, LoadableRoleService loadableRoleService) {
+      List<ReferenceDataLoader> referenceDataLoaders, LoadableRoleService loadableRoleService, Keycloak keycloak) {
 
-      super(jdbcTemplate, context, folioSpringLiquibase, kafkaAdminService, referenceDataLoaders, loadableRoleService);
+      super(jdbcTemplate, context, folioSpringLiquibase, kafkaAdminService, referenceDataLoaders, loadableRoleService,
+        keycloak);
     }
 
     @Override


### PR DESCRIPTION
## Purpose
Fix an issue when new tenant is created but `mod-roles-keycloak` uses cached Keycloak token which doesn't include information about the new tenant
US: [EUREKA-338](https://folio-org.atlassian.net/browse/EUREKA-338)

## Approach
* obtain a new token during tenant enabling, just after a DB update and before any interactions with Keycloak
* in integration tests that work with test keycloak realms, refresh token before each test

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
