### PR TITLE
MODROLESKC-301: add upsert rest API method to create default loadable roles

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## Version `v3.1.0` (in progress)
+* Added endpoint to create or update default roles via REST API (MODROLESKC-301)
+
 ## Version `v3.0.0` (14.03.2025)
 * Error with roles migration (MODROLESKC-282)
 * Create dummy capabilities / capability sets (MODROLESKC-270)

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -320,9 +320,9 @@
           "permissionsRequired": [ "loadable-roles.collection.get" ]
         },
         {
-          "methods": [ "POST" ],
+          "methods": [ "PUT" ],
           "pathPattern": "/loadable-roles",
-          "permissionsRequired": [ "loadable-roles.item.post" ]
+          "permissionsRequired": [ "loadable-roles.item.put" ]
         }
       ]
     },
@@ -666,9 +666,9 @@
       "description": "Searching loadable roles"
     },
     {
-      "permissionName": "loadable-roles.item.post",
-      "displayName": "Loadable roles item create",
-      "description": "Create a loadable role"
+      "permissionName": "loadable-roles.item.put",
+      "displayName": "Loadable roles item create or update",
+      "description": "Create or update a loadable role"
     }
   ],
   "launchDescriptor": {

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1,6 +1,12 @@
 {
   "id": "@artifactId@-@version@",
   "name": "roles-keycloak",
+  "requires": [
+    {
+      "id": "permissions",
+      "version": "5.6"
+    }
+  ],
   "provides": [
     {
       "id": "roles",
@@ -306,12 +312,17 @@
     },
     {
       "id": "loadable-roles",
-      "version": "1.0",
+      "version": "1.1",
       "handlers": [
         {
           "methods": [ "GET" ],
           "pathPattern": "/loadable-roles",
           "permissionsRequired": [ "loadable-roles.collection.get" ]
+        },
+        {
+          "methods": [ "POST" ],
+          "pathPattern": "/loadable-roles",
+          "permissionsRequired": [ "loadable-roles.item.post" ]
         }
       ]
     },
@@ -522,7 +533,7 @@
     },
     {
       "permissionName": "role-capabilities.collection.get",
-      "replaces": ["role.capabilities.collection.get"],
+      "replaces": [ "role.capabilities.collection.get" ],
       "displayName": "Role-Capabilities - Get capabilities assigned to role",
       "description": "Retrieve capabilities assigned to role"
     },
@@ -565,7 +576,7 @@
     },
     {
       "permissionName": "role-capability-sets.collection.get",
-      "replaces": ["role.capability-sets.collection.get"],
+      "replaces": [ "role.capability-sets.collection.get" ],
       "displayName": "Role-Capability-Sets - Get capability-sets assigned to role",
       "description": "Retrieve capability-sets assigned to role"
     },
@@ -587,7 +598,7 @@
     },
     {
       "permissionName": "user-capabilities.collection.get",
-      "replaces": ["user.capabilities.collection.get"],
+      "replaces": [ "user.capabilities.collection.get" ],
       "displayName": "Role-Capabilities - Get capabilities assigned to user",
       "description": "Retrieve capabilities assigned to user"
     },
@@ -629,7 +640,7 @@
     },
     {
       "permissionName": "user-capability-sets.collection.get",
-      "replaces": ["user.capability-sets.collection.get"],
+      "replaces": [ "user.capability-sets.collection.get" ],
       "displayName": "User-Capability-Sets - Get capability-sets assigned to user",
       "description": "Retrieve capability-sets assigned to user"
     },
@@ -653,12 +664,11 @@
       "permissionName": "loadable-roles.collection.get",
       "displayName": "Loadable roles collection get",
       "description": "Searching loadable roles"
