### PR TITLE
MODROLESKC-254: fix replacement of loadable permissions

### DIFF
--- a/src/main/java/org/folio/roles/repository/CapabilityRepository.java
+++ b/src/main/java/org/folio/roles/repository/CapabilityRepository.java
@@ -2,6 +2,7 @@ package org.folio.roles.repository;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import org.folio.roles.domain.entity.CapabilityEntity;
@@ -100,6 +101,9 @@ public interface CapabilityRepository extends BaseCqlJpaRepository<CapabilityEnt
 
   @Query("select entity from CapabilityEntity entity where entity.name in :names order by entity.name")
   List<CapabilityEntity> findAllByNames(@Param("names") Collection<String> names);
+
+  @Query("select entity from CapabilityEntity entity where entity.name = :name")
+  Optional<CapabilityEntity> findByName(@Param("name") String name);
 
   @Query("select distinct entity.id from CapabilityEntity entity where entity.id in :ids order by entity.id")
   Set<UUID> findCapabilityIdsByIdIn(@Param("ids") Collection<UUID> capabilityIds);

--- a/src/main/java/org/folio/roles/repository/LoadablePermissionRepository.java
+++ b/src/main/java/org/folio/roles/repository/LoadablePermissionRepository.java
@@ -3,6 +3,7 @@ package org.folio.roles.repository;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.folio.roles.domain.entity.LoadablePermissionEntity;
 import org.springframework.stereotype.Repository;
 
@@ -10,4 +11,8 @@ import org.springframework.stereotype.Repository;
 public interface LoadablePermissionRepository extends BaseCqlJpaRepository<LoadablePermissionEntity, UUID> {
 
   List<LoadablePermissionEntity> findAllByPermissionNameIn(Collection<String> permissionNames);
+
+  Stream<LoadablePermissionEntity> findAllByCapabilityId(UUID capabilityId);
+
+  Stream<LoadablePermissionEntity> findAllByCapabilitySetId(UUID capabilitySetId);
 }

