### PR TITLE
MODROLESKC-221: add replaced permissions for user permissions

### DIFF
--- a/src/main/java/org/folio/roles/repository/CapabilityRepository.java
+++ b/src/main/java/org/folio/roles/repository/CapabilityRepository.java
@@ -111,54 +111,112 @@ public interface CapabilityRepository extends BaseCqlJpaRepository<CapabilityEnt
   List<CapabilityEntity> findByCapabilitySetIds(@Param("ids") Collection<UUID> capabilitySetIds);
 
   @Query(nativeQuery = true, value = """
-    WITH prefixes AS (SELECT prefix || '%' AS prefix FROM UNNEST(cast(:prefixes as text[])) prefix)
-    SELECT DISTINCT c.folio_permission FROM (
-      SELECT uc.user_id, uc.capability_id FROM user_capability uc
+    WITH prefixes AS (
+        SELECT prefix || '%' AS pattern
+        FROM UNNEST(cast(:prefixes as text[])) prefix
+    ),
+    user_capabilities AS (
+        SELECT uc.user_id, uc.capability_id
+        FROM user_capability uc
 
-      UNION
+        UNION ALL
 
-      SELECT ucs.user_id, csc.capability_id FROM user_capability_set ucs
-      INNER JOIN capability_set_capability csc ON ucs.capability_set_id = csc.capability_set_id
+        SELECT ucs.user_id, csc.capability_id
+        FROM user_capability_set ucs
+        INNER JOIN capability_set_capability csc
+            ON ucs.capability_set_id = csc.capability_set_id
 
-      UNION
+        UNION ALL
 
-      SELECT ur.user_id, rc.capability_id FROM user_role ur
-      INNER JOIN (
-        SELECT rc.role_id, rc.capability_id FROM role_capability rc
+        SELECT ur.user_id, rc.capability_id
+        FROM user_role ur
+        INNER JOIN (
+            SELECT rc.role_id, rc.capability_id
+            FROM role_capability rc
 
-        UNION
+            UNION ALL
 
-        SELECT rcs.role_id, csc.capability_id FROM capability_set_capability csc
-        INNER JOIN role_capability_set rcs ON csc.capability_set_id = rcs.capability_set_id) rc
-        ON rc.role_id = ur.role_id) uc
+            SELECT rcs.role_id, csc.capability_id
+            FROM role_capability_set rcs
+            INNER JOIN capability_set_capability csc
+                ON rcs.capability_set_id = csc.capability_set_id
+        ) rc ON rc.role_id = ur.role_id
+    ),
+    user_permissions AS (
+        SELECT DISTINCT c.folio_permission
+        FROM user_capabilities uc
     INNER JOIN capability c ON uc.capability_id = c.id
-    INNER JOIN prefixes p ON c.folio_permission LIKE p.prefix
-    WHERE uc.user_id = :user_id""")
+        LEFT JOIN prefixes p ON c.folio_permission LIKE p.pattern
+        WHERE uc.user_id = :user_id
+          AND p.pattern IS NOT NULL
+    ),
+    replaced_permissions AS (
+        SELECT UNNEST(p.replaces) AS folio_permission
+        FROM user_permissions up
+        INNER JOIN permission p
+            ON p.name = up.folio_permission
+    )
+    SELECT DISTINCT folio_permission
+    FROM (
+        SELECT folio_permission FROM user_permissions
+
+        UNION ALL
+
+        SELECT folio_permission FROM replaced_permissions
+    ) combined_permissions;
+
+    """)
   List<String> findPermissionsByPrefixes(@Param("user_id") UUID userId, @Param("prefixes") String prefixes);
 
   @Query(nativeQuery = true, value = """