-    }
-  ],
-  "requires": [
+    },
     {
-      "id": "permissions",
-      "version": "5.6"
+      "permissionName": "loadable-roles.item.post",
+      "displayName": "Loadable roles item create",
+      "description": "Create a loadable role"
     }
   ],
   "launchDescriptor": {
@@ -668,23 +678,63 @@
       "HostConfig": {
         "Memory": 357913941,
         "PortBindings": {
-          "8081/tcp": [ { "HostPort": "%p" } ]
+          "8081/tcp": [
+            {
+              "HostPort": "%p"
+            }
+          ]
         }
       }
     },
     "env": [
-      { "name": "JAVA_OPTIONS", "value": "-XX:MaxRAMPercentage=85.0" },
-      { "name": "DB_HOST", "value": "postgres" },
-      { "name": "DB_PORT", "value": "5432" },
-      { "name": "DB_USERNAME", "value": "postgres" },
-      { "name": "DB_PASSWORD", "value": "postgres" },
-      { "name": "DB_DATABASE", "value": "okapi_modules" },
-      { "name": "KC_URL", "value": "keycloak:8080" },
-      { "name": "KC_CLIENT_SECRET", "value": "mod-roles-keycloak" },
-      { "name": "KC_CLIENT_ID", "value": "secret" },
-      { "name": "KC_POLICIES_CLIENT_NAME", "value": "mod-login-keycloak" },
-      { "name": "KC_TOKEN_TTL", "value": "59" },
-      { "name": "KC_CLIENT_ID_TTL", "value": "3600" }
+      {
+        "name": "JAVA_OPTIONS",
+        "value": "-XX:MaxRAMPercentage=85.0"
+      },
+      {
+        "name": "DB_HOST",
+        "value": "postgres"
+      },
+      {
+        "name": "DB_PORT",
+        "value": "5432"
+      },
+      {
+        "name": "DB_USERNAME",
+        "value": "postgres"
+      },
+      {
+        "name": "DB_PASSWORD",
+        "value": "postgres"
+      },
+      {
+        "name": "DB_DATABASE",
+        "value": "okapi_modules"
+      },
+      {
+        "name": "KC_URL",
+        "value": "keycloak:8080"
+      },
+      {
+        "name": "KC_CLIENT_SECRET",
+        "value": "mod-roles-keycloak"
+      },
+      {
+        "name": "KC_CLIENT_ID",
+        "value": "secret"
+      },
+      {
+        "name": "KC_POLICIES_CLIENT_NAME",
+        "value": "mod-login-keycloak"
+      },
+      {
+        "name": "KC_TOKEN_TTL",
+        "value": "59"
+      },
+      {
+        "name": "KC_CLIENT_ID_TTL",
+        "value": "3600"
+      }
     ]
   },
   "metadata": {
@@ -693,7 +743,7 @@
       "permissions": [
         "users-keycloak.auth-users.item.get",
         "users-keycloak.auth-users.item.post"
-	  ]
+      ]
     }
   }
 }

--- a/src/main/java/org/folio/roles/controller/LoadableRoleController.java
+++ b/src/main/java/org/folio/roles/controller/LoadableRoleController.java
@@ -20,8 +20,8 @@ public class LoadableRoleController implements LoadableRolesApi {
   }
 
   @Override
-  public ResponseEntity<LoadableRole> createLoadableRole(LoadableRole loadableRole) {
-    var response = service.saveDefaultRolesIncremental(loadableRole);
-    return ResponseEntity.status(201).body(response);
+  public ResponseEntity<LoadableRole> upsertLoadableRole(LoadableRole loadableRole) {
+    var response = service.upsertDefaultLoadableRole(loadableRole);
+    return ResponseEntity.ok().body(response);
   }
 }

--- a/src/main/java/org/folio/roles/controller/LoadableRoleController.java
+++ b/src/main/java/org/folio/roles/controller/LoadableRoleController.java
@@ -1,10 +1,8 @@
 package org.folio.roles.controller;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.folio.roles.domain.dto.LoadableRole;
 import org.folio.roles.domain.dto.LoadableRoles;
-import org.folio.roles.domain.dto.RoleType;
 import org.folio.roles.rest.resource.LoadableRolesApi;
 import org.folio.roles.service.loadablerole.LoadableRoleService;
 import org.springframework.http.ResponseEntity;
@@ -22,11 +20,8 @@ public class LoadableRoleController implements LoadableRolesApi {
   }
 
   @Override
