### PR TITLE
[MODROLESKC-216] Make all enum values in endpoints response with upper case as stored in DB

### DIFF
--- a/src/main/java/org/folio/roles/mapper/KeycloakPolicyMapper.java
+++ b/src/main/java/org/folio/roles/mapper/KeycloakPolicyMapper.java
@@ -263,7 +263,7 @@ public abstract class KeycloakPolicyMapper {
     return ofNullable(policyRepresentation)
       .map(AbstractPolicyRepresentation::getLogic)
       .map(Enum::name)
-      .map(PolicyLogicType::fromValue)
+      .map(enumValue -> PolicyLogicType.fromValue(enumValue.toUpperCase()))
       .orElse(null);
   }
 

--- a/src/main/java/org/folio/roles/mapper/KeycloakPolicyMapper.java
+++ b/src/main/java/org/folio/roles/mapper/KeycloakPolicyMapper.java
@@ -263,7 +263,7 @@ public abstract class KeycloakPolicyMapper {
     return ofNullable(policyRepresentation)
       .map(AbstractPolicyRepresentation::getLogic)
       .map(Enum::name)
-      .map(enumValue -> PolicyLogicType.fromValue(enumValue.toLowerCase()))
+      .map(PolicyLogicType::fromValue)
       .orElse(null);
   }
 

--- a/src/main/resources/reference-data/policies/time-policies.json
+++ b/src/main/resources/reference-data/policies/time-policies.json
@@ -8,7 +8,7 @@
       "timePolicy": {
         "start": "2023-07-01T00:00:00",
         "expires": "2033-07-01T00:00:00",
-        "logic": "positive",
+        "logic": "POSITIVE",
         "monthStart": "1",
         "monthEnd": "12",
         "hourStart": "8",

--- a/src/main/resources/swagger.api/schemas/policy/policyLogicType.json
+++ b/src/main/resources/swagger.api/schemas/policy/policyLogicType.json
@@ -4,12 +4,12 @@
   "description": "The logic type of policy.",
   "type": "string",
   "enum": [
-    "positive",
-    "negative"
+    "POSITIVE",
+    "NEGATIVE"
   ],
-  "default": "positive",
+  "default": "POSITIVE",
   "examples": [
-    "positive",
-    "negative"
+    "POSITIVE",
+    "NEGATIVE"
   ]
 }

--- a/src/main/resources/swagger.api/schemas/policy/userPolicy.json
+++ b/src/main/resources/swagger.api/schemas/policy/userPolicy.json
@@ -27,6 +27,6 @@
       "f7f7f7f7-7777-f7f7-f7f7-f7f7f7f7f7f7",
       "7f7f7f7f-7f7f-7777-7f7f-7f7f7f7f7f7f"
     ],
-    "logic": "positive"
+    "logic": "POSITIVE"
   }
 }

--- a/src/main/resources/swagger.api/schemas/role/roleType.json
+++ b/src/main/resources/swagger.api/schemas/role/roleType.json
@@ -2,5 +2,5 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "string",
   "description": "Role type",
-  "enum": [ "default", "support", "regular", "consortium" ]
+  "enum": [ "DEFAULT", "SUPPORT", "REGULAR", "CONSORTIUM" ]
 }

--- a/src/test/resources/json/reference-data/roles/librarian-support-role.json
+++ b/src/test/resources/json/reference-data/roles/librarian-support-role.json
@@ -3,7 +3,7 @@
     {
       "name": "Librarian Support",
       "description": "Role for Librarian Support",
-      "type": "support",
+      "type": "SUPPORT",
       "permissions": [
         "ui-users.view"
       ]

--- a/src/test/resources/json/reference-data/roles/user-support-role.json
+++ b/src/test/resources/json/reference-data/roles/user-support-role.json
@@ -3,7 +3,7 @@
     {
       "name": "User Support",
       "description": "Role for User Support",
-      "type": "support",
+      "type": "SUPPORT",
       "permissions": [
         "ui-users.view"
       ]


### PR DESCRIPTION
## Purpose
[[MODROLESKC-216] Make all enum values in endpoints response with upper case as stored in DB
](https://folio-org.atlassian.net/browse/MODROLESKC-216)

## Approach
Rename all enums and their usages

State before:
![image](https://github.com/user-attachments/assets/71fc6a8e-4bee-4be8-a85a-8d129ffd615b)
In DB all enum values stored in upper case
