### PR TITLE
MODROLESKC-234: Remove replaced capabilities and capability sets

### DIFF
--- a/src/main/java/org/folio/roles/service/capability/CapabilityReplacementsService.java
+++ b/src/main/java/org/folio/roles/service/capability/CapabilityReplacementsService.java
@@ -43,6 +43,7 @@ import org.folio.roles.utils.CapabilityUtils;
 import org.folio.spring.FolioExecutionContext;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -69,6 +70,7 @@ public class CapabilityReplacementsService {
    *
    * @param capabilityReplacements a map of old to new permissions, e.g. {"old" : ["new1", "new2"]}
    */
+  @Transactional
   public void processReplacements(CapabilityReplacements capabilityReplacements) {
     log.info("Processing assignments of replacement capabilities.");
     assignReplacementCapabilities(capabilityReplacements);

--- a/src/test/java/org/folio/roles/it/PermissionReplacementIT.java
+++ b/src/test/java/org/folio/roles/it/PermissionReplacementIT.java
@@ -11,7 +11,9 @@ import static org.folio.spring.integration.XOkapiHeaders.TENANT;
 import static org.folio.spring.integration.XOkapiHeaders.USER_ID;
 import static org.folio.test.TestUtils.asJsonString;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
 import static org.springframework.test.context.jdbc.SqlMergeMode.MergeMode.MERGE;
@@ -128,9 +130,9 @@ public class PermissionReplacementIT extends BaseIntegrationTest {
       .andExpect(content().contentType(APPLICATION_JSON)).andExpect(status().isCreated());
 
     // Verify that role got the capability assigned to it
-    doGet(get("/roles/capabilities").param("offset", "0").param("limit", "1").header(TENANT, TENANT_ID)
+    doGet(get("/roles/" + role.getId() + "/capabilities").header(TENANT, TENANT_ID)
       .header(XOkapiHeaders.USER_ID, USER_ID_HEADER)).andExpect(
-      jsonPath("$.roleCapabilities[0].capabilityId", is(capability.getId().toString())));
+      jsonPath("$.capabilities[0].id", is(capability.getId().toString())));
 
     // Find out Keycloak test-user's FOLIO ID
     var userId = UUID.fromString(
@@ -144,10 +146,9 @@ public class PermissionReplacementIT extends BaseIntegrationTest {
       .andExpect(content().contentType(APPLICATION_JSON)).andExpect(status().isCreated());
 
     // Verify that user got the capabilityset assigned to it
-    doGet(
-      get("/users/capability-sets").param("offset", "0").param("limit", "1")
-        .header(TENANT, TENANT_ID).header(XOkapiHeaders.USER_ID, USER_ID_HEADER)).andExpect(
-      jsonPath("$.userCapabilitySets[0].capabilitySetId", is(capabilitySet.getId().toString())));
+    doGet(get("/users/" + userId + "/capability-sets").header(TENANT, TENANT_ID)
+      .header(XOkapiHeaders.USER_ID, USER_ID_HEADER)).andExpect(
+      jsonPath("$.capabilitySets[0].id", is(capabilitySet.getId().toString())));
 
     // Trigger replacement of capabilities/capabilitysets
     var capabilitiesReplacementEvent =
@@ -169,16 +170,21 @@ public class PermissionReplacementIT extends BaseIntegrationTest {
           CapabilitySets.class).getCapabilitySets().stream().filter(cap -> cap.getName().equals("newfoo_item.manage"))
         .findAny().get();
 
-    // Verify that user and role have their new capabilities/capabilitysets assigned
+    // Verify that user and role have their new capabilities/capabilitysets assigned - and
+    // old capabilities/capabilitysets were removed
     await().atMost(ONE_MINUTE).pollInterval(ONE_HUNDRED_MILLISECONDS).untilAsserted(() -> doGet(
-      get("/roles/capabilities").param("offset", "0").param("limit", "10")
-        .header(TENANT, TENANT_ID).header(XOkapiHeaders.USER_ID, USER_ID_HEADER)).andExpect(
-        jsonPath("$.roleCapabilities[*].capabilityId", hasItem(newCapability.getId().toString()))).andReturn()
-      .getResponse().getContentAsString());
+      get("/roles/" + role.getId() + "/capabilities").header(TENANT, TENANT_ID)
+        .header(XOkapiHeaders.USER_ID, USER_ID_HEADER)).andExpect(jsonPath("$.capabilities", hasSize(1)))
+      .andExpect(jsonPath("$.capabilities[0].id", is(newCapability.getId().toString()))).andReturn().getResponse()
+      .getContentAsString());
     await().atMost(ONE_MINUTE).pollInterval(ONE_HUNDRED_MILLISECONDS).untilAsserted(() -> doGet(
-      get("/users/capability-sets").param("offset", "0").param("limit", "10")
-        .header(TENANT, TENANT_ID).header(XOkapiHeaders.USER_ID, USER_ID_HEADER)).andExpect(
-      jsonPath("$.userCapabilitySets[*].capabilitySetId", hasItem(newCapabilitySet.getId().toString()))));
+      get("/users/" + userId + "/capability-sets").header(TENANT, TENANT_ID)
+        .header(XOkapiHeaders.USER_ID, USER_ID_HEADER)).andExpect(jsonPath("$.capabilitySets", hasSize(1)))
+      .andExpect(jsonPath("$.capabilitySets[0].id", is(newCapabilitySet.getId().toString()))));
+
+    // Verify that replaced capability and capability set were removed and are no longer present
+    doGet("/capabilities").andExpect(jsonPath("$.capabilities[*].name", not(hasItem("foo_item.view"))));
+    doGet("/capability-sets").andExpect(jsonPath("$.capabilitySets[*].name", not(hasItem("foo_item.manage"))));
   }
 
   protected void createResource(String resourceName, String... scopeNames) {

--- a/src/test/java/org/folio/roles/service/capability/CapabilityReplacementsServiceTest.java
+++ b/src/test/java/org/folio/roles/service/capability/CapabilityReplacementsServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.common.utils.permission.model.PermissionAction.VIEW;
 import static org.folio.common.utils.permission.model.PermissionType.DATA;
 import static org.folio.roles.domain.dto.HttpMethod.GET;
+import static org.folio.roles.domain.model.event.DomainEventType.DELETE;
 import static org.folio.roles.integration.kafka.model.ModuleType.MODULE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -204,8 +205,10 @@ class CapabilityReplacementsServiceTest {
       (CapabilitySetEvent) publishedEvents.stream().filter(e -> e instanceof CapabilitySetEvent).findAny().get();
     assertThat(capEvent.getOldObject().getName()).isEqualTo("oldcap1.view");
     assertThat(capEvent.getOldObject().getId()).isEqualTo(cap1Id);
+    assertThat(capEvent.getType()).isEqualTo(DELETE);
     assertThat(capSetEvent.getOldObject().getName()).isEqualTo("capset1.view");
     assertThat(capSetEvent.getOldObject().getId()).isEqualTo(capSet1Id);
+    assertThat(capSetEvent.getType()).isEqualTo(DELETE);
   }
 
   private Capability createCapability(UUID id, String name) {


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/MODROLESKC-234

Ensure replaced capabilities/capability-sets get removed from the system - both user/role assignments are removed, and capabilities/capability-sets themselves are deleted.

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
