### PR TITLE
MODROLESKC-233: Update User Capability logic to update permission for user in the Keycloak for existing capabilities

### DIFF
--- a/src/main/java/org/folio/roles/service/capability/UserCapabilityService.java
+++ b/src/main/java/org/folio/roles/service/capability/UserCapabilityService.java
@@ -92,10 +92,9 @@ public class UserCapabilityService {
   @Transactional
   public void update(UUID userId, List<UUID> capabilityIds) {
     keycloakUserService.getKeycloakUserByUserId(userId);
-    var assignedUserCapabilityEntities = userCapabilityRepository.findAllByUserId(userId);
-    var assignedCapabilityIds = getCapabilityIds(assignedUserCapabilityEntities);
-    UpdateOperationHelper.create(assignedCapabilityIds, capabilityIds, "user-capability")
-      .consumeAndCacheNewEntities(newIds -> getCapabilityIds(assignCapabilities(userId, newIds, assignedCapabilityIds)))
+
+    UpdateOperationHelper.create(List.of(), capabilityIds, "user-capability")
+      .consumeAndCacheNewEntities(newIds -> getCapabilityIds(assignCapabilities(userId, newIds, List.of())))
       .consumeDeprecatedEntities((deprecatedIds, createdIds) -> removeCapabilities(userId, deprecatedIds, createdIds));
   }
 

--- a/src/main/java/org/folio/roles/service/capability/UserCapabilityService.java
+++ b/src/main/java/org/folio/roles/service/capability/UserCapabilityService.java
@@ -92,9 +92,11 @@ public class UserCapabilityService {
   @Transactional
   public void update(UUID userId, List<UUID> capabilityIds) {
     keycloakUserService.getKeycloakUserByUserId(userId);
-
-    UpdateOperationHelper.create(List.of(), capabilityIds, "user-capability")
-      .consumeAndCacheNewEntities(newIds -> getCapabilityIds(assignCapabilities(userId, newIds, List.of())))
+    var assignedUserCapabilityEntities = userCapabilityRepository.findAllByUserId(userId);
+    var assignedCapabilityIds = getCapabilityIds(assignedUserCapabilityEntities);
+    assignedCapabilityIds.removeAll(capabilityIds);
+    UpdateOperationHelper.create(assignedCapabilityIds, capabilityIds, "user-capability")
+      .consumeAndCacheNewEntities(newIds -> getCapabilityIds(assignCapabilities(userId, newIds, assignedCapabilityIds)))
       .consumeDeprecatedEntities((deprecatedIds, createdIds) -> removeCapabilities(userId, deprecatedIds, createdIds));
   }
 

--- a/src/test/java/org/folio/roles/service/capability/UserCapabilityServiceTest.java
+++ b/src/test/java/org/folio/roles/service/capability/UserCapabilityServiceTest.java
@@ -323,9 +323,10 @@ class UserCapabilityServiceTest {
       when(capabilitySetService.findByUserId(USER_ID, MAX_VALUE, 0)).thenReturn(PageResult.empty());
       when(userCapabilityRepository.findAllByUserId(USER_ID)).thenReturn(existingEntities);
       when(userCapabilityEntityMapper.convert(uce2)).thenReturn(userCapability(USER_ID, capabilityId2));
-      when(userCapabilityRepository.saveAll(List.of(uce2))).thenReturn(List.of(uce2));
+      when(userCapabilityEntityMapper.convert(uce3)).thenReturn(userCapability(USER_ID, capabilityId3));
+      when(userCapabilityRepository.saveAll(List.of(uce2, uce3))).thenReturn(List.of(uce2, uce3));
 
-      var newIds = List.of(capabilityId2);
+      var newIds = List.of(capabilityId2, capabilityId3);
       var deprecatedIds = List.of(capabilityId1);
       var endpointsToAssign = List.of(endpoint("/c2", GET));
       var endpointsToDelete = List.of(endpoint("/c1", GET));
@@ -339,20 +340,8 @@ class UserCapabilityServiceTest {
       verify(userPermissionService).createPermissions(USER_ID, endpointsToAssign);
       verify(userPermissionService).deletePermissions(USER_ID, endpointsToDelete);
       verify(userCapabilityRepository).deleteUserCapabilities(USER_ID, deprecatedIds);
-      verify(capabilityEndpointService).getByCapabilityIds(newIds, List.of(capabilityId1, capabilityId3));
-      verify(capabilityEndpointService).getByCapabilityIds(deprecatedIds, List.of(capabilityId3, capabilityId2));
-    }
-
-    @Test
-    void negative_notingToUpdate() {
-      var userCapabilityEntity = userCapabilityEntity(USER_ID, capabilityId1);
-      when(keycloakUserService.getKeycloakUserByUserId(USER_ID)).thenReturn(keycloakUser());
-      when(userCapabilityRepository.findAllByUserId(USER_ID)).thenReturn(List.of(userCapabilityEntity));
-
-      var capabilityIds = List.of(capabilityId1);
-      userCapabilityService.update(USER_ID, capabilityIds);
-
-      verifyNoInteractions(userPermissionService);
+      verify(capabilityEndpointService).getByCapabilityIds(newIds, List.of(capabilityId1));
+      verify(capabilityEndpointService).getByCapabilityIds(deprecatedIds, List.of(capabilityId2, capabilityId3));
     }
 
     @Test


### PR DESCRIPTION
 Previously, permissions in Keycloak for an existing capability were not updated, even though the capability was being updated in the FOLIO system. With this update, the system will now attempt to create the permission, and if it already exists, we will get the warning  "Permission for the user already exists." but if not it would be create it 

## Purpose

<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant Rally issue, add a link directly to the issue URL here.
 -->

## Approach
Remove the logic that skips permission creation for existing endpoints based on capabilities. Instead, the system will attempt to create permissions for existing capabilities if an update is required.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## TODOS and Open Questions

<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

- [ ] Check logging

## Learning

<!-- OPTIONAL
  Help out not only your reviewer but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries, or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