-  public ResponseEntity<LoadableRole> createLoadableRole(LoadableRole role) {
-    role.setType(RoleType.DEFAULT);
-    var roles = List.of(role);
-    service.saveDefaultRoles(roles);
-    var createdRole = service.findByIdOrName(role.getId(), role.getName()).orElseThrow();
-    return ResponseEntity.status(201).body(createdRole);
+  public ResponseEntity<LoadableRole> createLoadableRole(LoadableRole loadableRole) {
+    var response = service.saveDefaultRolesIncremental(loadableRole);
+    return ResponseEntity.status(201).body(response);
   }
 }

--- a/src/main/java/org/folio/roles/controller/LoadableRoleController.java
+++ b/src/main/java/org/folio/roles/controller/LoadableRoleController.java
@@ -1,7 +1,10 @@
 package org.folio.roles.controller;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.folio.roles.domain.dto.LoadableRole;
 import org.folio.roles.domain.dto.LoadableRoles;
+import org.folio.roles.domain.dto.RoleType;
 import org.folio.roles.rest.resource.LoadableRolesApi;
 import org.folio.roles.service.loadablerole.LoadableRoleService;
 import org.springframework.http.ResponseEntity;
@@ -16,5 +19,14 @@ public class LoadableRoleController implements LoadableRolesApi {
   @Override
   public ResponseEntity<LoadableRoles> findLoadableRoles(String query, Integer limit, Integer offset) {
     return ResponseEntity.ok(service.find(query, limit, offset));
+  }
+
+  @Override
+  public ResponseEntity<LoadableRole> createLoadableRole(LoadableRole role) {
+    role.setType(RoleType.DEFAULT);
+    var roles = List.of(role);
+    service.saveDefaultRoles(roles);
+    var createdRole = service.findByIdOrName(role.getId(), role.getName()).orElseThrow();
+    return ResponseEntity.status(201).body(createdRole);
   }
 }

--- a/src/main/java/org/folio/roles/domain/entity/LoadableRoleEntity.java
+++ b/src/main/java/org/folio/roles/domain/entity/LoadableRoleEntity.java
@@ -2,6 +2,7 @@ package org.folio.roles.domain.entity;
 
 import static org.apache.commons.collections4.CollectionUtils.emptyIfNull;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -31,6 +32,9 @@ public class LoadableRoleEntity extends RoleEntity {
     mappedBy = "role",
     orphanRemoval = true)
   private Set<LoadablePermissionEntity> permissions = new HashSet<>();
+
+  @Schema(name = "loaded_from_file")
+  private boolean loadedFromFile = false;
 
   public void setPermissions(Collection<LoadablePermissionEntity> newPermissions) {
     removeExistingPermissions();

--- a/src/main/java/org/folio/roles/repository/LoadableRoleRepository.java
+++ b/src/main/java/org/folio/roles/repository/LoadableRoleRepository.java
@@ -15,4 +15,6 @@ public interface LoadableRoleRepository extends BaseCqlJpaRepository<LoadableRol
   boolean existsByIdAndType(UUID id, EntityRoleType type);
 
   Stream<LoadableRoleEntity> findAllByType(EntityRoleType type);
+
+  Stream<LoadableRoleEntity> findAllByTypeAndLoadedFromFile(EntityRoleType type, boolean loadedFromFile);
 }

--- a/src/main/java/org/folio/roles/service/loadablerole/LoadableRoleService.java
+++ b/src/main/java/org/folio/roles/service/loadablerole/LoadableRoleService.java
@@ -137,7 +137,8 @@ public class LoadableRoleService {
     }
   }
 
