### PR TITLE
MODROLESKC-268

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -217,7 +217,7 @@
         {
           "methods": [ "GET" ],
           "pathPattern": "/roles/{id}/capability-sets",
-          "permissionsRequired": [ "role.capability-sets.collection.get" ]
+          "permissionsRequired": [ "role-capability-sets.collection.get" ]
         },
         {
           "methods": [ "PUT" ],
@@ -248,7 +248,7 @@
         {
           "methods": [ "GET" ],
           "pathPattern": "/users/{id}/capabilities",
-          "permissionsRequired": [ "user.capabilities.collection.get" ]
+          "permissionsRequired": [ "user-capabilities.collection.get" ]
         },
         {
           "methods": [ "PUT" ],
@@ -279,7 +279,7 @@
         {
           "methods": [ "GET" ],
           "pathPattern": "/users/{id}/capability-sets",
-          "permissionsRequired": [ "user.capability-sets.collection.get" ]
+          "permissionsRequired": [ "user-capability-sets.collection.get" ]
         },
         {
           "methods": [ "PUT" ],
@@ -563,7 +563,8 @@
       "description": "Delete all assigned capability-sets for role"
     },
     {
-      "permissionName": "role.capability-sets.collection.get",
+      "permissionName": "role-capability-sets.collection.get",
+      "replaces": ["role.capability-sets.collection.get"],
       "displayName": "Role-Capability-Sets - Get capability-sets assigned to role",
       "description": "Retrieve capability-sets assigned to role"
     },
@@ -575,7 +576,7 @@
         "role-capability-sets.collection.put",
         "role-capability-sets.collection.post",
         "role-capability-sets.collection.delete",
-        "role.capability-sets.collection.get"
+        "role-capability-sets.collection.get"
       ]
     },
     {
@@ -584,7 +585,8 @@
       "description": "Create a record associating one or more capabilities with user"
     },
     {
-      "permissionName": "user.capabilities.collection.get",
+      "permissionName": "user-capabilities.collection.get",
+      "replaces": ["user.capabilities.collection.get"],
       "displayName": "Role-Capabilities - Get capabilities assigned to user",
       "description": "Retrieve capabilities assigned to user"
     },
@@ -606,7 +608,7 @@
         "user-capabilities.collection.put",
         "user-capabilities.collection.post",
         "user-capabilities.collection.delete",
-        "user.capabilities.collection.get"
+        "user-capabilities.collection.get"
       ]
     },
     {
@@ -625,7 +627,8 @@
       "description": "Delete all assigned capability-sets for user"
     },
     {
-      "permissionName": "user.capability-sets.collection.get",
+      "permissionName": "user-capability-sets.collection.get",
+      "replaces": ["user.capability-sets.collection"],
       "displayName": "User-Capability-Sets - Get capability-sets assigned to user",
       "description": "Retrieve capability-sets assigned to user"
     },
@@ -637,7 +640,7 @@
         "user-capability-sets.collection.put",
         "user-capability-sets.collection.post",
         "user-capability-sets.collection.delete",
-        "user.capability-sets.collection.get"
+        "user-capability-sets.collection.get"
       ]
     },
     {


### PR DESCRIPTION
## Purpose

https://folio-org.atlassian.net/browse/MODROLESKC-268

MODROLESKC-268: Fix capability names to generate uniform names for all capability actions (e.g. User-Capabilities and not User Capabilities - for all actions like get, post, put etc)

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
