### PR TITLE
MODROLESKC-248: spring-kafka 3.3.0, folio-spring-support 8.2.2 fix vulns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,12 @@
   </licenses>
 
   <properties>
+    <!-- remove spring-kafka property after upgrading to Spring Boot 3.4.x;
+         this bumps spring-kafka from 3.2.4 to 3.3.0 to fix security vulnerability in kafka-clients:
+         https://www.cve.org/CVERecord?id=CVE-2024-31141
+    -->
+    <spring-kafka.version>3.3.0</spring-kafka.version>
+
     <java.version>17</java.version>
     <lombok.version>1.18.36</lombok.version>
     <swagger-annotations.version>2.2.26</swagger-annotations.version>
@@ -34,7 +40,7 @@
     <openapi-tools.jackson-databind-nullable.version>0.2.6</openapi-tools.jackson-databind-nullable.version>
     <mapstruct.version>1.6.3</mapstruct.version>
     <hypersistence-utils-hibernate-63.version>3.9.0</hypersistence-utils-hibernate-63.version>
-    <folio-spring-support.version>8.2.1</folio-spring-support.version>
+    <folio-spring-support.version>8.2.2</folio-spring-support.version>
     <coffee-boots.version>4.0.0</coffee-boots.version>
     <folio-java-checkstyle.version>1.0.1</folio-java-checkstyle.version>
     <applications-poc-tools.version>2.1.0-SNAPSHOT</applications-poc-tools.version>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODROLESKC-248

Upgrade spring-kafka from 3.2.4 to 3.3.0 to fix security vulnerability in kafka-clients:

* https://www.cve.org/CVERecord?id=CVE-2024-31141 Files or Directories Accessible to External Parties

Upgrade folio-spring-support from 8.2.1 to 8.2.2 fixing security vulnerability in spring-security-crypto:

* https://www.cve.org/CVERecord?id=CVE-2024-38827 Authorization Bypass

## Purpose
Fix security vulnerabilities.

## Approach
Bump the version of dependencies to a fixed version.

## TODOS and Open Questions
- [x] Check logging

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.