-  private void saveDefaultRoles(List<LoadableRole> roles) {
+  @Transactional
+  public void saveDefaultRoles(List<LoadableRole> roles) {
     var existing = findAllDefaultRoles();
     var incoming = mapper.toRoleEntity(roles);
     log.debug("Saving default roles:\n\texisting = {},\n\tincoming = {}", () -> toIdNames(existing),

--- a/src/main/java/org/folio/roles/service/loadablerole/LoadableRoleService.java
+++ b/src/main/java/org/folio/roles/service/loadablerole/LoadableRoleService.java
@@ -82,7 +82,7 @@ public class LoadableRoleService {
   public LoadableRole save(LoadableRole role) {
     var entity = mapper.toRoleEntity(role);
 
-    var saved = hasRole(entity) ? updateRole(entity) : createRole(entity);
+    var saved = saveOrUpdate(entity);
     return mapper.toRole(saved);
   }
 
@@ -90,6 +90,26 @@ public class LoadableRoleService {
   public void saveAll(List<LoadableRole> roles) {
     toStream(roles).collect(groupingBy(LoadableRole::getType))
       .forEach(this::saveAllByType);
+  }
+
+  @Transactional
+  public LoadableRole saveDefaultRolesIncremental(LoadableRole loadableRole) {
+    repository.findByIdOrName(loadableRole.getId(), loadableRole.getName())
+      .ifPresent(found -> loadableRole.setId(found.getId()));
+    var incoming = mapper.toRoleEntity(loadableRole);
+    incoming.getPermissions().forEach(p -> p.setRoleId(incoming.getId()));
+    incoming.setType(EntityRoleType.DEFAULT);
+    var existing = findAllDefaultRolesNotLoadedFromFiles();
+
+    mergeInBatch(List.of(incoming), existing, comparatorById(), this::createAll, this::updateAll, nothing());
+
+    var saved = repository.findByIdOrName(loadableRole.getId(), loadableRole.getName())
+      .orElseThrow(() -> new ServiceException("Loadable role not found in DB"));
+    return mapper.toRole(saved);
+  }
+
+  private LoadableRoleEntity saveOrUpdate(LoadableRoleEntity entity) {
+    return hasRole(entity) ? updateRole(entity) : createRole(entity);
   }
 
   private Page<LoadableRoleEntity> findByQuery(String query, Integer limit, Integer offset) {
@@ -137,18 +157,24 @@ public class LoadableRoleService {
     }
   }
 
-  @Transactional
-  public void saveDefaultRoles(List<LoadableRole> roles) {
-    var existing = findAllDefaultRoles();
+  private void saveDefaultRoles(List<LoadableRole> roles) {
+    var existing = findAllDefaultRolesLoadedFromFiles();
     var incoming = mapper.toRoleEntity(roles);
+    incoming.forEach(role -> role.setLoadedFromFile(true));
     log.debug("Saving default roles:\n\texisting = {},\n\tincoming = {}", () -> toIdNames(existing),
       () -> toIdNames(incoming));
 
     mergeInBatch(incoming, existing, comparatorById(), this::createAll, this::updateAll, this::deleteAll);
   }
 
-  private List<LoadableRoleEntity> findAllDefaultRoles() {
-    try (var defaultRoles = repository.findAllByType(EntityRoleType.DEFAULT)) {
+  private List<LoadableRoleEntity> findAllDefaultRolesLoadedFromFiles() {
+    try (var defaultRoles = repository.findAllByTypeAndLoadedFromFile(EntityRoleType.DEFAULT, true)) {
+      return defaultRoles.toList();
+    }
+  }
+
+  private List<LoadableRoleEntity> findAllDefaultRolesNotLoadedFromFiles() {
+    try (var defaultRoles = repository.findAllByTypeAndLoadedFromFile(EntityRoleType.DEFAULT, false)) {
       return defaultRoles.toList();
     }
   }
@@ -257,7 +283,7 @@ public class LoadableRoleService {
   }
 
   private LoadableRoleEntity saveToDb(LoadableRoleEntity entity) {
-    assert entity.getId() != null;
+    requireNonNull(entity.getId(), "Loadable role id cannot be null");
 
     return repository.save(entity);
   }

--- a/src/main/java/org/folio/roles/service/migration/MigrationRoleCreator.java
+++ b/src/main/java/org/folio/roles/service/migration/MigrationRoleCreator.java
@@ -99,7 +99,7 @@ public class MigrationRoleCreator {
   private static Role createRole(String roleName) {
     return new Role()
       .name(roleName)
-      .type(RoleType.DEFAULT)
+      .type(RoleType.REGULAR)
       .description("System generated role during migration");
   }
 }

--- a/src/main/java/org/folio/roles/service/role/RoleEntityService.java
+++ b/src/main/java/org/folio/roles/service/role/RoleEntityService.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.folio.roles.domain.dto.Role;
+import org.folio.roles.domain.model.PageResult;
 import org.folio.roles.mapper.entity.RoleEntityMapper;
 import org.folio.roles.repository.RoleEntityRepository;
 import org.folio.spring.data.OffsetRequest;
@@ -63,13 +64,14 @@ public class RoleEntityService {
   }
 
   @Transactional(readOnly = true)
-  public List<Role> findByQuery(String query, Integer offset, Integer limit) {
+  public PageResult<Role> findByQuery(String query, Integer offset, Integer limit) {
     var offsetRequest = OffsetRequest.of(offset, limit);
     var roleEntities = isNotBlank(query)
       ? repository.findByCql(query, offsetRequest)
       : repository.findAll(offsetRequest);
     log.debug("Roles have been found: count = {}", roleEntities.getTotalElements());
-    return mapper.toRole(roleEntities.getContent());
+    var rolesPages = roleEntities.map(mapper::toRole);
+    return PageResult.fromPage(rolesPages);
   }
 
   public Optional<Role> findByName(String roleName) {

--- a/src/main/resources/changelog/changelog-master.xml
+++ b/src/main/resources/changelog/changelog-master.xml
@@ -37,4 +37,5 @@
   <include file="changes/add-dummy-capability-field-to-capability-table.xml" relativeToChangelogFile="true"/>
   <include file="changes/add-visible-field-to-capabilities-and-capsets.xml" relativeToChangelogFile="true"/>
   <include file="changes/populate-visible-field-in-capabilities-and-capsets.xml" relativeToChangelogFile="true"/>
+  <include file="changes/add-loaded-from-file-field-to-loadable-roles.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changelog/changes/add-loaded-from-file-field-to-loadable-roles.xml
+++ b/src/main/resources/changelog/changes/add-loaded-from-file-field-to-loadable-roles.xml
@@ -8,5 +8,11 @@
       <column name="loaded_from_file"  type="boolean" defaultValueBoolean="false"/>
     </addColumn>
   </changeSet>
+  <changeSet id="set-loaded-from-file-true-for-existing-roles" author="Yauhen Vavilkin">
+    <update tableName="role_loadable">
+      <column name="loaded_from_file" valueBoolean="true"/>
+      <where>loaded_from_file = false</where>
+    </update>
+  </changeSet>
 
 </databaseChangeLog>

--- a/src/main/resources/changelog/changes/add-loaded-from-file-field-to-loadable-roles.xml
+++ b/src/main/resources/changelog/changes/add-loaded-from-file-field-to-loadable-roles.xml
@@ -5,7 +5,9 @@
                http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
   <changeSet id="add-loaded-from-file-field-to-loadable-roles" author="Yauhen Vavilkin">
     <addColumn tableName="role_loadable">
-      <column name="loaded_from_file"  type="boolean" defaultValueBoolean="false"/>
+      <column name="loaded_from_file" type="boolean" defaultValueBoolean="false">
+        <constraints nullable="false"/>
+      </column>
     </addColumn>
   </changeSet>
   <changeSet id="set-loaded-from-file-true-for-existing-roles" author="Yauhen Vavilkin">
@@ -14,5 +16,11 @@
       <where>loaded_from_file = false</where>
     </update>
   </changeSet>
-
+  <changeSet id="update-migrated-roles-type-to-regular" author="Yauhen Vavilkin">
+    <sql>
+      UPDATE role
+      SET type = 'REGULAR'
+      WHERE description = 'System generated role during migration';
+    </sql>
+  </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/changelog/changes/add-loaded-from-file-field-to-loadable-roles.xml
+++ b/src/main/resources/changelog/changes/add-loaded-from-file-field-to-loadable-roles.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+               http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+  <changeSet id="add-loaded-from-file-field-to-loadable-roles" author="Yauhen Vavilkin">
+    <addColumn tableName="role_loadable">
+      <column name="loaded_from_file"  type="boolean" defaultValueBoolean="false"/>
+    </addColumn>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/swagger.api/mod-roles-keycloak.yaml
+++ b/src/main/resources/swagger.api/mod-roles-keycloak.yaml
@@ -1056,6 +1056,28 @@ paths:
           $ref: '#/components/responses/badRequestResponse'
         '500':
           $ref: '#/components/responses/internalServerErrorResponse'
+    post:
+      description: Create a loadable role
+      operationId: createLoadableRole
+      tags:
+        - loadable-roles
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/loadableRole'
+      responses:
+        '201':
+          description: Created loadable role object
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/loadableRole'
+        '400':
+          $ref: '#/components/responses/badRequestResponse'
+        '500':
+          $ref: '#/components/responses/internalServerErrorResponse'
 
 components:
   schemas:

--- a/src/main/resources/swagger.api/mod-roles-keycloak.yaml
+++ b/src/main/resources/swagger.api/mod-roles-keycloak.yaml
@@ -1056,9 +1056,12 @@ paths:
           $ref: '#/components/responses/badRequestResponse'
         '500':
           $ref: '#/components/responses/internalServerErrorResponse'
-    post:
-      description: Create a loadable role
-      operationId: createLoadableRole
+    put:
+      description: >-
+        A default role is created or updated, role is populated with the specified
+        permissions (capabilities and capability sets) as they become available in
+        the system. Default role cannot be changed via Roles API.
+      operationId: upsertLoadableRole
       tags:
         - loadable-roles
       requestBody:
@@ -1068,8 +1071,8 @@ paths:
             schema:
               $ref: '#/components/schemas/loadableRole'
       responses:
-        '201':
-          description: Created loadable role object
+        '200':
+          description: Default loadable role was created or updated successfully
           content:
             application/json:
               schema:

--- a/src/main/resources/swagger.api/schemas/role/roles.json
+++ b/src/main/resources/swagger.api/schemas/role/roles.json
@@ -15,7 +15,8 @@
     },
     "totalRecords": {
       "description": "The total number of roles matching the provided criteria",
-      "type": "integer"
+      "type": "integer",
+      "format": "int64"
     }
   },
   "required": [

--- a/src/test/java/org/folio/roles/it/RoleKeycloakIT.java
+++ b/src/test/java/org/folio/roles/it/RoleKeycloakIT.java
@@ -253,9 +253,7 @@ class RoleKeycloakIT extends BaseIntegrationTest {
       .andExpect(status().isNotFound())
       .andExpect(content().contentType(APPLICATION_JSON))
       .andExpect(jsonPath("$.errors[0].type", is("EntityNotFoundException")))
-      .andExpect(jsonPath("$.errors[0].code", is("not_found_error")))
-      .andExpect(jsonPath("$.errors[0].message", is("Failed to find role: id = " + notExistingRoleId)))
-    ;
+      .andExpect(jsonPath("$.errors[0].code", is("not_found_error")));
   }
 
   private static Date timestampFrom(String value) {

--- a/src/test/java/org/folio/roles/service/loadablerole/LoadableRoleServiceTest.java
+++ b/src/test/java/org/folio/roles/service/loadablerole/LoadableRoleServiceTest.java
@@ -2,7 +2,6 @@ package org.folio.roles.service.loadablerole;
 
 import static java.util.UUID.randomUUID;
 import static org.apache.commons.lang3.RandomStringUtils.insecure;
-import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.folio.roles.support.LoadableRoleUtils.loadableRole;
@@ -13,15 +12,14 @@ import static org.folio.roles.support.TestUtils.copy;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.folio.roles.domain.entity.type.EntityRoleType;
 import org.folio.roles.exception.ServiceException;
 import org.folio.roles.integration.keyclock.KeycloakRoleService;
-import org.folio.roles.integration.keyclock.exception.KeycloakApiException;
 import org.folio.roles.mapper.LoadableRoleMapper;
 import org.folio.roles.repository.LoadableRoleRepository;
 import org.folio.roles.support.TestUtils;
@@ -198,7 +196,7 @@ class LoadableRoleServiceTest {
       when(repository.saveAndFlush(roleEntity)).thenReturn(roleEntity);
       when(capabilityAssignmentHelper.assignCapabilitiesAndSetsForPermissions(roleEntity.getPermissions()))
         .thenReturn(roleEntity.getPermissions());
-      when(repository.saveAllAndFlush(org.mockito.ArgumentMatchers.anyList())).thenReturn(java.util.List.of(roleEntity));
+      when(repository.saveAllAndFlush(org.mockito.ArgumentMatchers.anyList())).thenReturn(List.of(roleEntity));
       when(repository.findByIdOrName(role.getId(), role.getName())).thenReturn(Optional.of(roleEntity));
       when(mapper.toRole(roleEntity)).thenReturn(role);
 

--- a/src/test/java/org/folio/roles/service/migration/MigrationRoleCreatorTest.java
+++ b/src/test/java/org/folio/roles/service/migration/MigrationRoleCreatorTest.java
@@ -49,19 +49,19 @@ class MigrationRoleCreatorTest {
   private static Role migrationRole() {
     return new Role()
       .name(ROLE_NAME)
-      .type(RoleType.DEFAULT)
+      .type(RoleType.REGULAR)
       .description("System generated role during migration");
   }
 
   private static Roles createdMigrationRoles() {
-    return new Roles().addRolesItem(createdMigrationRole()).totalRecords(1);
+    return new Roles().addRolesItem(createdMigrationRole()).totalRecords(1L);
   }
 
   private static Role createdMigrationRole() {
     return new Role()
       .id(ROLE_ID)
       .name(ROLE_NAME)
-      .type(RoleType.DEFAULT)
+      .type(RoleType.REGULAR)
       .description("System generated role during migration");
   }
 
@@ -82,7 +82,7 @@ class MigrationRoleCreatorTest {
 
     @Test
     void positive_roleFound() {
-      when(roleService.create(List.of(migrationRole()))).thenReturn(new Roles().totalRecords(0));
+      when(roleService.create(List.of(migrationRole()))).thenReturn(new Roles().totalRecords(0L));
       when(roleService.search("name==" + ROLE_NAME, 0, 1)).thenReturn(createdMigrationRoles());
 
       var result = migrationRoleCreator.createRoles(List.of(userPermissions()));

--- a/src/test/java/org/folio/roles/service/role/RoleEntityServiceTest.java
+++ b/src/test/java/org/folio/roles/service/role/RoleEntityServiceTest.java
@@ -1,8 +1,6 @@
 package org.folio.roles.service.role;
 
-import static java.util.Arrays.stream;
 import static java.util.UUID.fromString;
-import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.roles.domain.dto.RoleType.REGULAR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -22,6 +20,7 @@ import java.util.UUID;
 import org.folio.roles.domain.dto.Metadata;
 import org.folio.roles.domain.dto.Role;
 import org.folio.roles.domain.entity.RoleEntity;
+import org.folio.roles.domain.entity.type.EntityRoleType;
 import org.folio.roles.mapper.entity.DateConvertHelper;
 import org.folio.roles.mapper.entity.RoleEntityMapper;
 import org.folio.roles.mapper.entity.RoleEntityMapperImpl;
@@ -74,6 +73,7 @@ class RoleEntityServiceTest {
     entity.setName(ROLE_NAME);
     entity.setId(ROLE_ID);
     entity.setDescription(ROLE_DESCRIPTION);
+    entity.setType(EntityRoleType.REGULAR);
     return entity;
   }
 
@@ -211,17 +211,17 @@ class RoleEntityServiceTest {
       var offset = 0;
       var limit = 10;
       var cqlQuery = "cql.allRecords = 1";
-      var roles = List.of(createRoleEntity());
-      var expectedPage = new PageImpl<>(roles, Pageable.ofSize(1), 1);
+      var rolesEntities = List.of(createRoleEntity());
 
-      when(repository.findByCql(cqlQuery, OffsetRequest.of(offset, limit))).thenReturn(expectedPage);
+      when(repository.findByCql(cqlQuery, OffsetRequest.of(offset, limit)))
+        .thenReturn(new PageImpl<>(rolesEntities, Pageable.ofSize(limit), rolesEntities.size()));
 
       var result = service.findByQuery(cqlQuery, offset, limit);
 
-      assertEquals(1, result.size());
-      assertEquals(ROLE_ID, result.get(0).getId());
-      assertEquals(ROLE_NAME, result.get(0).getName());
-      assertEquals(ROLE_DESCRIPTION, result.get(0).getDescription());
+      assertThat(result.getTotalRecords()).isEqualTo(1);
+      assertThat(result.getRecords().getFirst().getId()).isEqualTo(ROLE_ID);
+      assertThat(result.getRecords().getFirst().getName()).isEqualTo(ROLE_NAME);
+      assertThat(result.getRecords().getFirst().getDescription()).isEqualTo(ROLE_DESCRIPTION);
     }
   }
 

--- a/src/test/java/org/folio/roles/service/role/RoleEntityServiceTest.java
+++ b/src/test/java/org/folio/roles/service/role/RoleEntityServiceTest.java
@@ -1,6 +1,8 @@
 package org.folio.roles.service.role;
 
+import static java.util.Arrays.stream;
 import static java.util.UUID.fromString;
+import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.roles.domain.dto.RoleType.REGULAR;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/org/folio/roles/support/RoleUtils.java
+++ b/src/test/java/org/folio/roles/support/RoleUtils.java
@@ -1,9 +1,13 @@
 package org.folio.roles.support;
 
+import static org.folio.roles.domain.dto.RoleType.REGULAR;
+
 import java.util.UUID;
 import lombok.experimental.UtilityClass;
 import org.folio.roles.domain.dto.Role;
+import org.folio.roles.domain.dto.RoleType;
 import org.folio.roles.domain.entity.RoleEntity;
+import org.folio.roles.domain.entity.type.EntityRoleType;
 import org.keycloak.representations.idm.RoleRepresentation;
 
 @UtilityClass
@@ -17,11 +21,16 @@ public class RoleUtils {
   public static final String ROLE_NAME_2 = "role2";
   public static final String ROLE_DESCRIPTION_2 = "role2_description";
 
+  public static final UUID ROLE_ID_3 = UUID.randomUUID();
+  public static final String ROLE_NAME_3 = "role3";
+  public static final String ROLE_DESCRIPTION_3 = "role3_description";
+
   public static Role role() {
     var role = new Role();
     role.setId(ROLE_ID);
     role.setName(ROLE_NAME);
     role.setDescription(ROLE_DESCRIPTION);
+    role.setType(REGULAR);
     return role;
   }
 
@@ -30,6 +39,16 @@ public class RoleUtils {
     role.setId(ROLE_ID_2);
     role.setName(ROLE_NAME_2);
     role.setDescription(ROLE_DESCRIPTION_2);
+    role.setType(REGULAR);
+    return role;
+  }
+
+  public static Role defaultRole() {
+    var role = new Role();
+    role.setId(ROLE_ID_3);
+    role.setName(ROLE_NAME_3);
+    role.setDescription(ROLE_DESCRIPTION_3);
+    role.setType(RoleType.DEFAULT);
     return role;
   }
 
@@ -38,6 +57,16 @@ public class RoleUtils {
     roleEntity.setId(ROLE_ID_2);
     roleEntity.setName(ROLE_NAME_2);
     roleEntity.setDescription(ROLE_DESCRIPTION_2);
+    roleEntity.setType(EntityRoleType.REGULAR);
+    return roleEntity;
+  }
+
+  public static RoleEntity defaultRoleEntity() {
+    var roleEntity = new RoleEntity();
+    roleEntity.setId(ROLE_ID_3);
+    roleEntity.setName(ROLE_NAME_3);
+    roleEntity.setDescription(ROLE_DESCRIPTION_3);
+    roleEntity.setType(EntityRoleType.DEFAULT);
     return roleEntity;
   }
 


### PR DESCRIPTION
### **Purpose**
https://folio-org.atlassian.net/browse/MODROLESKC-301
It was decided to re-use Loadable Role mechanism for system user’s roles, instead of implementing something similar to dummy capabilities.

### **Approach**
 - add PUT `/loadable-roles` to create or update loadable roles
 - add tests
 - restrict update|create|delete Default roles via roles rest API 
 - increase interface version

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [x] API/schema changes
  - [x] Interface version updates
  - [x] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [x] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
