### PR TITLE
[MODROLESKC-226]- Fix setting role type from payload

### DIFF
--- a/src/main/java/org/folio/roles/service/role/RoleService.java
+++ b/src/main/java/org/folio/roles/service/role/RoleService.java
@@ -82,6 +82,7 @@ public class RoleService {
   public Role create(Role role) {
     var createdRole = keycloakService.create(role);
     try {
+      createdRole.setType(role.getType());
       Role savedRole = entityService.create(createdRole);
       log.debug("Role has been created: id = {}, name = {}", savedRole.getId(), savedRole.getName());
       return savedRole;
@@ -169,6 +170,7 @@ public class RoleService {
       return empty();
     }
     try {
+      createdRole.get().setType(role.getType());
       return of(entityService.create(createdRole.get()));
     } catch (Exception e) {
       keycloakService.deleteById(createdRole.get().getId());

--- a/src/test/java/org/folio/roles/it/RoleKeycloakIT.java
+++ b/src/test/java/org/folio/roles/it/RoleKeycloakIT.java
@@ -32,6 +32,7 @@ import java.time.LocalDateTime;
 import java.util.Date;
 import org.folio.roles.base.BaseIntegrationTest;
 import org.folio.roles.domain.dto.Role;
+import org.folio.roles.domain.dto.RoleType;
 import org.folio.roles.domain.dto.Roles;
 import org.folio.roles.domain.dto.RolesRequest;
 import org.folio.test.extensions.KeycloakRealms;
@@ -111,7 +112,7 @@ class RoleKeycloakIT extends BaseIntegrationTest {
   @Test
   @KeycloakRealms("classpath:json/keycloak/test-realm.json")
   void createRole_positive() throws Exception {
-    var roleToCreate = new Role().name("test role").description("test description");
+    var roleToCreate = new Role().name("test role").description("test description").type(RoleType.CONSORTIUM);
     var roleToCreateAsJson = asJsonString(roleToCreate);
     mockMvc.perform(post("/roles")
         .content(roleToCreateAsJson)

--- a/src/test/java/org/folio/roles/it/RoleKeycloakIT.java
+++ b/src/test/java/org/folio/roles/it/RoleKeycloakIT.java
@@ -122,6 +122,8 @@ class RoleKeycloakIT extends BaseIntegrationTest {
       .andExpect(status().isCreated())
       .andExpect(content().json(roleToCreateAsJson))
       .andExpect(jsonPath("$.id").value(notNullValue()))
+      .andExpect(jsonPath("$.name").value("test role"))
+      .andExpect(jsonPath("$.type").value(RoleType.CONSORTIUM.toString()))
       .andExpect(jsonPath("$.metadata.createdByUserId").value(equalTo(USER_ID_HEADER)))
       .andExpect(jsonPath("$.metadata.createdDate").value(notNullValue()))
       .andExpect(jsonPath("$.metadata.updatedByUserId").value(equalTo(USER_ID_HEADER)))


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/MODROLESKC-226
Currently role is not taking into payload role name
<img width="727" alt="image" src="https://github.com/user-attachments/assets/5e7dfceb-c64e-4ec0-bfc2-a539e18f11d5">

## Approach
- Set roleType before saving

## TODOS and Open Questions

<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

- [ ] Check logging

## Learning

<!-- OPTIONAL
  Help out not only your reviewer but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries, or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