-    SELECT DISTINCT c.folio_permission FROM (
-      SELECT uc.user_id, uc.capability_id FROM user_capability uc
+    WITH user_permissions AS (
+      SELECT c.folio_permission
+      FROM (
+        SELECT uc.user_id, uc.capability_id
+        FROM user_capability uc
 
-      UNION
+        UNION ALL
 
-      SELECT ucs.user_id, csc.capability_id FROM user_capability_set ucs
-      INNER JOIN capability_set_capability csc ON ucs.capability_set_id = csc.capability_set_id
+        SELECT ucs.user_id, csc.capability_id
+        FROM user_capability_set ucs
+        INNER JOIN capability_set_capability csc
+          ON ucs.capability_set_id = csc.capability_set_id
 
-      UNION
+        UNION ALL
 
-      SELECT ur.user_id, rc.capability_id FROM user_role ur
-      INNER JOIN (
-        SELECT rc.role_id, rc.capability_id FROM role_capability rc
+        SELECT ur.user_id, rc.capability_id
+        FROM user_role ur
+        INNER JOIN (
+          SELECT rc.role_id, rc.capability_id
+          FROM role_capability rc
 
-        UNION
+          UNION ALL
 
-        SELECT rcs.role_id, csc.capability_id FROM capability_set_capability csc
-        INNER JOIN role_capability_set rcs ON csc.capability_set_id = rcs.capability_set_id
-      ) rc ON rc.role_id = ur.role_id) uc
-    INNER JOIN capability c ON uc.capability_id = c.id
-    WHERE uc.user_id = :user_id
-    ORDER BY c.folio_permission""")
+          SELECT rcs.role_id, csc.capability_id
+          FROM role_capability_set rcs
+          INNER JOIN capability_set_capability csc
+            ON rcs.capability_set_id = csc.capability_set_id
+        ) rc
+          ON rc.role_id = ur.role_id
+      ) uc
+      INNER JOIN capability c
+        ON uc.capability_id = c.id
+      WHERE uc.user_id = :user_id
+    ),
+    replaced_permissions AS (
+      SELECT UNNEST(p.replaces) AS folio_permission
+      FROM user_permissions up
+      INNER JOIN permission p
+        ON p.name = up.folio_permission
+    )
+    SELECT folio_permission
+    FROM (
+      SELECT folio_permission FROM user_permissions
+      UNION ALL
+      SELECT folio_permission FROM replaced_permissions
+    ) all_permissions
+    GROUP BY folio_permission;
+    """)
   List<String> findAllFolioPermissions(@Param("user_id") UUID userId);
 
   @Modifying
@@ -169,4 +227,69 @@ public interface CapabilityRepository extends BaseCqlJpaRepository<CapabilityEnt
 
   @Query("select entity from CapabilityEntity entity where entity.permission in :names order by entity.name")
   List<CapabilityEntity> findAllByPermissionNames(@Param("names") Collection<String> names);
+
+  @Query(nativeQuery = true, value = """
+    WITH prefixes AS (
+      SELECT prefix || '%' AS pattern
+      FROM UNNEST(CAST(:prefixes AS text[])) AS prefix
+    ),
+    permission_names AS (
+      SELECT permission_name
+      FROM UNNEST(CAST(:permission_names AS text[])) AS permission_name
+    ),
+    user_capabilities AS (
+      SELECT uc.user_id, uc.capability_id FROM user_capability uc
+
+      UNION ALL
+
+      SELECT ucs.user_id, csc.capability_id
+      FROM user_capability_set ucs
+      INNER JOIN capability_set_capability csc
+        ON ucs.capability_set_id = csc.capability_set_id
+
+      UNION ALL
+
+      SELECT ur.user_id, rc.capability_id
+      FROM user_role ur
+      INNER JOIN (
+        SELECT rc.role_id, rc.capability_id FROM role_capability rc
+
+        UNION ALL
+
+        SELECT rcs.role_id, csc.capability_id
+        FROM role_capability_set rcs
+        INNER JOIN capability_set_capability csc
+          ON rcs.capability_set_id = csc.capability_set_id
+      ) rc ON rc.role_id = ur.role_id
+    ),
+    user_permissions AS (
+      SELECT DISTINCT c.folio_permission
+      FROM user_capabilities uc
+      INNER JOIN capability c ON uc.capability_id = c.id
+      WHERE uc.user_id = :user_id
+        AND (
+          c.folio_permission IN (SELECT permission_name FROM permission_names)
+          OR EXISTS (
+            SELECT 1 FROM prefixes p
+            WHERE c.folio_permission LIKE p.pattern
+          )
+        )
+    ),
+    replaced_permissions AS (
+      SELECT UNNEST(p.replaces) AS folio_permission
+      FROM user_permissions up
+      INNER JOIN permission p
+        ON p.name = up.folio_permission
+    )
+    SELECT DISTINCT folio_permission
+    FROM (
+      SELECT folio_permission FROM user_permissions
+
+      UNION ALL
+
+      SELECT folio_permission FROM replaced_permissions
+    ) t;
+    """)
+  List<String> findPermissionsByPrefixesAndPermissionNames(@Param("user_id") UUID userId,
+    @Param("permission_names") String permissionNames, @Param("prefixes") String prefixes);
 }

--- a/src/main/java/org/folio/roles/service/capability/CapabilityService.java
+++ b/src/main/java/org/folio/roles/service/capability/CapabilityService.java
@@ -45,7 +45,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CapabilityService {
 
-  private final List<String> visiblePermissionPrefixes = List.of("ui-", "module", "plugin");
+  public static final String VISIBLE_PERMISSION_PREFIXES = buildPrefixesParam(List.of("ui-", "module", "plugin"));
 
   private final CapabilityRepository capabilityRepository;
   private final FolioExecutionContext folioExecutionContext;
@@ -245,16 +245,15 @@ public class CapabilityService {
   @Transactional(readOnly = true)
   public List<String> getUserPermissions(UUID userId, boolean onlyVisible, List<String> desiredPermissions) {
     if (onlyVisible) {
-      var permissionPrefixesParam = buildPrefixesParam(visiblePermissionPrefixes);
-      return capabilityRepository.findPermissionsByPrefixes(userId, permissionPrefixesParam);
+      return capabilityRepository.findPermissionsByPrefixes(userId, VISIBLE_PERMISSION_PREFIXES);
     }
 
     if (isNotEmpty(desiredPermissions)) {
-      var preparedPrefixes = desiredPermissions.stream().map(CapabilityService::trimWildcard).toList();
-      var filteredPerms = capabilityRepository.findPermissionsByPrefixes(userId, buildPrefixesParam(preparedPrefixes));
-      return toStream(filteredPerms)
-        .filter(s1 -> toStream(desiredPermissions).anyMatch(s2 -> match(s1, s2)))
-        .toList();
+      var prefixes =
+        toStream(desiredPermissions).filter(s -> s.contains("*")).map(CapabilityService::trimWildcard).toList();
+      var permNames = toStream(desiredPermissions).filter(s -> !s.contains("*")).toList();
+      return capabilityRepository.findPermissionsByPrefixesAndPermissionNames(userId, buildPrefixesParam(permNames),
+        buildPrefixesParam(prefixes));
     }
 
     return capabilityRepository.findAllFolioPermissions(userId);
@@ -278,12 +277,6 @@ public class CapabilityService {
 
   private static String trimWildcard(String param) {
     return param.endsWith("*") ? param.substring(0, param.length() - 1) : param;
-  }
-
-  private static boolean match(String s1, String s2) {
-    return s2.endsWith(".*")
-      ? s1.startsWith(s2.substring(0, s2.length() - 1))
-      : s1.equals(s2);
   }
 
   private static String buildPrefixesParam(List<String> prefixes) {

--- a/src/test/java/org/folio/roles/it/PermissionsUserIT.java
+++ b/src/test/java/org/folio/roles/it/PermissionsUserIT.java
@@ -33,16 +33,18 @@ import org.springframework.util.LinkedMultiValueMap;
 @IntegrationTest
 @SqlMergeMode(MERGE)
 @Sql(scripts = {
-  "classpath:/sql/capabilities/populate-capabilities.sql",
-  "classpath:/sql/capability-sets/populate-capability-sets.sql",
-  "classpath:/sql/populate-user-capability-relations.sql"
+  "/sql/capabilities/populate-capabilities.sql",
+  "/sql/capability-sets/populate-capability-sets.sql",
+  "/sql/populate-user-capability-relations.sql",
+  "/sql/capabilities/populate-capability-permissions.sql"
 })
 @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {
-  "classpath:/sql/truncate-capability-tables.sql",
-  "classpath:/sql/truncate-role-tables.sql",
-  "classpath:/sql/truncate-role-capability-tables.sql",
-  "classpath:/sql/truncate-user-capability-tables.sql",
-  "classpath:/sql/truncate-roles-user-related-tables.sql"
+  "/sql/truncate-capability-tables.sql",
+  "/sql/truncate-role-tables.sql",
+  "/sql/truncate-role-capability-tables.sql",
+  "/sql/truncate-user-capability-tables.sql",
+  "/sql/truncate-roles-user-related-tables.sql",
+  "/sql/truncate-permission-table.sql"
 })
 class PermissionsUserIT extends BaseIntegrationTest {
 
@@ -82,39 +84,51 @@ class PermissionsUserIT extends BaseIntegrationTest {
     var userId6 = UUID.fromString("fe0d0b41-c743-44c9-8842-9a190a0cf568");
 
     return Stream.of(
-      arguments(userId1, true, List.of(
-          "module.foo.item.post", "plugin.foo.item.get", "ui-foo.item.delete", "ui-foo.item.put"),
+      arguments(userId1, true, List.of("module.foo.item.post", "plugin.foo.item.get", "ui-foo.item.delete",
+          "ui-foo.item.put", "replaced.ui-foo.item.put"),
         List.of("ui-foo.item.*", "module.foo.item.post")),
       arguments(userId1, false, List.of(
-        "foo.item.delete", "foo.item.get", "foo.item.post", "foo.item.put",
-        "module.foo.item.post", "plugin.foo.item.get", "ui-foo.item.delete", "ui-foo.item.put"), emptyList()),
+        "foo.item.delete", "replaced.foo.item.delete", "foo.item.get", "foo.item.post", "foo.item.put",
+        "module.foo.item.post", "plugin.foo.item.get", "ui-foo.item.delete", "ui-foo.item.put",
+        "replaced.ui-foo.item.put"), emptyList()),
 
       arguments(userId2, true, List.of(
-        "plugin.foo.item.get", "ui-foo.item.delete", "ui-foo.item.put"), emptyList()),
+        "plugin.foo.item.get", "ui-foo.item.delete", "ui-foo.item.put", "replaced.ui-foo.item.put"), emptyList()),
       arguments(userId2, false, List.of(
-        "foo.item.delete", "foo.item.get", "foo.item.post", "foo.item.put",
-        "plugin.foo.item.get", "ui-foo.item.delete", "ui-foo.item.put"), emptyList()),
+        "foo.item.delete", "replaced.foo.item.delete", "foo.item.get", "foo.item.post", "foo.item.put",
+        "plugin.foo.item.get", "ui-foo.item.delete", "ui-foo.item.put", "replaced.ui-foo.item.put"), emptyList()),
 
       arguments(userId3, true, List.of(
-        "module.foo.item.post", "plugin.foo.item.get", "ui-foo.item.delete", "ui-foo.item.put"), emptyList()),
+        "module.foo.item.post", "plugin.foo.item.get", "ui-foo.item.delete", "ui-foo.item.put",
+        "replaced.ui-foo.item.put"), emptyList()),
       arguments(userId3, false, List.of(
-        "module.foo.item.post", "plugin.foo.item.get", "ui-foo.item.delete", "ui-foo.item.put"), emptyList()),
+        "module.foo.item.post", "plugin.foo.item.get", "ui-foo.item.delete", "ui-foo.item.put",
+        "replaced.ui-foo.item.put"), emptyList()),
 
       arguments(userId4, true, List.of("ui-foo.item.delete"), emptyList()),
       arguments(userId4, false, List.of(
-        "foo.item.delete", "foo.item.get", "foo.item.post",
+        "foo.item.delete", "replaced.foo.item.delete", "foo.item.get", "foo.item.post",
         "foo.item.put", "ui-foo.item.delete"), emptyList()),
 
