### PR TITLE
SubPermissions processing

### DIFF
--- a/src/main/java/org/folio/roles/integration/kafka/CapabilityEventProcessor.java
+++ b/src/main/java/org/folio/roles/integration/kafka/CapabilityEventProcessor.java
@@ -12,7 +12,6 @@ import static org.apache.commons.collections4.ListUtils.emptyIfNull;
 import static org.apache.commons.lang3.StringUtils.uncapitalize;
 import static org.folio.common.utils.CollectionUtils.toStream;
 import static org.folio.roles.integration.kafka.model.ModuleType.MODULE;
-import static org.folio.roles.integration.kafka.model.ModuleType.UI_MODULE;
 import static org.folio.roles.utils.CapabilityUtils.getCapabilityName;
 import static org.folio.roles.utils.CollectionUtils.union;
 
@@ -39,7 +38,6 @@ import org.folio.roles.integration.kafka.model.CapabilityEvent;
 import org.folio.roles.integration.kafka.model.CapabilityResultHolder;
 import org.folio.roles.integration.kafka.model.CapabilitySetDescriptor;
 import org.folio.roles.integration.kafka.model.FolioResource;
-import org.folio.roles.integration.kafka.model.ModuleType;
 import org.folio.roles.integration.kafka.model.Permission;
 import org.folio.roles.service.permission.FolioPermissionService;
 import org.folio.roles.service.permission.PermissionOverrider;
@@ -75,7 +73,7 @@ public class CapabilityEventProcessor {
     var grouped = groupByHavingSubPermissions(resources);
     var capabilities = mapItems(grouped.get(FALSE), res -> createCapability(event, res));
     var capabilitySetDescriptors =
-      mapItems(grouped.get(TRUE), res -> createCapabilitySetDescriptor(event, res, MODULE));
+      mapItems(grouped.get(TRUE), res -> createCapabilitySetDescriptor(event, res));
     return toCapabilityResultHolder(capabilities, capabilitySetDescriptors);
   }
 