--- a/src/main/java/org/folio/roles/repository/LoadablePermissionRepository.java
+++ b/src/main/java/org/folio/roles/repository/LoadablePermissionRepository.java
@@ -5,10 +5,12 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.folio.roles.domain.entity.LoadablePermissionEntity;
+import org.folio.roles.domain.entity.key.LoadablePermissionKey;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface LoadablePermissionRepository extends BaseCqlJpaRepository<LoadablePermissionEntity, UUID> {
+public interface LoadablePermissionRepository
+  extends BaseCqlJpaRepository<LoadablePermissionEntity, LoadablePermissionKey> {
 
   List<LoadablePermissionEntity> findAllByPermissionNameIn(Collection<String> permissionNames);
 

--- a/src/main/java/org/folio/roles/service/capability/CapabilityService.java
+++ b/src/main/java/org/folio/roles/service/capability/CapabilityService.java
@@ -19,6 +19,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -153,6 +154,18 @@ public class CapabilityService {
   public List<Capability> findByNames(Collection<String> capabilityNames) {
     var capabilityEntities = capabilityRepository.findAllByNames(capabilityNames);
     return capabilityEntityMapper.convert(capabilityEntities);
+  }
+
+  /**
+   * Retrieves capability by capability name.
+   *
+   * @param capabilityName - capability name
+   * @return found {@link Capability} object
+   */
+  @Transactional(readOnly = true)
+  public Optional<Capability> findByName(String capabilityName) {
+    var capabilityEntity = capabilityRepository.findByName(capabilityName);
+    return capabilityEntity.map(capabilityEntityMapper::convert);
   }
 
   /**

--- a/src/test/java/org/folio/roles/service/capability/CapabilityReplacementsServiceTest.java
+++ b/src/test/java/org/folio/roles/service/capability/CapabilityReplacementsServiceTest.java
@@ -33,6 +33,7 @@ import org.folio.roles.integration.kafka.mapper.CapabilitySetMapper;
 import org.folio.roles.integration.kafka.model.CapabilityEvent;
 import org.folio.roles.integration.kafka.model.FolioResource;
 import org.folio.roles.integration.kafka.model.Permission;
+import org.folio.roles.repository.LoadablePermissionRepository;
 import org.folio.roles.repository.RoleCapabilityRepository;
 import org.folio.roles.repository.RoleCapabilitySetRepository;
 import org.folio.roles.repository.UserCapabilityRepository;
@@ -66,6 +67,7 @@ class CapabilityReplacementsServiceTest {
   @Mock private CapabilityService capabilityService;
   @Mock private CapabilitySetService capabilitySetService;
   @Mock private CapabilitySetMapper capabilitySetMapper;
+  @Mock private LoadablePermissionRepository loadablePermissionRepository;
 
   @Test
   void testDeduceReplacementsPositive() {

--- a/src/test/java/org/folio/roles/service/capability/CapabilityReplacementsServiceTest.java
+++ b/src/test/java/org/folio/roles/service/capability/CapabilityReplacementsServiceTest.java
@@ -15,16 +15,20 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.folio.common.utils.permission.model.PermissionData;
 import org.folio.roles.domain.dto.Capability;
 import org.folio.roles.domain.dto.CapabilitySet;
 import org.folio.roles.domain.dto.Endpoint;
+import org.folio.roles.domain.entity.LoadablePermissionEntity;
 import org.folio.roles.domain.entity.RoleCapabilityEntity;
 import org.folio.roles.domain.entity.RoleCapabilitySetEntity;
 import org.folio.roles.domain.entity.UserCapabilityEntity;
 import org.folio.roles.domain.entity.UserCapabilitySetEntity;
+import org.folio.roles.domain.entity.key.LoadablePermissionKey;
 import org.folio.roles.domain.model.CapabilityReplacements;
 import org.folio.roles.domain.model.ExtendedCapabilitySet;
 import org.folio.roles.domain.model.event.CapabilitySetEvent;
@@ -39,6 +43,7 @@ import org.folio.roles.repository.RoleCapabilitySetRepository;
 import org.folio.roles.repository.UserCapabilityRepository;
 import org.folio.roles.repository.UserCapabilitySetRepository;
 import org.folio.roles.service.permission.PermissionOverrider;
+import org.folio.roles.support.LoadablePermissionUtils;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.test.types.UnitTest;
 import org.junit.jupiter.api.Test;
@@ -149,6 +154,7 @@ class CapabilityReplacementsServiceTest {
     var cap2Id = randomUUID();
     var capSet1Id = randomUUID();
     var capSet2Id = randomUUID();
+    var roleId = randomUUID();
 
     when(capabilityService.findByNames(Set.of("newcap1.view", "newcapset2.view"))).thenReturn(
       List.of(createCapability(cap1Id, "newcap1.view")));
@@ -162,6 +168,20 @@ class CapabilityReplacementsServiceTest {
       List.of(createCapability(cap1Id, "oldcap1.view")));
     when(capabilitySetService.findByNames(Set.of("oldcap1.view", "oldcapset2.view"))).thenReturn(
       List.of(createCapabilitySet(capSet1Id, "oldcapset2.view")));
+
+    when(loadablePermissionRepository.findAllByCapabilityId(cap1Id)).thenReturn(Stream.of(
+      LoadablePermissionUtils.loadablePermissionEntity(roleId,
+        LoadablePermissionUtils.loadablePermission(roleId, "oldperm1"))));
+    when(capabilityService.findByName("newcap1.view")).thenReturn(
+      Optional.of(createCapability(cap1Id, "newcap1.view")));
+    when(capabilityService.findByName("newcapset2.view")).thenReturn(Optional.empty());
+
+    when(loadablePermissionRepository.findAllByCapabilitySetId(capSet1Id)).thenReturn(Stream.of(
+      LoadablePermissionUtils.loadablePermissionEntity(roleId,
+        LoadablePermissionUtils.loadablePermission(roleId, "oldset1"))));
+    when(capabilitySetService.findByName("newcapset1.view")).thenReturn(
+      Optional.of(createCapabilitySet(capSet1Id, "newcapset1.view")));
+    when(capabilitySetService.findByName("newcap2.view")).thenReturn(Optional.empty());
 
     var publishedEvents = new ArrayList<>();
     doAnswer(inv -> publishedEvents.add(inv.getArgument(0))).when(applicationEventPublisher)
@@ -188,6 +208,19 @@ class CapabilityReplacementsServiceTest {
     var capabilityReplacements =
       new CapabilityReplacements(oldCapabilitiesToNewCapabilities, oldCapabilityRoleAssignments,
         oldCapabilityUserAssignments, oldCapabilitySetRoleAssignments, oldCapabilitySetUserAssignments);
+
+    var newLoadablePermissions = new ArrayList<LoadablePermissionEntity>();
+    when(loadablePermissionRepository.save(any())).then(inv -> {
+      var loadablePermissionEntity = inv.getArgument(0, LoadablePermissionEntity.class);
+      newLoadablePermissions.add(loadablePermissionEntity);
+      return loadablePermissionEntity;
+    });
+    var deletedIds = new ArrayList<LoadablePermissionKey>();
+    doAnswer(inv -> {
+      deletedIds.addAll(inv.getArgument(0));
+      return null;
+    }).when(loadablePermissionRepository).deleteAllById(any());
+
     unit.processReplacements(capabilityReplacements);
 
     verify(roleCapabilityService).create(role1Id, List.of(cap1Id), true);
@@ -211,12 +244,27 @@ class CapabilityReplacementsServiceTest {
     assertThat(capSetEvent.getOldObject().getName()).isEqualTo("capset1.view");
     assertThat(capSetEvent.getOldObject().getId()).isEqualTo(capSet1Id);
     assertThat(capSetEvent.getType()).isEqualTo(DELETE);
+
+    assertThat(newLoadablePermissions).hasSize(2);
+    newLoadablePermissions.forEach(
+      loadablePermissionEntity -> assertThat(loadablePermissionEntity.getRoleId()).isEqualTo(roleId));
+    assertThat(newLoadablePermissions.stream()
+      .filter(lp -> cap1Id.equals(lp.getCapabilityId()) && lp.getPermissionName().equals("newcap1.view"))).hasSize(1);
+    assertThat(newLoadablePermissions.stream().filter(
+      lp -> capSet1Id.equals(lp.getCapabilitySetId()) && lp.getPermissionName().equals("newcapset1.view"))).hasSize(1);
+
+    assertThat(deletedIds).hasSize(2);
+    assertThat(deletedIds.stream()
+      .filter(id -> roleId.equals(id.getRoleId()) && id.getPermissionName().equals("oldperm1"))).hasSize(1);
+    assertThat(deletedIds.stream().filter(
+      id -> roleId.equals(id.getRoleId()) && id.getPermissionName().equals("oldset1"))).hasSize(1);
   }
 
   private Capability createCapability(UUID id, String name) {
     var result = new Capability();
     result.setId(id);
     result.setName(name);
+    result.setPermission(name);
     return result;
   }
 
@@ -224,6 +272,7 @@ class CapabilityReplacementsServiceTest {
     var result = new CapabilitySet();
     result.setId(id);
     result.setName(name);
+    result.setPermission(name);
     return result;
   }
 }

--- a/src/test/java/org/folio/roles/support/LoadablePermissionUtils.java
+++ b/src/test/java/org/folio/roles/support/LoadablePermissionUtils.java
@@ -32,6 +32,13 @@ public class LoadablePermissionUtils {
       .create();
   }
 
+  public static LoadablePermission loadablePermission(UUID roleId, String permissionName) {
+    return Instancio.of(LOADABLE_PERMISSION_MODEL)
+      .set(field(LoadablePermission::getRoleId), roleId)
+      .set(field(LoadablePermission::getPermissionName), permissionName)
+      .create();
+  }
+
   public static List<LoadablePermission> loadablePermissions(int maxSize) {
     return loadablePermissions(1, maxSize);
   }


### PR DESCRIPTION
## Purpose

https://folio-org.atlassian.net/browse/MODROLESKC-254

Fix issue where loadable role permissions in DB prevent capability replacement logic from deleting old replaced capabilities or capability sets.

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