-      arguments(userId5, true, List.of("plugin.foo.item.get", "ui-foo.item.put"), emptyList()),
+      arguments(userId5, true, List.of("plugin.foo.item.get", "ui-foo.item.put", "replaced.ui-foo.item.put"),
+        emptyList()),
       arguments(userId5, false, List.of(
-        "foo.item.delete", "foo.item.get", "foo.item.post",
-        "foo.item.put", "plugin.foo.item.get", "ui-foo.item.put"), emptyList()),
+        "foo.item.delete", "replaced.foo.item.delete", "foo.item.get", "foo.item.post",
+        "foo.item.put", "plugin.foo.item.get", "ui-foo.item.put", "replaced.ui-foo.item.put"), emptyList()),
 
       arguments(userId6, true, emptyList(), emptyList()),
       arguments(userId6, false, emptyList(), emptyList()),
       arguments(userId1, false, List.of(
-          "foo.item.delete", "foo.item.get", "foo.item.post", "foo.item.put", "ui-foo.item.delete"),
-        List.of("foo.item.*", "ui-foo.item.delete"))
+          "foo.item.delete", "replaced.foo.item.delete", "foo.item.get", "foo.item.post", "foo.item.put",
+          "ui-foo.item.delete"),
+        List.of("foo.item.*", "ui-foo.item.delete")),
+      arguments(userId1, false, List.of(
+          "foo.item.delete", "replaced.foo.item.delete", "foo.item.get", "foo.item.post", "foo.item.put",
+          "ui-foo.item.delete", "ui-foo.item.put", "replaced.ui-foo.item.put"),
+        List.of("foo.item.*", "ui-foo.item.*")),
+      arguments(userId1, false, List.of(
+          "foo.item.delete", "replaced.foo.item.delete", "ui-foo.item.delete"),
+        List.of("foo.item.delete", "ui-foo.item.delete"))
     );
   }
 }

