### PR TITLE
MODUSERSKC-52: Create capability set with its permission for UI modules

### DIFF
--- a/src/test/java/org/folio/roles/integration/kafka/CapabilityEventProcessorTest.java
+++ b/src/test/java/org/folio/roles/integration/kafka/CapabilityEventProcessorTest.java
@@ -92,6 +92,9 @@ class CapabilityEventProcessorTest {
     var uiCapability = capability(null, csResource, VIEW, itemViewPerm).description(csDescription).moduleId(MODULE_ID);
     var setResources = Map.of(resource, List.of(VIEW));
     var capabilitySetDesc = capabilitySetDescriptor(csResource, itemViewPerm, setResources).moduleId(MODULE_ID);
+    var uiCapabilitySetDesc = capabilitySetDescriptor(
+      csResource, itemViewPerm, Map.of(resource, List.of(VIEW), csResource, List.of(VIEW))).moduleId(MODULE_ID);
+
     var permission = permission(itemGetPermName).description(description);
     var permissionSet = permission(itemViewPerm, itemGetPermName).description(csDescription);
 
@@ -182,7 +185,7 @@ class CapabilityEventProcessorTest {
 
       arguments("ui-module event (permission set)",
         event(UI_MODULE, resource(permissionSet), resource(permission)),
-        result(List.of(uiCapability, capability), List.of(capabilitySetDesc))),
+        result(List.of(uiCapability, capability), List.of(uiCapabilitySetDesc))),
 
       arguments("module event(empty resources)", event(UI_MODULE), result(emptyList(), emptyList())),
       arguments("ui-module event(empty resources)", event(UI_MODULE), result(emptyList(), emptyList())),

--- a/src/test/java/org/folio/roles/it/KafkaMessageListenerIT.java
+++ b/src/test/java/org/folio/roles/it/KafkaMessageListenerIT.java
@@ -162,11 +162,12 @@ class KafkaMessageListenerIT extends BaseIntegrationTest {
       .andReturn();
 
     var foundCapabilitySet = parseResponse(searchResult, CapabilitySets.class).getCapabilitySets().get(0);
-    assertThat(foundCapabilitySet.getCapabilities()).hasSize(6);
+    assertThat(foundCapabilitySet.getCapabilities()).hasSize(7);
 
     doGet("/capability-sets/{id}/capabilities", foundCapabilitySet.getId())
       .andExpect(jsonPath("$.capabilities[*].name", containsInAnyOrder("foo_item.create", "foo_item.edit",
-        "foo_item.view", "settings_enabled.view", "settings_test_enabled.view", "ui-test_foo.view")));
+        "foo_item.view", "settings_enabled.view", "settings_test_enabled.view", "ui-test_foo.view",
+        "ui-test_foo.create")));
   }
 
   private void sendCapabilityEventAndCheckResult() throws Exception {


### PR DESCRIPTION
## Purpose
Create capability set with its permission for UI modules
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant Rally issue, add a link directly to the issue URL here.
 -->

## Approach

<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## TODOS and Open Questions

<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

- [ ] Check logging

## Learning
<img width="1148" alt="image" src="https://github.com/user-attachments/assets/dd401990-4b9a-4e38-97f5-d84143fef5b9">

<img width="1066" alt="image" src="https://github.com/user-attachments/assets/ef090ec6-d250-49cd-a5d2-5516a642674b">


<!-- OPTIONAL
  Help out not only your reviewer but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries, or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
