### PR TITLE
MODROLESKC-268: Fix module descriptor, remove unnecessary endpoints

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -171,17 +171,12 @@
     },
     {
       "id": "role-capabilities",
-      "version": "1.0",
+      "version": "1.1",
       "handlers": [
         {
           "methods": [ "POST" ],
           "pathPattern": "/roles/capabilities",
           "permissionsRequired": [ "role-capabilities.collection.post" ]
-        },
-        {
-          "methods": [ "GET" ],
-          "pathPattern": "/roles/capabilities",
-          "permissionsRequired": [ "role-capabilities.collection.get" ]
         },
         {
           "methods": [ "GET" ],
@@ -202,17 +197,12 @@
     },
     {
       "id": "role-capability-sets",
-      "version": "1.1",
+      "version": "1.2",
       "handlers": [
         {
           "methods": [ "POST" ],
           "pathPattern": "/roles/capability-sets",
           "permissionsRequired": [ "role-capability-sets.collection.post" ]
-        },
-        {
-          "methods": [ "GET" ],
-          "pathPattern": "/roles/capability-sets",
-          "permissionsRequired": [ "role-capability-sets.collection.get" ]
         },
         {
           "methods": [ "GET" ],
@@ -233,17 +223,12 @@
     },
     {
       "id": "user-capabilities",
-      "version": "1.0",
+      "version": "1.1",
       "handlers": [
         {
           "methods": [ "POST" ],
           "pathPattern": "/users/capabilities",
           "permissionsRequired": [ "user-capabilities.collection.post" ]
-        },
-        {
-          "methods": [ "GET" ],
-          "pathPattern": "/users/capabilities",
-          "permissionsRequired": [ "user-capabilities.collection.get" ]
         },
         {
           "methods": [ "GET" ],
@@ -264,17 +249,12 @@
     },
     {
       "id": "user-capability-sets",
-      "version": "1.0",
+      "version": "1.1",
       "handlers": [
         {
           "methods": [ "POST" ],
           "pathPattern": "/users/capability-sets",
           "permissionsRequired": [ "user-capability-sets.collection.post" ]
-        },
-        {
-          "methods": [ "GET" ],
-          "pathPattern": "/users/capability-sets",
-          "permissionsRequired": [ "user-capability-sets.collection.get" ]
         },
         {
           "methods": [ "GET" ],

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -217,7 +217,7 @@
         {
           "methods": [ "GET" ],
           "pathPattern": "/roles/{id}/capability-sets",
-          "permissionsRequired": [ "role.capability-sets.collection.get" ]
+          "permissionsRequired": [ "role-capability-sets.collection.get" ]
         },
         {
           "methods": [ "PUT" ],
@@ -248,7 +248,7 @@
         {
           "methods": [ "GET" ],
           "pathPattern": "/users/{id}/capabilities",
-          "permissionsRequired": [ "user.capabilities.collection.get" ]
+          "permissionsRequired": [ "user-capabilities.collection.get" ]
         },
         {
           "methods": [ "PUT" ],
@@ -279,7 +279,7 @@
         {
           "methods": [ "GET" ],
           "pathPattern": "/users/{id}/capability-sets",
-          "permissionsRequired": [ "user.capability-sets.collection.get" ]
+          "permissionsRequired": [ "user-capability-sets.collection.get" ]
         },
         {
           "methods": [ "PUT" ],
@@ -536,7 +536,8 @@
       "description": "Delete all assigned capabilities for role"
     },
     {
-      "permissionName": "role.capabilities.collection.get",
+      "permissionName": "role-capabilities.collection.get",
+	  "replaces": ["role.capabilities.collection.get"],
       "displayName": "Role-Capabilities - Find records by the query",
       "description": "Retrieve role-capability items by CQL query"
     },
@@ -573,7 +574,8 @@
       "description": "Delete all assigned capability-sets for role"
     },
     {
-      "permissionName": "role.capability-sets.collection.get",
+      "permissionName": "role-capability-sets.item.get",
+	  "replaces": ["role.capability-sets.collection.get"],
       "displayName": "Role-Capability-Sets - Get capability-sets assigned to role",
       "description": "Retrieve capability-sets assigned to role"
     },
@@ -610,7 +612,8 @@
       "description": "Delete all assigned capabilities for user"
     },
     {
-      "permissionName": "user.capabilities.collection.get",
+      "permissionName": "user-capabilities.collection.get",
+	  "replaces": ["user.capabilities.collection.get"],
       "displayName": "User-Capabilities - Find records by query",
       "description": "Retrieve user-capability items by CQL query"
     },
@@ -647,7 +650,8 @@
       "description": "Delete all assigned capability-sets for user"
     },
     {
-      "permissionName": "user.capability-sets.collection.get",
+      "permissionName": "user-capability-sets.collection.get",
+	  "replaces": ["user.capability-sets.collection.get"],
       "displayName": "User-Capability-Sets - Get capability-sets assigned to user",
       "description": "Retrieve capability-sets assigned to user"
     },

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -574,7 +574,7 @@
       "description": "Delete all assigned capability-sets for role"
     },
     {
-      "permissionName": "role-capability-sets.item.get",
+      "permissionName": "role-capability-sets.collection.get",
 	  "replaces": ["role.capability-sets.collection.get"],
       "displayName": "Role-Capability-Sets - Get capability-sets assigned to role",
       "description": "Retrieve capability-sets assigned to role"

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -207,7 +207,7 @@
         {
           "methods": [ "GET" ],
           "pathPattern": "/roles/{id}/capability-sets",
-          "permissionsRequired": [ "role-capability-sets.collection.get" ]
+          "permissionsRequired": [ "role.capability-sets.collection.get" ]
         },
         {
           "methods": [ "PUT" ],
@@ -233,7 +233,7 @@
         {
           "methods": [ "GET" ],
           "pathPattern": "/users/{id}/capabilities",
-          "permissionsRequired": [ "user-capabilities.collection.get" ]
+          "permissionsRequired": [ "user.capabilities.collection.get" ]
         },
         {
           "methods": [ "PUT" ],
@@ -259,7 +259,7 @@
         {
           "methods": [ "GET" ],
           "pathPattern": "/users/{id}/capability-sets",
-          "permissionsRequired": [ "user-capability-sets.collection.get" ]
+          "permissionsRequired": [ "user.capability-sets.collection.get" ]
         },
         {
           "methods": [ "PUT" ],
@@ -516,12 +516,6 @@
       "description": "Delete all assigned capabilities for role"
     },
     {
-      "permissionName": "role-capabilities.collection.get",
-	  "replaces": ["role.capabilities.collection.get"],
-      "displayName": "Role-Capabilities - Find records by the query",
-      "description": "Retrieve role-capability items by CQL query"
-    },
-    {
       "permissionName": "role-capabilities.all",
       "displayName": "Role-Capabilities - all permissions",
       "description": "All permissions for role-capability management",
@@ -539,11 +533,6 @@
       "description": "Create a record associating one or more capabilities with role"
     },
     {
-      "permissionName": "role-capability-sets.collection.get",
-      "displayName": "Role-Capability-Sets - Find records by the query",
-      "description": "Retrieve role-capability items by CQL query"
-    },
-    {
       "permissionName": "role-capability-sets.collection.put",
       "displayName": "Role-Capability-Sets - Update a set of records for role",
       "description": "Update assigned capability-sets for role"
@@ -554,8 +543,7 @@
       "description": "Delete all assigned capability-sets for role"
     },
     {
-      "permissionName": "role-capability-sets.collection.get",
-	  "replaces": ["role.capability-sets.collection.get"],
+      "permissionName": "role.capability-sets.collection.get",
       "displayName": "Role-Capability-Sets - Get capability-sets assigned to role",
       "description": "Retrieve capability-sets assigned to role"
     },
@@ -565,7 +553,6 @@
       "description": "All permissions for role-capability set management",
       "subPermissions": [
         "role-capability-sets.collection.put",
-        "role-capability-sets.collection.get",
         "role-capability-sets.collection.post",
         "role-capability-sets.collection.delete",
         "role.capability-sets.collection.get"
@@ -577,7 +564,7 @@
       "description": "Create a record associating one or more capabilities with user"
     },
     {
-      "permissionName": "user-capabilities.collection.get",
+      "permissionName": "user.capabilities.collection.get",
       "displayName": "Role-Capabilities - Get capabilities assigned to user",
       "description": "Retrieve capabilities assigned to user"
     },
@@ -592,12 +579,6 @@
       "description": "Delete all assigned capabilities for user"
     },
     {
-      "permissionName": "user-capabilities.collection.get",
-	  "replaces": ["user.capabilities.collection.get"],
-      "displayName": "User-Capabilities - Find records by query",
-      "description": "Retrieve user-capability items by CQL query"
-    },
-    {
       "permissionName": "user-capabilities.all",
       "displayName": "User-Capabilities - all permissions",
       "description": "All permissions for user-capability management",
@@ -605,7 +586,6 @@
         "user-capabilities.collection.put",
         "user-capabilities.collection.post",
         "user-capabilities.collection.delete",
-        "user-capabilities.collection.get",
         "user.capabilities.collection.get"
       ]
     },
@@ -613,11 +593,6 @@
       "permissionName": "user-capability-sets.collection.post",
       "displayName": "User-Capability-Sets - Create record",
       "description": "Create a record associating one or more capabilities with user"
-    },
-    {
-      "permissionName": "user-capability-sets.collection.get",
-      "displayName": "User-Capability-Sets - Find records by the query",
-      "description": "Retrieve role-capability items by CQL query"
     },
     {
       "permissionName": "user-capability-sets.collection.put",
@@ -630,8 +605,7 @@
       "description": "Delete all assigned capability-sets for user"
     },
     {
-      "permissionName": "user-capability-sets.collection.get",
-	  "replaces": ["user.capability-sets.collection.get"],
+      "permissionName": "user.capability-sets.collection.get",
       "displayName": "User-Capability-Sets - Get capability-sets assigned to user",
       "description": "Retrieve capability-sets assigned to user"
     },
@@ -641,7 +615,6 @@
       "description": "All permissions for user-capability set management",
       "subPermissions": [
         "user-capability-sets.collection.put",
-        "user-capability-sets.collection.get",
         "user-capability-sets.collection.post",
         "user-capability-sets.collection.delete",
         "user.capability-sets.collection.get"

--- a/src/main/java/org/folio/roles/controller/RoleCapabilityController.java
+++ b/src/main/java/org/folio/roles/controller/RoleCapabilityController.java
@@ -44,14 +44,6 @@ public class RoleCapabilityController implements RoleCapabilityApi {
   }
 
   @Override
-  public ResponseEntity<RoleCapabilities> getRoleCapabilities(String query, Integer limit, Integer offset) {
-    var pageResult = roleCapabilityService.find(query, limit, offset);
-    return ResponseEntity.ok(new RoleCapabilities()
-      .roleCapabilities(pageResult.getRecords())
-      .totalRecords(pageResult.getTotalRecords()));
-  }
-
-  @Override
   public ResponseEntity<Void> updateRoleCapabilities(UUID roleId, CapabilitiesUpdateRequest request) {
     roleCapabilityService.update(roleId, request);
     return ResponseEntity.noContent().build();

--- a/src/main/java/org/folio/roles/controller/RoleCapabilitySetController.java
+++ b/src/main/java/org/folio/roles/controller/RoleCapabilitySetController.java
@@ -43,14 +43,6 @@ public class RoleCapabilitySetController implements RoleCapabilitySetApi {
   }
 
   @Override
-  public ResponseEntity<RoleCapabilitySets> getRoleCapabilitySets(String query, Integer limit, Integer offset) {
-    var pageResult = roleCapabilitySetService.find(query, limit, offset);
-    return ResponseEntity.ok(new RoleCapabilitySets()
-      .roleCapabilitySets(pageResult.getRecords())
-      .totalRecords(pageResult.getTotalRecords()));
-  }
-
-  @Override
   public ResponseEntity<Void> updateRoleCapabilitySets(UUID roleId, CapabilitySetsUpdateRequest request) {
     roleCapabilitySetService.update(roleId, request);
     return ResponseEntity.noContent().build();

--- a/src/main/java/org/folio/roles/controller/UserCapabilityController.java
+++ b/src/main/java/org/folio/roles/controller/UserCapabilityController.java
@@ -42,14 +42,6 @@ public class UserCapabilityController implements UserCapabilityApi {
   }
 
   @Override
-  public ResponseEntity<UserCapabilities> getUserCapabilities(String query, Integer limit, Integer offset) {
-    var pageResult = userCapabilityService.find(query, limit, offset);
-    return ResponseEntity.ok(new UserCapabilities()
-      .userCapabilities(pageResult.getRecords())
-      .totalRecords(pageResult.getTotalRecords()));
-  }
-
-  @Override
   public ResponseEntity<Void> updateUserCapabilities(UUID userId, CapabilitiesUpdateRequest request) {
     userCapabilityService.update(userId, request.getCapabilityIds());
     return ResponseEntity.noContent().build();

--- a/src/main/java/org/folio/roles/controller/UserRoleController.java
+++ b/src/main/java/org/folio/roles/controller/UserRoleController.java
@@ -33,12 +33,6 @@ public class UserRoleController implements RolesUsersApi {
   }
 
   @Override
-  public ResponseEntity<UserRoles> findUserRoles(String query, Integer limit, Integer offset) {
-    var rolesUsers = userRoleService.findByQuery(query, offset, limit);
-    return ResponseEntity.ok(rolesUsers);
-  }
-
-  @Override
   public ResponseEntity<UserRoles> getUserRoles(UUID userId) {
     var rolesUser = userRoleService.findById(userId);
     return ResponseEntity.ok(rolesUser);

--- a/src/main/resources/swagger.api/mod-roles-keycloak.yaml
+++ b/src/main/resources/swagger.api/mod-roles-keycloak.yaml
@@ -169,28 +169,6 @@ paths:
           $ref: '#/components/responses/badRequestResponse'
         '500':
           $ref: '#/components/responses/internalServerErrorResponse'
-    get:
-      description: Search user-role relations by CQL query
-      operationId: findUserRoles
-      tags:
-        - roles-users
-      parameters:
-        - $ref: '#/components/parameters/query'
-        - $ref: '#/components/parameters/limit'
-        - $ref: '#/components/parameters/offset'
-      responses:
-        '200':
-          description: Array of roles users
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/userRoles'
-              example:
-                $ref: '#/components/examples/userRolesResponse'
-        '400':
-          $ref: '#/components/responses/badRequestResponse'
-        '500':
-          $ref: '#/components/responses/internalServerErrorResponse'
 
   /roles/users/{id}:
     get:
@@ -263,28 +241,6 @@ paths:
       responses:
         '201':
           description: Assigned roles to user
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/roleCapabilities'
-              example:
-                $ref: '#/components/examples/roleCapabilitiesResponse'
-        '400':
-          $ref: '#/components/responses/badRequestResponse'
-        '500':
-          $ref: '#/components/responses/internalServerErrorResponse'
-    get:
-      description: Get role-capability relation items by CQL query and pagination parameters
-      operationId: getRoleCapabilities
-      tags:
-        - role-capability
-      parameters:
-        - $ref: '#/components/parameters/query'
-        - $ref: '#/components/parameters/limit'
-        - $ref: '#/components/parameters/offset'
-      responses:
-        '201':
-          description: Array of roles users
           content:
             application/json:
               schema:
@@ -374,28 +330,6 @@ paths:
       responses:
         '201':
           description: Assigned roles to user
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/roleCapabilitySets'
-              example:
-                $ref: '#/components/examples/roleCapabilitySetsResponse'
-        '400':
-          $ref: '#/components/responses/badRequestResponse'
-        '500':
-          $ref: '#/components/responses/internalServerErrorResponse'
-    get:
-      description: Get role-capability-set relation items by CQL query
-      operationId: getRoleCapabilitySets
-      tags:
-        - role-capability-set
-      parameters:
-        - $ref: '#/components/parameters/query'
-        - $ref: '#/components/parameters/limit'
-        - $ref: '#/components/parameters/offset'
-      responses:
-        '201':
-          description: Array of roles users
           content:
             application/json:
               schema:
@@ -804,28 +738,6 @@ paths:
       responses:
         '201':
           description: Capabilities user
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/userCapabilities'
-              example:
-                $ref: '#/components/examples/userCapabilitiesResponse'
-        '400':
-          $ref: '#/components/responses/badRequestResponse'
-        '500':
-          $ref: '#/components/responses/internalServerErrorResponse'
-    get:
-      description: Search user capabilities by CQL query
-      operationId: getUserCapabilities
-      tags:
-        - user-capability
-      parameters:
-        - $ref: '#/components/parameters/query'
-        - $ref: '#/components/parameters/limit'
-        - $ref: '#/components/parameters/offset'
-      responses:
-        '200':
-          description: A collection of capabilities users
           content:
             application/json:
               schema:

--- a/src/test/java/org/folio/roles/controller/RoleCapabilityControllerTest.java
+++ b/src/test/java/org/folio/roles/controller/RoleCapabilityControllerTest.java
@@ -86,36 +86,6 @@ class RoleCapabilityControllerTest {
   }
 
   @Test
-  void searchRoleCapabilities_positive() throws Exception {
-    var query = "cql.allRecords=1";
-    var roleCapability = roleCapability();
-    when(roleCapabilityService.find(query, 100, 20)).thenReturn(asSinglePage(roleCapability));
-
-    mockMvc.perform(get("/roles/capabilities")
-        .contentType(APPLICATION_JSON)
-        .param("query", query)
-        .param("limit", "100")
-        .param("offset", "20")
-        .header(TENANT, TENANT_ID))
-      .andExpect(status().isOk())
-      .andExpect(content().contentType(APPLICATION_JSON))
-      .andExpect(content().json(asJsonString(roleCapabilities(1, roleCapability)), true));
-  }
-
-  @Test
-  void searchRoleCapabilities_positive_defaultQueryAndPageParameters() throws Exception {
-    var roleCapability = roleCapability();
-    when(roleCapabilityService.find(null, 10, 0)).thenReturn(asSinglePage(roleCapability));
-
-    mockMvc.perform(get("/roles/capabilities")
-        .contentType(APPLICATION_JSON)
-        .header(TENANT, TENANT_ID))
-      .andExpect(status().isOk())
-      .andExpect(content().contentType(APPLICATION_JSON))
-      .andExpect(content().json(asJsonString(roleCapabilities(1, roleCapability)), true));
-  }
-
-  @Test
   void findByRoleId_positive() throws Exception {
     var foundCapability = capability();
     when(capabilityService.findByRoleId(ROLE_ID, false, 100, 20)).thenReturn(asSinglePage(foundCapability));

--- a/src/test/java/org/folio/roles/controller/RoleCapabilitySetControllerTest.java
+++ b/src/test/java/org/folio/roles/controller/RoleCapabilitySetControllerTest.java
@@ -85,36 +85,6 @@ class RoleCapabilitySetControllerTest {
   }
 
   @Test
-  void searchRoleCapabilities_positive() throws Exception {
-    var query = "cql.allRecords=1";
-    var roleCapabilitySet = roleCapabilitySet();
-    when(roleCapabilitySetService.find(query, 100, 20)).thenReturn(asSinglePage(roleCapabilitySet));
-
-    mockMvc.perform(get("/roles/capability-sets")
-        .contentType(APPLICATION_JSON)
-        .param("query", query)
-        .param("limit", "100")
-        .param("offset", "20")
-        .header(TENANT, TENANT_ID))
-      .andExpect(status().isOk())
-      .andExpect(content().contentType(APPLICATION_JSON))
-      .andExpect(content().json(asJsonString(roleCapabilitySets(1, roleCapabilitySet)), true));
-  }
-
-  @Test
-  void searchRoleCapabilities_positive_defaultQueryAndPageParameters() throws Exception {
-    var roleCapabilitySet = roleCapabilitySet();
-    when(roleCapabilitySetService.find(null, 10, 0)).thenReturn(asSinglePage(roleCapabilitySet));
-
-    mockMvc.perform(get("/roles/capability-sets")
-        .contentType(APPLICATION_JSON)
-        .header(TENANT, TENANT_ID))
-      .andExpect(status().isOk())
-      .andExpect(content().contentType(APPLICATION_JSON))
-      .andExpect(content().json(asJsonString(roleCapabilitySets(1, roleCapabilitySet)), true));
-  }
-
-  @Test
   void findByRoleId_positive() throws Exception {
     var foundCapabilitySet = capabilitySet();
     when(capabilitySetService.findByRoleId(ROLE_ID, 100, 20)).thenReturn(asSinglePage(foundCapabilitySet));

--- a/src/test/java/org/folio/roles/controller/UserCapabilityControllerTest.java
+++ b/src/test/java/org/folio/roles/controller/UserCapabilityControllerTest.java
@@ -62,36 +62,6 @@ class UserCapabilityControllerTest {
   }
 
   @Test
-  void searchUserCapabilities_positive() throws Exception {
-    var query = "cql.allRecords=1";
-    var userCapability = userCapability();
-    when(userCapabilityService.find(query, 100, 20)).thenReturn(asSinglePage(userCapability));
-
-    mockMvc.perform(get("/users/capabilities")
-        .contentType(APPLICATION_JSON)
-        .param("query", query)
-        .param("limit", "100")
-        .param("offset", "20")
-        .header(TENANT, TENANT_ID))
-      .andExpect(status().isOk())
-      .andExpect(content().contentType(APPLICATION_JSON))
-      .andExpect(content().json(asJsonString(userCapabilities(1, userCapability)), true));
-  }
-
-  @Test
-  void searchUserCapabilities_positive_defaultQueryAndPageParameters() throws Exception {
-    var userCapability = userCapability();
-    when(userCapabilityService.find(null, 10, 0)).thenReturn(asSinglePage(userCapability));
-
-    mockMvc.perform(get("/users/capabilities")
-        .contentType(APPLICATION_JSON)
-        .header(TENANT, TENANT_ID))
-      .andExpect(status().isOk())
-      .andExpect(content().contentType(APPLICATION_JSON))
-      .andExpect(content().json(asJsonString(userCapabilities(1, userCapability)), true));
-  }
-
-  @Test
   void findByUserId_positive() throws Exception {
     var foundCapability = capability();
     when(capabilityService.findByUserId(USER_ID, false, 100, 20)).thenReturn(asSinglePage(foundCapability));

--- a/src/test/java/org/folio/roles/controller/UserCapabilitySetControllerTest.java
+++ b/src/test/java/org/folio/roles/controller/UserCapabilitySetControllerTest.java
@@ -62,36 +62,6 @@ class UserCapabilitySetControllerTest {
   }
 
   @Test
-  void searchUserCapabilities_positive() throws Exception {
-    var query = "cql.allRecords=1";
-    var userCapabilitySet = userCapabilitySet();
-    when(userCapabilitySetService.find(query, 100, 20)).thenReturn(asSinglePage(userCapabilitySet));
-
-    mockMvc.perform(get("/users/capability-sets")
-        .contentType(APPLICATION_JSON)
-        .param("query", query)
-        .param("limit", "100")
-        .param("offset", "20")
-        .header(TENANT, TENANT_ID))
-      .andExpect(status().isOk())
-      .andExpect(content().contentType(APPLICATION_JSON))
-      .andExpect(content().json(asJsonString(userCapabilitySets(1, userCapabilitySet)), true));
-  }
-
-  @Test
-  void searchUserCapabilities_positive_defaultQueryAndPageParameters() throws Exception {
-    var userCapabilitySet = userCapabilitySet();
-    when(userCapabilitySetService.find(null, 10, 0)).thenReturn(asSinglePage(userCapabilitySet));
-
-    mockMvc.perform(get("/users/capability-sets")
-        .contentType(APPLICATION_JSON)
-        .header(TENANT, TENANT_ID))
-      .andExpect(status().isOk())
-      .andExpect(content().contentType(APPLICATION_JSON))
-      .andExpect(content().json(asJsonString(userCapabilitySets(1, userCapabilitySet)), true));
-  }
-
-  @Test
   void findByUserId_positive() throws Exception {
     var foundCapabilitySet = capabilitySet();
     when(capabilitySetService.findByUserId(USER_ID, 100, 20)).thenReturn(asSinglePage(foundCapabilitySet));

--- a/src/test/java/org/folio/roles/controller/UserRoleControllerTest.java
+++ b/src/test/java/org/folio/roles/controller/UserRoleControllerTest.java
@@ -117,21 +117,6 @@ class UserRoleControllerTest {
   }
 
   @Nested
-  @DisplayName("findUserRoles")
-  class FindUserRoles {
-
-    @Test
-    void positive() throws Exception {
-      var userRoles = userRoles(List.of(userRole(ROLE_ID)));
-      when(service.findByQuery(null, 0, 10)).thenReturn(userRoles);
-      mockMvc.perform(get("/roles/users"))
-        .andExpect(status().isOk())
-        .andExpect(content().contentType(APPLICATION_JSON))
-        .andExpect(content().json(asJsonString(userRoles)));
-    }
-  }
-
-  @Nested
   @DisplayName("updateUserRoles")
   class UpdateUserRoles {
 

--- a/src/test/java/org/folio/roles/it/RoleCapabilityIT.java
+++ b/src/test/java/org/folio/roles/it/RoleCapabilityIT.java
@@ -31,6 +31,7 @@ import static org.folio.spring.integration.XOkapiHeaders.TENANT;
 import static org.folio.spring.integration.XOkapiHeaders.USER_ID;
 import static org.folio.test.TestUtils.asJsonString;
 import static org.folio.test.TestUtils.parseResponse;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
@@ -95,58 +96,6 @@ class RoleCapabilityIT extends BaseIntegrationTest {
   @BeforeEach
   void setUp() {
     keycloak.tokenManager().grantToken();
-  }
-
-  @Test
-  @Sql(scripts = {
-    "classpath:/sql/populate-test-role.sql",
-    "classpath:/sql/populate-role-policy.sql",
-    "classpath:/sql/capabilities/populate-capabilities.sql",
-    "classpath:/sql/capabilities/populate-role-capability-relations.sql"
-  })
-  void findCapabilities_positive() throws Exception {
-    doGet(get("/roles/capabilities")
-      .header(TENANT, TENANT_ID)
-      .header(USER_ID, USER_ID_HEADER))
-      .andExpect(content().json(asJsonString(roleCapabilities(
-        roleCapability(ROLE_ID, FOO_CREATE_CAPABILITY),
-        roleCapability(ROLE_ID, FOO_VIEW_CAPABILITY)))
-      ));
-  }
-
-  @Test
-  @Sql(scripts = {
-    "classpath:/sql/populate-test-role.sql",
-    "classpath:/sql/populate-role-policy.sql",
-    "classpath:/sql/capabilities/populate-capabilities.sql",
-    "classpath:/sql/capabilities/populate-role-capability-relations.sql"
-  })
-  void findCapabilities_positive_offsetAndLimit() throws Exception {
-    doGet(get("/roles/capabilities")
-      .param("offset", "1")
-      .param("limit", "1")
-      .header(TENANT, TENANT_ID)
-      .header(USER_ID, USER_ID_HEADER))
-      .andExpect(content().json(asJsonString(
-        roleCapabilities(2L, roleCapability(ROLE_ID, FOO_VIEW_CAPABILITY)))
-      ));
-  }
-
-  @Test
-  @Sql(scripts = {
-    "classpath:/sql/populate-test-role.sql",
-    "classpath:/sql/populate-role-policy.sql",
-    "classpath:/sql/capabilities/populate-capabilities.sql",
-    "classpath:/sql/capabilities/populate-role-capability-relations.sql"
-  })
-  void findCapabilities_positive_cqlQuery() throws Exception {
-    doGet(get("/roles/capabilities")
-      .param("query", "capabilityId==\"" + FOO_CREATE_CAPABILITY + "\"")
-      .header(TENANT, TENANT_ID)
-      .header(USER_ID, USER_ID_HEADER))
-      .andExpect(content().json(asJsonString(
-        roleCapabilities(roleCapability(ROLE_ID, FOO_CREATE_CAPABILITY)))
-      ));
   }
 
   @Test
@@ -356,11 +305,10 @@ class RoleCapabilityIT extends BaseIntegrationTest {
 
     updateRoleCapabilities(request);
 
-    doGet("/roles/capabilities")
-      .andExpect(content().json(asJsonString(roleCapabilities(
-        roleCapability(ROLE_ID, FOO_VIEW_CAPABILITY),
-        roleCapability(ROLE_ID, FOO_EDIT_CAPABILITY),
-        roleCapability(ROLE_ID, FOO_DELETE_CAPABILITY)))));
+    doGet("/roles/{id}/capabilities", ROLE_ID)
+      .andExpect(jsonPath("$.capabilities[*].id").value(
+        containsInAnyOrder(FOO_VIEW_CAPABILITY.toString(), FOO_EDIT_CAPABILITY.toString(),
+          FOO_DELETE_CAPABILITY.toString())));
 
     assertThat(kcTestClient.getPermissionNames()).containsAll(List.of(
       kcPermissionName(fooItemGetEndpoint()),
@@ -382,10 +330,9 @@ class RoleCapabilityIT extends BaseIntegrationTest {
 
     updateRoleCapabilities(request);
 
-    doGet("/roles/capabilities")
-      .andExpect(content().json(asJsonString(roleCapabilities(
-        roleCapability(ROLE_ID, FOO_EDIT_CAPABILITY),
-        roleCapability(ROLE_ID, FOO_DELETE_CAPABILITY)))));
+    doGet("/roles/{id}/capabilities", ROLE_ID)
+      .andExpect(jsonPath("$.capabilities[*].id").value(
+        containsInAnyOrder(FOO_EDIT_CAPABILITY.toString(), FOO_DELETE_CAPABILITY.toString())));
 
     assertThat(kcTestClient.getPermissionNames()).containsAll(List.of(
       kcPermissionName(fooItemDeleteEndpoint()),
@@ -406,10 +353,9 @@ class RoleCapabilityIT extends BaseIntegrationTest {
 
     updateRoleCapabilities(request1);
 
-    doGet("/roles/capabilities")
-      .andExpect(content().json(asJsonString(roleCapabilities(
-        roleCapability(ROLE_ID, FOO_EDIT_CAPABILITY),
-        roleCapability(ROLE_ID, FOO_DELETE_CAPABILITY)))));
+    doGet("/roles/{id}/capabilities", ROLE_ID)
+      .andExpect(jsonPath("$.capabilities[*].id").value(
+        containsInAnyOrder(FOO_EDIT_CAPABILITY.toString(), FOO_DELETE_CAPABILITY.toString())));
 
     assertThat(kcTestClient.getPermissionNames()).containsAll(List.of(
       kcPermissionName(fooItemDeleteEndpoint()),
@@ -420,9 +366,8 @@ class RoleCapabilityIT extends BaseIntegrationTest {
 
     updateRoleCapabilities(request2);
 
-    var emptyResponse = roleCapabilities();
-    doGet("/roles/capabilities")
-      .andExpect(content().json(asJsonString(emptyResponse)));
+    doGet("/roles/{id}/capabilities", ROLE_ID)
+      .andExpect(content().json(asJsonString(capabilities())));
 
     assertThat(kcTestClient.getPermissionNames()).isEmpty();
   }
@@ -454,7 +399,7 @@ class RoleCapabilityIT extends BaseIntegrationTest {
         .header(USER_ID, USER_ID_HEADER))
       .andExpect(status().isNoContent());
 
-    doGet("/roles/capabilities").andExpect(content().json(asJsonString(roleCapabilities())));
+    doGet("/roles/{id}/capabilities", ROLE_ID).andExpect(content().json(asJsonString(capabilities())));
 
     assertThat(kcTestClient.getPermissionNames()).isEmpty();
   }

--- a/src/test/java/org/folio/roles/it/RoleKeycloakIT.java
+++ b/src/test/java/org/folio/roles/it/RoleKeycloakIT.java
@@ -3,7 +3,6 @@ package org.folio.roles.it;
 import static java.time.ZoneId.systemDefault;
 import static java.util.UUID.fromString;
 import static org.apache.commons.collections4.IterableUtils.find;
-import static org.folio.roles.support.RoleCapabilitySetUtils.roleCapabilitySets;
 import static org.folio.roles.support.TestConstants.TENANT_ID;
 import static org.folio.roles.support.TestConstants.USER_ID_HEADER;
 import static org.folio.roles.support.UserRoleTestUtils.userRoles;
@@ -196,8 +195,11 @@ class RoleKeycloakIT extends BaseIntegrationTest {
       .andExpect(content().contentType(APPLICATION_JSON))
       .andExpect(content().json(asJsonString(userRoles())));
 
-    doGet("/roles/capability-sets")
-      .andExpect(content().json(asJsonString(roleCapabilitySets())));
+    attemptGet("/roles/{id}/capability-sets", ROLE_1.getId())
+      .andExpect(status().isNotFound())
+      .andExpect(content().contentType(APPLICATION_JSON))
+      .andExpect(jsonPath("$.errors[0].type", is("EntityNotFoundException")))
+      .andExpect(jsonPath("$.errors[0].code", is("not_found_error")));
   }
 
   @Test

--- a/src/test/java/org/folio/roles/it/UserCapabilityIT.java
+++ b/src/test/java/org/folio/roles/it/UserCapabilityIT.java
@@ -24,6 +24,7 @@ import static org.folio.roles.support.UserCapabilityUtils.userCapabilitiesReques
 import static org.folio.roles.support.UserCapabilityUtils.userCapability;
 import static org.folio.spring.integration.XOkapiHeaders.TENANT;
 import static org.folio.test.TestUtils.asJsonString;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
@@ -87,54 +88,6 @@ class UserCapabilityIT extends BaseIntegrationTest {
   @BeforeEach
   void setUp() {
     keycloak.tokenManager().grantToken();
-  }
-
-  @Test
-  @Sql(scripts = {
-    "classpath:/sql/populate-user-policy.sql",
-    "classpath:/sql/capabilities/populate-capabilities.sql",
-    "classpath:/sql/capabilities/populate-user-capability-relations.sql"
-  })
-  void findCapabilities_positive() throws Exception {
-    doGet(get("/users/capabilities")
-      .header(TENANT, TENANT_ID)
-      .header(XOkapiHeaders.USER_ID, USER_ID_HEADER))
-      .andExpect(content().json(asJsonString(userCapabilities(
-        userCapability(USER_ID, FOO_CREATE_CAPABILITY), userCapability(USER_ID, FOO_VIEW_CAPABILITY)))
-      ));
-  }
-
-  @Test
-  @Sql(scripts = {
-    "classpath:/sql/populate-user-policy.sql",
-    "classpath:/sql/capabilities/populate-capabilities.sql",
-    "classpath:/sql/capabilities/populate-user-capability-relations.sql"
-  })
-  void findCapabilities_positive_offsetAndLimit() throws Exception {
-    doGet(get("/users/capabilities")
-      .param("offset", "1")
-      .param("limit", "1")
-      .header(TENANT, TENANT_ID)
-      .header(XOkapiHeaders.USER_ID, USER_ID_HEADER))
-      .andExpect(content().json(asJsonString(
-        userCapabilities(2L, userCapability(USER_ID, FOO_VIEW_CAPABILITY)))
-      ));
-  }
-
-  @Test
-  @Sql(scripts = {
-    "classpath:/sql/populate-user-policy.sql",
-    "classpath:/sql/capabilities/populate-capabilities.sql",
-    "classpath:/sql/capabilities/populate-user-capability-relations.sql"
-  })
-  void findCapabilities_positive_cqlQuery() throws Exception {
-    doGet(get("/users/capabilities")
-      .param("query", "capabilityId==\"" + FOO_CREATE_CAPABILITY + "\"")
-      .header(TENANT, TENANT_ID)
-      .header(XOkapiHeaders.USER_ID, USER_ID_HEADER))
-      .andExpect(content().json(asJsonString(
-        userCapabilities(userCapability(USER_ID, FOO_CREATE_CAPABILITY)))
-      ));
   }
 
   @Test
@@ -265,11 +218,9 @@ class UserCapabilityIT extends BaseIntegrationTest {
 
     updateUserCapabilities(request);
 
-    doGet("/users/capabilities")
-      .andExpect(content().json(asJsonString(userCapabilities(
-        userCapability(USER_ID, FOO_VIEW_CAPABILITY),
-        userCapability(USER_ID, FOO_EDIT_CAPABILITY),
-        userCapability(USER_ID, FOO_DELETE_CAPABILITY)))));
+    doGet("/users/{id}/capabilities", USER_ID).andExpect(jsonPath("$.capabilities[*].id").value(
+      containsInAnyOrder(FOO_VIEW_CAPABILITY.toString(), FOO_EDIT_CAPABILITY.toString(),
+        FOO_DELETE_CAPABILITY.toString())));
 
     assertThat(kcTestClient.getPermissionNames()).containsAll(List.of(
       kcPermissionName(fooItemGetEndpoint()),
@@ -291,7 +242,7 @@ class UserCapabilityIT extends BaseIntegrationTest {
         .header(XOkapiHeaders.USER_ID, USER_ID_HEADER))
       .andExpect(status().isNoContent());
 
-    doGet("/users/capabilities").andExpect(content().json(asJsonString(userCapabilities())));
+    doGet("/users/{id}/capabilities", USER_ID).andExpect(content().json(asJsonString(capabilities())));
 
     assertThat(kcTestClient.getPermissionNames()).isEmpty();
   }

--- a/src/test/java/org/folio/roles/it/UserCapabilitySetIT.java
+++ b/src/test/java/org/folio/roles/it/UserCapabilitySetIT.java
@@ -33,6 +33,7 @@ import static org.folio.roles.support.UserCapabilityUtils.userCapabilitiesReques
 import static org.folio.roles.support.UserCapabilityUtils.userCapability;
 import static org.folio.spring.integration.XOkapiHeaders.TENANT;
 import static org.folio.test.TestUtils.asJsonString;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
@@ -326,15 +327,13 @@ class UserCapabilitySetIT extends BaseIntegrationTest {
         .header(XOkapiHeaders.USER_ID, USER_ID_HEADER))
       .andExpect(status().isNoContent());
 
-    doGet("/users/capability-sets")
+    doGet("/users/{id}/capability-sets", USER_ID)
       .andExpect(content().json(asJsonString(userCapabilitySets())));
 
-    doGet("/users/capabilities")
-      .andExpect(content().json(asJsonString(userCapabilities(
-        userCapability(USER_ID, FOO_VIEW_CAPABILITY),
-        userCapability(USER_ID, FOO_CREATE_CAPABILITY)
-      ))));
-
+    doGet("/users/{id}/capabilities", USER_ID)
+      .andExpect(
+        jsonPath("$.capabilities[*].id").value(
+          containsInAnyOrder(FOO_CREATE_CAPABILITY.toString(), FOO_VIEW_CAPABILITY.toString())));
     assertThat(kcTestClient.getPermissionNames()).containsAll(List.of(
       kcPermissionName(fooItemGetEndpoint()),
       kcPermissionName(fooItemPostEndpoint())


### PR DESCRIPTION
## Purpose

https://folio-org.atlassian.net/browse/MODROLESKC-268

Fixed incorrectly named permissions in module descriptor, removed unnecessary endpoints that called for duplication of permissions, updated versions and tests accordingly.

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
