### PR TITLE
MODROLESKC-271: Add 'Cataloger - Linked Data Editor' role

### DIFF
--- a/src/main/resources/reference-data/roles/cataloger-linked-data-editor.json
+++ b/src/main/resources/reference-data/roles/cataloger-linked-data-editor.json
@@ -1,0 +1,11 @@
+{
+  "roles": [
+    {
+      "name": "Cataloger - Linked Data Editor",
+      "description": "Role for Linked Data Editor Cataloger",
+      "permissions": [
+        "ui-linked-data.all"
+      ]
+    }
+  ]
+}

--- a/src/test/java/org/folio/roles/it/ReferenceDataIT.java
+++ b/src/test/java/org/folio/roles/it/ReferenceDataIT.java
@@ -52,7 +52,7 @@ class ReferenceDataIT extends BaseIntegrationTest {
         .header(USER_ID, USER_ID_HEADER)
         .queryParam("limit", valueOf(MAX_VALUE)))
       .andExpect(status().isOk())
-      .andExpect(jsonPath("$.totalRecords").value(29));
+      .andExpect(jsonPath("$.totalRecords").value(30));
 
     mockMvc.perform(get("/policies")
         .header(TENANT, TENANT_ID)


### PR DESCRIPTION
## Purpose

To create an out-of-box role `Cataloger - Linked Data Editor`. 
Folio administrative staff should be able to assign this role to Linked Data catalogers.

Related links:
Linked data application descriptor: [app-linked-data](https://github.com/folio-org/app-linked-data)
Backend repo: [mod-linked-data/](https://github.com/folio-org/mod-linked-data/)
Frontend repo: [ui-ld-folio-wrapper](https://github.com/folio-org/ui-ld-folio-wrapper)



## Approach

Add a new role definition file similar to other existing defintions

## TODOS and Open Questions

Please note that linked-data is not part of platform complete application. Do we need to do anything special in this case?

## Learning

N/A

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [X] Code coverage on new code is 80% or greater
  - [X] Duplications on new code is 3% or less
  - [X] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:
N/A
- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
