### PR TITLE
MODROLESKC-231: fix for null-pointer exception

### DIFF
--- a/src/main/java/org/folio/roles/service/capability/CapabilityReplacementsService.java
+++ b/src/main/java/org/folio/roles/service/capability/CapabilityReplacementsService.java
@@ -142,7 +142,7 @@ public class CapabilityReplacementsService {
 
   protected String applyFolioPermissionOverrides(String permissionName) {
     var mappedPermission = permissionOverrider.getPermissionMappings().get(permissionName);
-    if (mappedPermission != null) {
+    if (mappedPermission != null && mappedPermission.getPermissionName() != null) {
       return mappedPermission.getPermissionName();
     }
     return permissionName;

--- a/src/test/java/org/folio/roles/service/capability/CapabilityReplacementsServiceTest.java
+++ b/src/test/java/org/folio/roles/service/capability/CapabilityReplacementsServiceTest.java
@@ -70,6 +70,8 @@ class CapabilityReplacementsServiceTest {
   void testDeduceReplacementsPositive() {
     when(permissionOverrider.getPermissionMappings()).thenReturn(Map.of("old-perm2.get",
       PermissionData.builder().permissionName("old-perm-two.get").action(VIEW).resource("resource2").type(DATA)
+        .build(), "old-perm.get",
+      PermissionData.builder().action(VIEW).resource("resource").type(DATA)
         .build()));
 
     var testData = new CapabilityEvent();


### PR DESCRIPTION
## Purpose

Avoid null-pointer exceptions in case permission mapping overrides don't provide new name for a permission.

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