@@ -93,21 +91,21 @@ public class CapabilityEventProcessor {
     var grouped = groupByHavingSubPermissions(resources);
     var capabilities = mapItems(resources, res -> createCapability(event, res));
     var capabilitySetDescriptors =
-      mapItems(grouped.get(TRUE), res -> createCapabilitySetDescriptor(event, res, UI_MODULE));
+      mapItems(grouped.get(TRUE), res -> createCapabilitySetDescriptor(event, res));
     return toCapabilityResultHolder(capabilities, capabilitySetDescriptors);
   }
 
   private Optional<CapabilitySetDescriptor> createCapabilitySetDescriptor(
-    CapabilityEvent event, FolioResource resource, ModuleType moduleType) {
+    CapabilityEvent event, FolioResource resource) {
     var folioPermission = resource.getPermission().getPermissionName();
     var permissionMappingOverrides = permissionOverrider.getPermissionMappings();
     return Optional.of(extractPermissionData(folioPermission, permissionMappingOverrides))
       .filter(CapabilityEventProcessor::hasRequiredFields)
-      .map(raw -> createCapabilitySetDescriptor(event, resource, raw, moduleType));
+      .map(raw -> createCapabilitySetDescriptor(event, resource, raw));
   }
 
   private CapabilitySetDescriptor createCapabilitySetDescriptor(
-    CapabilityEvent event, FolioResource res, PermissionData permissionData, ModuleType moduleType) {
+    CapabilityEvent event, FolioResource res, PermissionData permissionData) {
     var permission = res.getPermission();
     /*
      * The SubPermissions are handled equally for both module types: MODULE and UI_MODULE.

--- a/src/main/java/org/folio/roles/integration/kafka/CapabilityEventProcessor.java
+++ b/src/main/java/org/folio/roles/integration/kafka/CapabilityEventProcessor.java
@@ -1,6 +1,5 @@
 package org.folio.roles.integration.kafka;
 
-import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.groupingBy;
@@ -11,7 +10,6 @@ import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.apache.commons.collections4.ListUtils.emptyIfNull;
 import static org.apache.commons.lang3.StringUtils.uncapitalize;
 import static org.folio.common.utils.CollectionUtils.toStream;
-import static org.folio.roles.integration.kafka.model.ModuleType.MODULE;
 import static org.folio.roles.utils.CapabilityUtils.getCapabilityName;
 import static org.folio.roles.utils.CollectionUtils.union;
 
@@ -64,17 +62,7 @@ public class CapabilityEventProcessor {
     }
 
     var folioResources = event.getResources();
-    return event.getModuleType() == MODULE
-      ? processModuleResources(event, folioResources)
-      : processUiModuleResources(event, folioResources);
-  }
-
-  private CapabilityResultHolder processModuleResources(CapabilityEvent event, List<FolioResource> resources) {
-    var grouped = groupByHavingSubPermissions(resources);
-    var capabilities = mapItems(grouped.get(FALSE), res -> createCapability(event, res));
-    var capabilitySetDescriptors =
-      mapItems(grouped.get(TRUE), res -> createCapabilitySetDescriptor(event, res));
-    return toCapabilityResultHolder(capabilities, capabilitySetDescriptors);
+    return processModuleResources(event, folioResources);
   }
 
   /**
@@ -86,8 +74,9 @@ public class CapabilityEventProcessor {
    * Such Capabilities can be distinguished by the following criteria:
    * the end-points list of the capability must be empty,
    * and the capability name must be equal to the capability set name that it reflects.
+   * Both backend and UI modules are processed in the same way.
    */
-  private CapabilityResultHolder processUiModuleResources(CapabilityEvent event, List<FolioResource> resources) {
+  private CapabilityResultHolder processModuleResources(CapabilityEvent event, List<FolioResource> resources) {
     var grouped = groupByHavingSubPermissions(resources);
     var capabilities = mapItems(resources, res -> createCapability(event, res));
     var capabilitySetDescriptors =

--- a/src/main/java/org/folio/roles/integration/kafka/CapabilityEventProcessor.java
+++ b/src/main/java/org/folio/roles/integration/kafka/CapabilityEventProcessor.java
@@ -109,9 +109,12 @@ public class CapabilityEventProcessor {
   private CapabilitySetDescriptor createCapabilitySetDescriptor(
     CapabilityEvent event, FolioResource res, PermissionData permissionData, ModuleType moduleType) {
     var permission = res.getPermission();
-    var subPermissions = moduleType == UI_MODULE
-      ? union(permission.getSubPermissions(), List.of(permission.getPermissionName()))
-      : permission.getSubPermissions();
+    /*
+     * The SubPermissions are handled equally for both module types: MODULE and UI_MODULE.
+     * It is needed to support cases when a PermissionSet defined in BE modules are used in UI modules.
+     * see https://folio-org.atlassian.net/browse/MODROLESKC-240
+     */
+    var subPermissions =  union(permission.getSubPermissions(), List.of(permission.getPermissionName()));
     var subPermissionsExpanded = folioPermissionService.expandPermissionNames(subPermissions);
 
     var capabilities = subPermissionsExpanded.stream()

--- a/src/test/java/org/folio/roles/integration/kafka/CapabilityEventProcessorTest.java
+++ b/src/test/java/org/folio/roles/integration/kafka/CapabilityEventProcessorTest.java
@@ -111,7 +111,7 @@ class CapabilityEventProcessorTest {
 
       arguments("module event (permission and permissionSet)",
         event(MODULE, resource(permission), resource(permissionSet)),
-        result(List.of(capability), List.of(capabilitySetDesc))),
+        result(List.of(capability, uiCapability), List.of(capabilitySetDesc))),
 
       arguments("module event (found element endpoints empty)",
         event(MODULE,
@@ -170,16 +170,16 @@ class CapabilityEventProcessorTest {
 
       arguments("module event (permission set)",
         event(MODULE, resource(permissionSet)),
-        result(emptyList(), List.of(capabilitySetDesc))),
+        result(List.of(uiCapability), List.of(capabilitySetDesc))),
 
       arguments("module event (permission set) mapping overrides",
         event(MODULE,
           resource(permission(itemViewPerm, "perm.name").description(csDescription))),
-        result(emptyList(), List.of(capabilitySetDesc))),
+        result(List.of(uiCapability), List.of(capabilitySetDesc))),
 
       arguments("module event (duplicate permission set)",
         event(MODULE, resource(permissionSet), resource(permissionSet)),
-        result(emptyList(), List.of(capabilitySetDesc))),
+        result(List.of(uiCapability), List.of(capabilitySetDesc))),
 
       arguments("ui-module event (permission)",
         event(UI_MODULE, resource(permission)),

--- a/src/test/java/org/folio/roles/integration/kafka/CapabilityEventProcessorTest.java
+++ b/src/test/java/org/folio/roles/integration/kafka/CapabilityEventProcessorTest.java
@@ -95,10 +95,11 @@ class CapabilityEventProcessorTest {
     var csDescription = csResource + " - permission set description";
     var capability = capability(null, resource, VIEW, itemGetPermName).description(description).moduleId(MODULE_ID);
     var uiCapability = capability(null, csResource, VIEW, itemViewPerm).description(csDescription).moduleId(MODULE_ID);
-    var setResources = Map.of(resource, List.of(VIEW));
+    // now subPermissions are processed identically for both UI_MODULE and MODULE moduleTypes!
+    // see capabilityEventProcessor.createCapabilitySetDescriptor#112 method
+    var setResources = Map.of(resource, List.of(VIEW), csResource, List.of(VIEW));
     var capabilitySetDesc = capabilitySetDescriptor(csResource, itemViewPerm, setResources).moduleId(MODULE_ID);
-    var uiCapabilitySetDesc = capabilitySetDescriptor(
-      csResource, itemViewPerm, Map.of(resource, List.of(VIEW), csResource, List.of(VIEW))).moduleId(MODULE_ID);
+    var uiCapabilitySetDesc = capabilitySetDescriptor(csResource, itemViewPerm, setResources).moduleId(MODULE_ID);
 
     var permission = permission(itemGetPermName).description(description);
     var permissionSet = permission(itemViewPerm, itemGetPermName).description(csDescription);

--- a/src/test/java/org/folio/roles/it/KafkaMessageListenerIT.java
+++ b/src/test/java/org/folio/roles/it/KafkaMessageListenerIT.java
@@ -122,6 +122,7 @@ class KafkaMessageListenerIT extends BaseIntegrationTest {
     kafkaTemplate.send(FOLIO_IT_CAPABILITIES_TOPIC, capabilityEvent);
 
     var expectedCapabilitiesJson = asJsonString(capabilities(
+      fooItemCapability(MANAGE, "foo.item.all", APPLICATION_ID_V2),
       fooItemCapability(CREATE, "foo.item.post", APPLICATION_ID_V2, fooItemPostEndpoint()),
       fooItemCapability(DELETE, "foo.item.delete", APPLICATION_ID_V2, fooItemDeleteEndpoint()),
       fooItemCapability(EDIT, "foo.item.put", APPLICATION_ID_V2, fooItemPutEndpoint(), fooItemPatchEndpoint()),
@@ -142,7 +143,7 @@ class KafkaMessageListenerIT extends BaseIntegrationTest {
     assertCapabilityNamesBySetId(capabilitySets.get(0).getId(), "foo_item.create", "foo_item.edit", "foo_item.view");
     assertCapabilityNamesBySetId(capabilitySets.get(1).getId(), "foo_item.edit", "foo_item.view");
     assertCapabilityNamesBySetId(capabilitySets.get(2).getId(),
-      "foo_item.create", "foo_item.delete", "foo_item.edit", "foo_item.view");
+      "foo_item.create", "foo_item.delete", "foo_item.edit", "foo_item.manage", "foo_item.view");
     assertCapabilityNamesBySetId(capabilitySets.get(3).getId(), "foo_item.view");
   }
 
@@ -154,7 +155,7 @@ class KafkaMessageListenerIT extends BaseIntegrationTest {
     var uiCapabilityEvent = readValue("json/kafka-events/ui-capability-event.json", ResourceEvent.class);
     kafkaTemplate.send(FOLIO_IT_CAPABILITIES_TOPIC, uiCapabilityEvent);
 
-    await().untilAsserted(() -> doGet("/capabilities").andExpect(jsonPath("$.totalRecords", is(8))));
+    await().untilAsserted(() -> doGet("/capabilities").andExpect(jsonPath("$.totalRecords", is(9))));
     await().untilAsserted(() -> doGet("/capability-sets").andExpect(jsonPath("$.totalRecords", is(7))));
 
     var searchResult = doGet(get("/capability-sets")
@@ -177,6 +178,7 @@ class KafkaMessageListenerIT extends BaseIntegrationTest {
     kafkaTemplate.send(FOLIO_IT_CAPABILITIES_TOPIC, capabilityEvent);
 
     var expectedCapabilitiesJson = asJsonString(capabilities(
+      fooItemCapability(MANAGE, "foo.item.all"),
       fooItemCapability(CREATE, "foo.item.post", fooItemPostEndpoint()),
       fooItemCapability(DELETE, "foo.item.delete", fooItemDeleteEndpoint()),
       fooItemCapability(EDIT, "foo.item.put", fooItemPutEndpoint(), fooItemPatchEndpoint()),
@@ -187,7 +189,8 @@ class KafkaMessageListenerIT extends BaseIntegrationTest {
       .andExpect(jsonPath("$.capabilities[0].metadata.createdDate", notNullValue()))
       .andExpect(jsonPath("$.capabilities[1].metadata.createdDate", notNullValue()))
       .andExpect(jsonPath("$.capabilities[2].metadata.createdDate", notNullValue()))
-      .andExpect(jsonPath("$.capabilities[3].metadata.createdDate", notNullValue())));
+      .andExpect(jsonPath("$.capabilities[3].metadata.createdDate", notNullValue()))
+      .andExpect(jsonPath("$.capabilities[4].metadata.createdDate", notNullValue())));
 
     var expectedCapabilitySets = asJsonString(capabilitySets(
       fooItemCapabilitySet(CREATE),
@@ -208,7 +211,7 @@ class KafkaMessageListenerIT extends BaseIntegrationTest {
     assertCapabilityNamesBySetId(capabilitySets.get(0).getId(), "foo_item.create", "foo_item.edit", "foo_item.view");
     assertCapabilityNamesBySetId(capabilitySets.get(1).getId(), "foo_item.edit", "foo_item.view");
     assertCapabilityNamesBySetId(capabilitySets.get(2).getId(),
-      "foo_item.create", "foo_item.delete", "foo_item.edit", "foo_item.view");
+      "foo_item.create", "foo_item.delete", "foo_item.edit", "foo_item.manage", "foo_item.view");
     assertCapabilityNamesBySetId(capabilitySets.get(3).getId(), "foo_item.view");
   }
 
@@ -216,7 +219,7 @@ class KafkaMessageListenerIT extends BaseIntegrationTest {
   void handleCapabilityEvent_positive_eventIsSentWhenTenantIsDisabled() {
     var capabilityEvent = readValue("json/kafka-events/be-capability-event.json", ResourceEvent.class);
     kafkaTemplate.send(FOLIO_IT_CAPABILITIES_TOPIC, capabilityEvent);
-    await().untilAsserted(() -> doGet("/capabilities").andExpect(jsonPath("$.totalRecords", is(4))));
+    await().untilAsserted(() -> doGet("/capabilities").andExpect(jsonPath("$.totalRecords", is(5))));
     await().untilAsserted(() -> doGet("/capability-sets").andExpect(jsonPath("$.totalRecords", is(4))));
 
     removeTenant(TENANT_ID);
@@ -224,7 +227,7 @@ class KafkaMessageListenerIT extends BaseIntegrationTest {
     awaitFor(FIVE_HUNDRED_MILLISECONDS);
 
     enableTenant(TENANT_ID);
-    await().untilAsserted(() -> doGet("/capabilities").andExpect(jsonPath("$.totalRecords", is(4))));
+    await().untilAsserted(() -> doGet("/capabilities").andExpect(jsonPath("$.totalRecords", is(5))));
     await().untilAsserted(() -> doGet("/capability-sets").andExpect(jsonPath("$.totalRecords", is(4))));
   }
 
@@ -313,7 +316,7 @@ class KafkaMessageListenerIT extends BaseIntegrationTest {
       .applicationId(applicationId)
       .permission(permission)
       .endpoints(Arrays.asList(endpoints))
-      .description(permission + " - description");
+      .description(capabilityName + " - description");
   }
 
   private static CapabilitySet fooItemCapabilitySet(CapabilityAction action) {

--- a/src/test/java/org/folio/roles/it/PermissionReplacementIT.java
+++ b/src/test/java/org/folio/roles/it/PermissionReplacementIT.java
@@ -33,7 +33,6 @@ import org.folio.roles.domain.dto.CapabilitySets;
 import org.folio.roles.domain.dto.Role;
 import org.folio.roles.domain.dto.RoleType;
 import org.folio.roles.integration.kafka.model.ResourceEvent;
-import org.folio.roles.integration.keyclock.KeycloakClientService;
 import org.folio.roles.integration.keyclock.KeycloakUserService;
 import org.folio.spring.integration.XOkapiHeaders;
 import org.folio.test.extensions.KeycloakRealms;
@@ -65,7 +64,6 @@ public class PermissionReplacementIT extends BaseIntegrationTest {
   public static final String TEST_KC_CLIENT_ID = "00000000-0000-0000-0000-000000000010";
   public static final String TEST_KC_REALM_NAME = "test";
 
-  @Autowired private KeycloakClientService keycloakClientService;
   @Autowired private Keycloak keycloak;
   @Autowired private KafkaTemplate<String, Object> kafkaTemplate;
   @Autowired private ObjectMapper objectMapper;
@@ -103,7 +101,7 @@ public class PermissionReplacementIT extends BaseIntegrationTest {
     var capabilityEvent = readValue("json/kafka-events/be-capability-event.json", ResourceEvent.class);
     kafkaTemplate.send(FOLIO_IT_CAPABILITIES_TOPIC, capabilityEvent);
     await().atMost(ONE_MINUTE).pollInterval(ONE_HUNDRED_MILLISECONDS)
-      .untilAsserted(() -> doGet("/capabilities").andExpect(jsonPath("$.totalRecords", is(4))));
+      .untilAsserted(() -> doGet("/capabilities").andExpect(jsonPath("$.totalRecords", is(5))));
     await().atMost(ONE_MINUTE).pollInterval(ONE_HUNDRED_MILLISECONDS)
       .untilAsserted(() -> doGet("/capability-sets").andExpect(jsonPath("$.totalRecords", is(4))));
 

--- a/src/test/java/org/folio/roles/it/RoleCapabilitySetUpdateIT.java
+++ b/src/test/java/org/folio/roles/it/RoleCapabilitySetUpdateIT.java
@@ -12,6 +12,7 @@ import static org.folio.roles.support.CapabilitySetUtils.capabilitySets;
 import static org.folio.roles.support.CapabilityUtils.APPLICATION_ID_V2;
 import static org.folio.roles.support.CapabilityUtils.FOO_CREATE_CAPABILITY;
 import static org.folio.roles.support.CapabilityUtils.FOO_DELETE_CAPABILITY;
+import static org.folio.roles.support.CapabilityUtils.FOO_EDIT_CAPABILITY;
 import static org.folio.roles.support.CapabilityUtils.FOO_RESOURCE;
 import static org.folio.roles.support.CapabilityUtils.FOO_VIEW_CAPABILITY;
 import static org.folio.roles.support.EndpointUtils.fooItemDeleteEndpoint;
@@ -111,7 +112,7 @@ class RoleCapabilitySetUpdateIT extends BaseIntegrationTest {
     awaitUntilAsserted(() -> doGet(request).andExpect(content().json(asJsonString(capabilitySets()))));
     awaitUntilAsserted(RoleCapabilitySetUpdateIT::assertAssignedCapabilitySets);
     awaitUntilAsserted(() -> assertThat(kcTestClient.getPermissionNames()).isEmpty());
-    doGet("/capabilities").andExpect(jsonPath("$.totalRecords", is(9)));
+    doGet("/capabilities").andExpect(jsonPath("$.totalRecords", is(8)));
   }
 
   @Test
@@ -175,10 +176,11 @@ class RoleCapabilitySetUpdateIT extends BaseIntegrationTest {
     var request = getFooCreateCapabilitySet();
     awaitUntilAsserted(() -> doGet(request).andExpect(content().json(asJsonString(capabilitySets()))));
 
-    var capabilitySet = capabilitySet(FOO_MANAGE_CAPABILITY_SET, FOO_RESOURCE, MANAGE, FOO_MANAGE_CAPABILITIES);
+    var capabilitySet = capabilitySet(FOO_MANAGE_CAPABILITY_SET, FOO_RESOURCE, MANAGE, List.of(
+      FOO_VIEW_CAPABILITY, FOO_EDIT_CAPABILITY, FOO_DELETE_CAPABILITY));
     awaitUntilAsserted(() -> assertAssignedCapabilitySets(capabilitySet));
     awaitUntilAsserted(() -> assertThat(kcTestClient.getPermissionNames()).containsExactlyInAnyOrder(
-      kcPermissionName(fooItemGetEndpoint()), kcPermissionName(fooItemPostEndpoint()),
+      kcPermissionName(fooItemGetEndpoint()),
       kcPermissionName(fooItemPutEndpoint()), kcPermissionName(fooItemDeleteEndpoint())));
   }
 
@@ -205,8 +207,7 @@ class RoleCapabilitySetUpdateIT extends BaseIntegrationTest {
 
     assertAssignedCapabilitySets(updatedCapabilitySet);
     awaitUntilAsserted(() -> assertThat(kcTestClient.getPermissionNames()).containsExactlyInAnyOrder(
-      kcPermissionName(fooItemGetEndpoint()), kcPermissionName(fooItemDeleteEndpoint()),
-      kcPermissionName(fooItemPostEndpoint())));
+      kcPermissionName(fooItemDeleteEndpoint()), kcPermissionName(fooItemGetEndpoint())));
   }
 
   @Test
@@ -236,8 +237,7 @@ class RoleCapabilitySetUpdateIT extends BaseIntegrationTest {
 
     assertAssignedCapabilitySets(updatedCapabilitySet);
     awaitUntilAsserted(TWO_SECONDS, () -> assertThat(kcTestClient.getPermissionNames()).containsExactlyInAnyOrder(
-      kcPermissionName(fooItemPostEndpoint()), kcPermissionName(fooItemGetEndpoint()),
-      kcPermissionName(fooItemDeleteEndpoint())));
+      kcPermissionName(fooItemGetEndpoint()), kcPermissionName(fooItemDeleteEndpoint())));
   }
 
   @Test
@@ -269,7 +269,7 @@ class RoleCapabilitySetUpdateIT extends BaseIntegrationTest {
     var capabilitySet = capabilitySet(FOO_MANAGE_CAPABILITY_SET, FOO_RESOURCE, MANAGE, FOO_MANAGE_CAPABILITIES);
     assertAssignedCapabilitySets(updatedCapabilitySet, capabilitySet);
     awaitUntilAsserted(TWO_SECONDS, () -> assertThat(kcTestClient.getPermissionNames()).containsExactlyInAnyOrder(
-      kcPermissionName(fooItemGetEndpoint()), kcPermissionName(fooItemPostEndpoint()),
+      kcPermissionName(fooItemGetEndpoint()),
       kcPermissionName(fooItemDeleteEndpoint()), kcPermissionName(fooItemPutEndpoint())));
   }
 

--- a/src/test/java/org/folio/roles/it/RoleCapabilitySetUpdateIT.java
+++ b/src/test/java/org/folio/roles/it/RoleCapabilitySetUpdateIT.java
@@ -195,7 +195,7 @@ class RoleCapabilitySetUpdateIT extends BaseIntegrationTest {
   void handleCapabilityEvent_positive_updatedCapability() throws Exception {
     var capabilityEvent = readValue("json/kafka-events/be-capability-set-upgrade-event.json", ResourceEvent.class);
     kafkaTemplate.send(FOLIO_IT_CAPABILITIES_TOPIC, capabilityEvent);
-    var newCapabilities = List.of(FOO_VIEW_CAPABILITY, FOO_DELETE_CAPABILITY);
+    var newCapabilities = List.of(FOO_VIEW_CAPABILITY, FOO_DELETE_CAPABILITY, FOO_CREATE_CAPABILITY);
     var updatedCapabilitySet = capabilitySet(FOO_CREATE_CAPABILITY_SET, FOO_RESOURCE, CREATE, newCapabilities)
       .permission("foo.item.create")
       .applicationId(APPLICATION_ID_V2);
@@ -205,7 +205,8 @@ class RoleCapabilitySetUpdateIT extends BaseIntegrationTest {
 
     assertAssignedCapabilitySets(updatedCapabilitySet);
     awaitUntilAsserted(() -> assertThat(kcTestClient.getPermissionNames()).containsExactlyInAnyOrder(
-      kcPermissionName(fooItemGetEndpoint()), kcPermissionName(fooItemDeleteEndpoint())));
+      kcPermissionName(fooItemGetEndpoint()), kcPermissionName(fooItemDeleteEndpoint()),
+      kcPermissionName(fooItemPostEndpoint())));
   }
 
   @Test
@@ -225,7 +226,7 @@ class RoleCapabilitySetUpdateIT extends BaseIntegrationTest {
       kcPermissionName(fooItemGetEndpoint()), kcPermissionName(fooItemPostEndpoint()));
 
     kafkaTemplate.send(FOLIO_IT_CAPABILITIES_TOPIC, capabilityEvent);
-    var newCapabilities = List.of(FOO_VIEW_CAPABILITY, FOO_DELETE_CAPABILITY);
+    var newCapabilities = List.of(FOO_VIEW_CAPABILITY, FOO_DELETE_CAPABILITY, FOO_CREATE_CAPABILITY);
     var updatedCapabilitySet = capabilitySet(FOO_CREATE_CAPABILITY_SET, FOO_RESOURCE, CREATE, newCapabilities)
       .permission("foo.item.create")
       .applicationId(APPLICATION_ID_V2);
@@ -257,7 +258,7 @@ class RoleCapabilitySetUpdateIT extends BaseIntegrationTest {
       kcPermissionName(fooItemDeleteEndpoint()), kcPermissionName(fooItemPutEndpoint()));
 
     kafkaTemplate.send(FOLIO_IT_CAPABILITIES_TOPIC, capabilityEvent);
-    var newCapabilities = List.of(FOO_VIEW_CAPABILITY, FOO_DELETE_CAPABILITY);
+    var newCapabilities = List.of(FOO_VIEW_CAPABILITY, FOO_DELETE_CAPABILITY, FOO_CREATE_CAPABILITY);
     var updatedCapabilitySet = capabilitySet(FOO_CREATE_CAPABILITY_SET, FOO_RESOURCE, CREATE, newCapabilities)
       .permission("foo.item.create")
       .applicationId(APPLICATION_ID_V2);

--- a/src/test/java/org/folio/roles/it/UserCapabilitySetUpdateIT.java
+++ b/src/test/java/org/folio/roles/it/UserCapabilitySetUpdateIT.java
@@ -192,7 +192,7 @@ class UserCapabilitySetUpdateIT extends BaseIntegrationTest {
   void handleCapabilityEvent_positive_updatedCapability() throws Exception {
     var capabilityEvent = readValue("json/kafka-events/be-capability-set-upgrade-event.json", ResourceEvent.class);
     kafkaTemplate.send(FOLIO_IT_CAPABILITIES_TOPIC, capabilityEvent);
-    var newCapabilities = List.of(FOO_VIEW_CAPABILITY, FOO_DELETE_CAPABILITY);
+    var newCapabilities = List.of(FOO_VIEW_CAPABILITY, FOO_DELETE_CAPABILITY, FOO_CREATE_CAPABILITY);
     var updatedCapabilitySet = capabilitySet(FOO_CREATE_CAPABILITY_SET, FOO_RESOURCE, CREATE, newCapabilities)
       .permission("foo.item.create")
       .applicationId(APPLICATION_ID_V2);
@@ -202,7 +202,8 @@ class UserCapabilitySetUpdateIT extends BaseIntegrationTest {
 
     assertAssignedCapabilitySets(updatedCapabilitySet);
     awaitUntilAsserted(() -> assertThat(kcTestClient.getPermissionNames()).containsExactlyInAnyOrder(
-      kcPermissionName(fooItemGetEndpoint()), kcPermissionName(fooItemDeleteEndpoint())));
+      kcPermissionName(fooItemGetEndpoint()), kcPermissionName(fooItemDeleteEndpoint()),
+      kcPermissionName(fooItemPostEndpoint())));
   }
 
   @Test
@@ -222,7 +223,7 @@ class UserCapabilitySetUpdateIT extends BaseIntegrationTest {
       kcPermissionName(fooItemGetEndpoint()), kcPermissionName(fooItemPostEndpoint()));
 
     kafkaTemplate.send(FOLIO_IT_CAPABILITIES_TOPIC, capabilityEvent);
-    var newCapabilities = List.of(FOO_VIEW_CAPABILITY, FOO_DELETE_CAPABILITY);
+    var newCapabilities = List.of(FOO_VIEW_CAPABILITY, FOO_DELETE_CAPABILITY, FOO_CREATE_CAPABILITY);
     var updatedCapabilitySet = capabilitySet(FOO_CREATE_CAPABILITY_SET, FOO_RESOURCE, CREATE, newCapabilities)
       .permission("foo.item.create")
       .applicationId(APPLICATION_ID_V2);
@@ -254,7 +255,7 @@ class UserCapabilitySetUpdateIT extends BaseIntegrationTest {
       kcPermissionName(fooItemDeleteEndpoint()), kcPermissionName(fooItemPutEndpoint()));
 
     kafkaTemplate.send(FOLIO_IT_CAPABILITIES_TOPIC, capabilityEvent);
-    var newCapabilities = List.of(FOO_VIEW_CAPABILITY, FOO_DELETE_CAPABILITY);
+    var newCapabilities = List.of(FOO_VIEW_CAPABILITY, FOO_DELETE_CAPABILITY, FOO_CREATE_CAPABILITY);
     var updatedCapabilitySet = capabilitySet(FOO_CREATE_CAPABILITY_SET, FOO_RESOURCE, CREATE, newCapabilities)
       .permission("foo.item.create")
       .applicationId(APPLICATION_ID_V2);

--- a/src/test/java/org/folio/roles/it/UserCapabilitySetUpdateIT.java
+++ b/src/test/java/org/folio/roles/it/UserCapabilitySetUpdateIT.java
@@ -12,6 +12,7 @@ import static org.folio.roles.support.CapabilitySetUtils.capabilitySets;
 import static org.folio.roles.support.CapabilityUtils.APPLICATION_ID_V2;
 import static org.folio.roles.support.CapabilityUtils.FOO_CREATE_CAPABILITY;
 import static org.folio.roles.support.CapabilityUtils.FOO_DELETE_CAPABILITY;
+import static org.folio.roles.support.CapabilityUtils.FOO_EDIT_CAPABILITY;
 import static org.folio.roles.support.CapabilityUtils.FOO_RESOURCE;
 import static org.folio.roles.support.CapabilityUtils.FOO_VIEW_CAPABILITY;
 import static org.folio.roles.support.EndpointUtils.fooItemDeleteEndpoint;
@@ -110,7 +111,7 @@ class UserCapabilitySetUpdateIT extends BaseIntegrationTest {
     awaitUntilAsserted(() -> doGet(request).andExpect(content().json(asJsonString(capabilitySets()))));
     awaitUntilAsserted(UserCapabilitySetUpdateIT::assertAssignedCapabilitySets);
     awaitUntilAsserted(() -> assertThat(kcTestClient.getPermissionNames()).isEmpty());
-    doGet("/capabilities").andExpect(jsonPath("$.totalRecords", is(9)));
+    doGet("/capabilities").andExpect(jsonPath("$.totalRecords", is(8)));
   }
 
   @Test
@@ -173,10 +174,11 @@ class UserCapabilitySetUpdateIT extends BaseIntegrationTest {
     var request = getFooCreateCapabilitySet();
     awaitUntilAsserted(() -> doGet(request).andExpect(content().json(asJsonString(capabilitySets()))));
 
-    var capabilitySet = capabilitySet(FOO_MANAGE_CAPABILITY_SET, FOO_RESOURCE, MANAGE, FOO_MANAGE_CAPABILITIES);
+    var capabilitySet = capabilitySet(FOO_MANAGE_CAPABILITY_SET, FOO_RESOURCE, MANAGE, List.of(
+      FOO_VIEW_CAPABILITY, FOO_EDIT_CAPABILITY, FOO_DELETE_CAPABILITY));
     awaitUntilAsserted(() -> assertAssignedCapabilitySets(capabilitySet));
     awaitUntilAsserted(() -> assertThat(kcTestClient.getPermissionNames()).containsExactlyInAnyOrder(
-      kcPermissionName(fooItemGetEndpoint()), kcPermissionName(fooItemPostEndpoint()),
+      kcPermissionName(fooItemGetEndpoint()),
       kcPermissionName(fooItemPutEndpoint()), kcPermissionName(fooItemDeleteEndpoint())));
   }
 
@@ -202,8 +204,7 @@ class UserCapabilitySetUpdateIT extends BaseIntegrationTest {
 
     assertAssignedCapabilitySets(updatedCapabilitySet);
     awaitUntilAsserted(() -> assertThat(kcTestClient.getPermissionNames()).containsExactlyInAnyOrder(
-      kcPermissionName(fooItemGetEndpoint()), kcPermissionName(fooItemDeleteEndpoint()),
-      kcPermissionName(fooItemPostEndpoint())));
+      kcPermissionName(fooItemGetEndpoint()), kcPermissionName(fooItemDeleteEndpoint())));
   }
 
   @Test
@@ -233,8 +234,7 @@ class UserCapabilitySetUpdateIT extends BaseIntegrationTest {
 
     assertAssignedCapabilitySets(updatedCapabilitySet);
     awaitUntilAsserted(TWO_SECONDS, () -> assertThat(kcTestClient.getPermissionNames()).containsExactlyInAnyOrder(
-      kcPermissionName(fooItemPostEndpoint()), kcPermissionName(fooItemGetEndpoint()),
-      kcPermissionName(fooItemDeleteEndpoint())));
+      kcPermissionName(fooItemGetEndpoint()), kcPermissionName(fooItemDeleteEndpoint())));
   }
 
   @Test
@@ -266,7 +266,7 @@ class UserCapabilitySetUpdateIT extends BaseIntegrationTest {
 
     assertAssignedCapabilitySets(updatedCapabilitySet, capabilitySet);
     awaitUntilAsserted(TWO_SECONDS, () -> assertThat(kcTestClient.getPermissionNames()).containsExactlyInAnyOrder(
-      kcPermissionName(fooItemGetEndpoint()), kcPermissionName(fooItemPostEndpoint()),
+      kcPermissionName(fooItemGetEndpoint()),
       kcPermissionName(fooItemDeleteEndpoint()), kcPermissionName(fooItemPutEndpoint())));
   }
 

--- a/src/test/resources/json/kafka-events/be-capability-event.json
+++ b/src/test/resources/json/kafka-events/be-capability-event.json
@@ -10,8 +10,8 @@
       {
         "permission": {
           "permissionName": "foo.item.get",
-          "displayName": "foo.item.get - display name",
-          "description": "foo.item.get - description"
+          "displayName": "foo_item.view - display name",
+          "description": "foo_item.view - description"
         },
         "endpoints": [
           {
@@ -23,8 +23,8 @@
       {
         "permission": {
           "permissionName": "foo.item.put",
-          "displayName": "foo.item.put - display name",
-          "description": "foo.item.put - description"
+          "displayName": "foo_item.edit - display name",
+          "description": "foo_item.edit - description"
         },
         "endpoints": [
           {
@@ -40,8 +40,8 @@
       {
         "permission": {
           "permissionName": "foo.item.post",
-          "displayName": "foo.item.post - display name",
-          "description": "foo.item.post - description"
+          "displayName": "foo_item.create - display name",
+          "description": "foo_item.create - description"
         },
         "endpoints": [
           {
@@ -53,8 +53,8 @@
       {
         "permission": {
           "permissionName": "foo.item.delete",
-          "displayName": "foo.item.delete - display name",
-          "description": "foo.item.delete - description"
+          "displayName": "foo_item.delete - display name",
+          "description": "foo_item.delete - description"
         },
         "endpoints": [
           {

--- a/src/test/resources/sql/kafka-message-listener-it/all-capabilities.sql
+++ b/src/test/resources/sql/kafka-message-listener-it/all-capabilities.sql
@@ -2,14 +2,16 @@ SET SEARCH_PATH = 'test_mod_roles_keycloak';
 
 INSERT INTO capability (id, name, description, resource, action, type, application_id,
                                                 folio_permission, module_id, created_by_user_id, created_date)
-VALUES ('366240cd-fb38-42c1-9e72-1694532ecf06', 'foo_item.view', 'foo.item.get - description', 'Foo Item',
+VALUES ('366240cd-fb38-42c1-9e72-1694532ecf06', 'foo_item.view', 'foo_item.view - description', 'Foo Item',
         'VIEW', 'DATA', 'test-application-0.0.1', 'foo.item.get', 'foo-module-1.0.0', NULL, '2023-10-24 13:39:50'),
-       ('dbc35c91-c086-43ec-8a42-1bf8779817fc', 'foo_item.edit', 'foo.item.put - description', 'Foo Item',
+       ('dbc35c91-c086-43ec-8a42-1bf8779817fc', 'foo_item.edit', 'foo_item.edit - description', 'Foo Item',
         'EDIT', 'DATA', 'test-application-0.0.1', 'foo.item.put', 'foo-module-1.0.0', NULL, '2023-10-24 13:39:51'),
-       ('35137e56-2689-4245-9588-ca2ef43d7aff', 'foo_item.create', 'foo.item.post - description', 'Foo Item',
+       ('35137e56-2689-4245-9588-ca2ef43d7aff', 'foo_item.create', 'foo_item.create - description', 'Foo Item',
         'CREATE', 'DATA', 'test-application-0.0.1', 'foo.item.post', 'foo-module-1.0.0', NULL, '2023-10-24 13:39:52'),
-       ('ebdef33e-2958-4401-bf20-2bf2d3f61bd2', 'foo_item.delete', 'foo.item.delete - description', 'Foo Item',
-        'DELETE', 'DATA', 'test-application-0.0.1', 'foo.item.delete', 'foo-module-1.0.0', NULL, '2023-10-24 13:39:53');
+       ('ebdef33e-2958-4401-bf20-2bf2d3f61bd2', 'foo_item.delete', 'foo_item.delete - description', 'Foo Item',
+        'DELETE', 'DATA', 'test-application-0.0.1', 'foo.item.delete', 'foo-module-1.0.0', NULL, '2023-10-24 13:39:53'),
+       ('8b117697-ecf3-47d8-84c9-d5d1734e0237', 'foo_item.manage', 'foo_item.manage - description', 'Foo Item',
+        'MANAGE', 'DATA', 'test-application-0.0.1', 'foo.item.all', 'foo-module-1.0.0', NULL, '2023-10-24 13:39:53');
 
 INSERT INTO capability_endpoint(capability_id, path, method)
 VALUES ('366240cd-fb38-42c1-9e72-1694532ecf06', '/foo/items/{id}', 'GET'),
@@ -39,4 +41,5 @@ VALUES ('60a691b2-d5ee-4845-84f7-b3f68ab6ec13', '366240cd-fb38-42c1-9e72-1694532
        ('8b117697-ecf3-47d8-84c9-d5d1734e0237', '366240cd-fb38-42c1-9e72-1694532ecf06'),
        ('8b117697-ecf3-47d8-84c9-d5d1734e0237', 'dbc35c91-c086-43ec-8a42-1bf8779817fc'),
        ('8b117697-ecf3-47d8-84c9-d5d1734e0237', '35137e56-2689-4245-9588-ca2ef43d7aff'),
-       ('8b117697-ecf3-47d8-84c9-d5d1734e0237', 'ebdef33e-2958-4401-bf20-2bf2d3f61bd2');
+       ('8b117697-ecf3-47d8-84c9-d5d1734e0237', 'ebdef33e-2958-4401-bf20-2bf2d3f61bd2'),
+       ('8b117697-ecf3-47d8-84c9-d5d1734e0237', '8b117697-ecf3-47d8-84c9-d5d1734e0237');


### PR DESCRIPTION
## Purpose
In order to support cases when PermissionSets defined in the back-end modules are used in the UI-modules, we need to changes the capability and capability set creation in mod-roles-keycloak

## Approach
modify CapabilitySetDescriptor creation in `CapabilityEventProcessor`

