### PR TITLE
MODROLESKC-257

### DIFF
--- a/src/main/java/org/folio/roles/service/capability/CapabilityEventHandler.java
+++ b/src/main/java/org/folio/roles/service/capability/CapabilityEventHandler.java
@@ -88,6 +88,8 @@ public class CapabilityEventHandler extends AbstractCapabilityEventHandler {
     var capabilityId = deprecatedCapability.getId();
     var deprecatedEndpoints = getCapabilityEndpoints(deprecatedCapability);
 
+    log.info("Deleting capability {} ", deprecatedCapability.getName());
+
     try (var ignored = new FolioExecutionContextSetter(event.getContext())) {
       performActionForPolicies(
         policyService.findRolePoliciesByCapabilityId(capabilityId),

--- a/src/main/java/org/folio/roles/service/capability/CapabilityReplacementsService.java
+++ b/src/main/java/org/folio/roles/service/capability/CapabilityReplacementsService.java
@@ -215,6 +215,7 @@ public class CapabilityReplacementsService {
   protected void unassignReplacedCapabilities(CapabilityReplacements capabilityReplacements) {
     var oldCapabilitiesAndSetsToRemove = capabilityReplacements.oldCapabilitiesToNewCapabilities().keySet();
 
+    log.info("Removing old capabilities and capability sets: {}", String.join(", ", oldCapabilitiesAndSetsToRemove));
     var oldCapabilitiesToRemove = capabilityService.findByNames(oldCapabilitiesAndSetsToRemove);
     oldCapabilitiesToRemove.stream().map(
       deprecatedCapability -> org.folio.roles.domain.model.event.CapabilityEvent.deleted(deprecatedCapability)

--- a/src/main/java/org/folio/roles/service/capability/CapabilitySetEventHandler.java
+++ b/src/main/java/org/folio/roles/service/capability/CapabilitySetEventHandler.java
@@ -91,6 +91,8 @@ public class CapabilitySetEventHandler extends AbstractCapabilityEventHandler {
     var deprecatedCapabilitySet = event.getOldObject();
     var capabilitySetId = deprecatedCapabilitySet.getId();
 
+    log.info("Deleting capability set {} ", deprecatedCapabilitySet.getName());
+
     try (var ignored = new FolioExecutionContextSetter(event.getContext())) {
       performActionForPolicies(
         policyService.findRolePoliciesByCapabilitySetId(capabilitySetId),


### PR DESCRIPTION
## Purpose

https://folio-org.atlassian.net/browse/MODROLESKC-257

Fix duplicate key error on updating permissions which prevents the service from properly handling permission update Kafka event.

Also added extra logging to deletion of deprecated capabilities and capability-sets.

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
