### PR TITLE
MODROLESKC-295 -  Inconsistent naming of permissions

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -522,6 +522,7 @@
     },
     {
       "permissionName": "role-capabilities.collection.get",
+      "replaces": ["role.capabilities.collection.get"],
       "displayName": "Role-Capabilities - Get capabilities assigned to role",
       "description": "Retrieve capabilities assigned to role"
     },
@@ -628,7 +629,7 @@
     },
     {
       "permissionName": "user-capability-sets.collection.get",
-      "replaces": ["user.capability-sets.collection"],
+      "replaces": ["user.capability-sets.collection.get"],
       "displayName": "User-Capability-Sets - Get capability-sets assigned to user",
       "description": "Retrieve capability-sets assigned to user"
     },

--- a/src/main/resources/permissions-view-edit-mapping/capabilities/capabilities-to-view-edit-capabilities.json
+++ b/src/main/resources/permissions-view-edit-mapping/capabilities/capabilities-to-view-edit-capabilities.json
@@ -1,9 +1,7 @@
 {
   "viewCapabilities": [
     "user-capabilities_collection.view",
-    "user_capabilities_collection.view",
     "user-capability-sets_collection.view",
-    "user_capability-sets_collection.view",
     "roles_users_item.view",
     "roles_users_collection.view",
     "role-capabilities_collection.view",

--- a/src/test/java/org/folio/roles/service/migration/ManagePermissionsResolverTest.java
+++ b/src/test/java/org/folio/roles/service/migration/ManagePermissionsResolverTest.java
@@ -53,7 +53,7 @@ class ManagePermissionsResolverTest {
     var managedCapabilities = managePermissionsResolver.getCapabilitiesToManageCapabilities();
     var managedPermissions = managePermissionsResolver.getPermissionsToManagePermissions();
 
-    assertThat(managedCapabilities.getViewCapabilities()).hasSize(17);
+    assertThat(managedCapabilities.getViewCapabilities()).hasSize(15);
     assertThat(managedCapabilities.getEditCapabilities()).hasSize(20);
     assertThat(managedPermissions.getViewPermissions()).hasSize(4);
     assertThat(managedPermissions.getEditPermissions()).hasSize(12);


### PR DESCRIPTION
### **Purpose**
Explain why these changes are needed and link the related issue (e.g., https://folio-org.atlassian.net/browse/PROJ-123).

[MODROLESKC-295](https://folio-org.atlassian.net/browse/MODROLESKC-295) - Inconsistent naming of permissions

### **Approach**
Provide a brief technical summary of the changes.

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