--- a/src/test/java/org/folio/roles/service/capability/CapabilityServiceTest.java
+++ b/src/test/java/org/folio/roles/service/capability/CapabilityServiceTest.java
@@ -6,8 +6,10 @@ import static java.util.Collections.emptySet;
 import static java.util.List.of;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.folio.common.utils.CollectionUtils.toStream;
 import static org.folio.roles.domain.entity.CapabilityEntity.DEFAULT_CAPABILITY_SORT;
 import static org.folio.roles.integration.kafka.model.ResourceEventType.CREATE;
+import static org.folio.roles.service.capability.CapabilityService.VISIBLE_PERMISSION_PREFIXES;
 import static org.folio.roles.support.CapabilitySetUtils.CAPABILITY_SET_ID;
 import static org.folio.roles.support.CapabilitySetUtils.capabilitySet;
 import static org.folio.roles.support.CapabilityUtils.APPLICATION_ID;
@@ -28,6 +30,7 @@ import static org.mockito.Mockito.when;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.folio.roles.domain.model.PageResult;
 import org.folio.roles.domain.model.event.CapabilityEvent;
@@ -454,33 +457,40 @@ class CapabilityServiceTest {
 
     @Test
     void positive_onlyVisiblePermissions() {
-      var prefixes = ArgumentCaptor.forClass(String.class);
       var permissions = List.of(PERMISSION_NAME);
-      when(capabilityRepository.findPermissionsByPrefixes(eq(USER_ID), prefixes.capture())).thenReturn(permissions);
+      when(capabilityRepository.findPermissionsByPrefixes(eq(USER_ID), eq(VISIBLE_PERMISSION_PREFIXES)))
+        .thenReturn(permissions);
       var result = capabilityService.getUserPermissions(USER_ID, true, emptyList());
 
       assertThat(result).containsExactly(PERMISSION_NAME);
-      assertThat(prefixes.getValue()).isEqualTo("{ui-, module, plugin}");
     }
 
-    @ParameterizedTest(name = "{index} request: {0}, user's perms: {1}, resolved perms: {2}")
+    @ParameterizedTest(name = "{index} request: {0}, permission names: {1}, prefixes: {2}, result: {3}")
     @MethodSource("permissionsProvider")
-    void positive_desiredPermissions(List<String> desiredPerms, List<String> userPerms, List<String> resolvedPerms) {
-      when(capabilityRepository.findPermissionsByPrefixes(eq(USER_ID), anyString())).thenReturn(userPerms);
+    void positive_desiredPermissions(List<String> request, List<String> permNames, List<String> prefixes,
+      List<String> resolvedPerms) {
+      var names = toStream(permNames).collect(Collectors.joining(", ", "{", "}"));
+      var prefs = toStream(prefixes).collect(Collectors.joining(", ", "{", "}"));
 
-      var result = capabilityService.getUserPermissions(USER_ID, false, desiredPerms);
+      when(capabilityRepository.findPermissionsByPrefixesAndPermissionNames(eq(USER_ID), anyString(), anyString()))
+        .thenReturn(resolvedPerms);
+
+      var result = capabilityService.getUserPermissions(USER_ID, false, request);
 
       assertThat(result).containsExactlyInAnyOrderElementsOf(resolvedPerms);
+      verify(capabilityRepository).findPermissionsByPrefixesAndPermissionNames(USER_ID, names, prefs);
     }
 
-    //permissionsToResolve : userPermissions : resolvedPermissions
+    //request : prefixes from request : permission names from request : resolved permissions
     static Stream<Arguments> permissionsProvider() {
       return Stream.of(
-        Arguments.of(of("ui.all", "be.all"), of("ui.all", "users.all"), of("ui.all")),
-        Arguments.of(of("be.*"), of("ui.all", "be.get", "be.post"), of("be.get", "be.post")),
-        Arguments.of(of("be.it.*", "ui.all"), of("be.all", "be.it.get", "be.it.post"), of("be.it.get", "be.it.post")),
-        Arguments.of(of("be.it.*", "ui.all"), emptyList(), emptyList()),
-        Arguments.of(of("be.it.*", "ui.all"), of("be.all", "users.item.all"), emptyList())
+        Arguments.of(of("ui.all", "be.all"), of("ui.all", "be.all"), emptyList(), of("ui.all")),
+        Arguments.of(of("be.*"), emptyList(), of("be."), emptyList()),
+        Arguments.of(of("be.it.*", "ui.all"), of("ui.all"), of("be.it."), emptyList()),
+        Arguments.of(of("be.it.*", "ui.*"), emptyList(), of("be.it.", "ui."), emptyList()),
+        Arguments.of(of("be.it.view.*", "ui.all"), of("ui.all"), of("be.it.view."), emptyList()),
+        Arguments.of(of("be.it.*", "ui.all"), of("ui.all"), of("be.it."),
+          of("be.all", "ui.all", "replaced.ui.all.view"))
       );
     }
   }

--- a/src/test/java/org/folio/roles/service/capability/CapabilityServiceTest.java
+++ b/src/test/java/org/folio/roles/service/capability/CapabilityServiceTest.java
@@ -458,7 +458,7 @@ class CapabilityServiceTest {
     @Test
     void positive_onlyVisiblePermissions() {
       var permissions = List.of(PERMISSION_NAME);
-      when(capabilityRepository.findPermissionsByPrefixes(eq(USER_ID), eq(VISIBLE_PERMISSION_PREFIXES)))
+      when(capabilityRepository.findPermissionsByPrefixes(USER_ID, VISIBLE_PERMISSION_PREFIXES))
         .thenReturn(permissions);
       var result = capabilityService.getUserPermissions(USER_ID, true, emptyList());
 

--- a/src/test/resources/sql/capabilities/populate-capability-permissions.sql
+++ b/src/test/resources/sql/capabilities/populate-capability-permissions.sql
@@ -1,0 +1,9 @@
+-- add permissions for capabilities
+INSERT INTO permission(id, name, display_name, description, visible, sub_permissions, replaces)
+VALUES ('e1a5683a-fece-43fb-bbaa-52a438af1111', 'foo.item.delete',
+        'Delete Foo Item', 'Permission to delete a foo item',
+        NULL, NULL, ARRAY['replaced.foo.item.delete']),
+
+       ('e1a5683a-1111-1111-1111-52a438af1111', 'ui-foo.item.put',
+        'Ui Update Foo Item', 'Ui Permission to update foo item',
+        NULL, NULL, ARRAY['replaced.ui-foo.item.put']);


### PR DESCRIPTION
## Purpose
FOLIO Permissions can be renamed via a new "replaces" property.  The Eureka platform should honor this property.
https://folio-org.atlassian.net/browse/MODROLESKC-221

## Approach

- change SQL to request user permissions
- add SQL for querying desired permission
- adjust tests by test cases

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
