### PR TITLE
MODROLESKC-301: fix default roles deletion

### DIFF
--- a/src/main/java/org/folio/roles/service/role/RoleService.java
+++ b/src/main/java/org/folio/roles/service/role/RoleService.java
@@ -138,7 +138,7 @@ public class RoleService {
    */
   @Transactional
   public void deleteById(UUID id) {
-    var actualRole = keycloakService.getById(id);
+    var actualRole = entityService.getById(id);
     checkIfRoleHasDefaultType(actualRole);
     entityService.deleteById(id);
     try {

--- a/src/test/java/org/folio/roles/it/RoleKeycloakIT.java
+++ b/src/test/java/org/folio/roles/it/RoleKeycloakIT.java
@@ -210,8 +210,8 @@ class RoleKeycloakIT extends BaseIntegrationTest {
       .andExpect(content().contentType(APPLICATION_JSON))
       .andExpect(jsonPath("$.errors[0].type", is("EntityNotFoundException")))
       .andExpect(jsonPath("$.errors[0].code", is("not_found_error")))
-      .andExpect(jsonPath("$.errors[0].message", is("Failed to find role: id = " + notExistingRoleId)))
-    ;
+      .andExpect(jsonPath("$.errors[0].message",
+        is("Unable to find org.folio.roles.domain.entity.RoleEntity with id " + notExistingRoleId)));
   }
 
   @Test

--- a/src/test/java/org/folio/roles/it/RoleKeycloakIT.java
+++ b/src/test/java/org/folio/roles/it/RoleKeycloakIT.java
@@ -203,6 +203,7 @@ class RoleKeycloakIT extends BaseIntegrationTest {
   @Test
   void deleteRole_negative_notFound() throws Exception {
     var notExistingRoleId = ROLE_NOT_EXISTED.getId();
+    var errorMessage = "Unable to find org.folio.roles.domain.entity.RoleEntity with id " + notExistingRoleId;
     mockMvc.perform(delete("/roles/{id}", notExistingRoleId)
         .header(TENANT, TENANT_ID)
         .header(USER_ID, USER_ID_HEADER))
@@ -210,8 +211,7 @@ class RoleKeycloakIT extends BaseIntegrationTest {
       .andExpect(content().contentType(APPLICATION_JSON))
       .andExpect(jsonPath("$.errors[0].type", is("EntityNotFoundException")))
       .andExpect(jsonPath("$.errors[0].code", is("not_found_error")))
-      .andExpect(jsonPath("$.errors[0].message",
-        is("Unable to find org.folio.roles.domain.entity.RoleEntity with id " + notExistingRoleId)));
+      .andExpect(jsonPath("$.errors[0].message", is(errorMessage)));
   }
 
   @Test

--- a/src/test/java/org/folio/roles/service/role/RoleServiceTest.java
+++ b/src/test/java/org/folio/roles/service/role/RoleServiceTest.java
@@ -210,7 +210,7 @@ class RoleServiceTest {
 
     @Test
     void positive() {
-      when(keycloakService.getById(ROLE_ID)).thenReturn(role());
+      when(entityService.getById(ROLE_ID)).thenReturn(role());
 
       facade.deleteById(ROLE_ID);
 
@@ -222,7 +222,7 @@ class RoleServiceTest {
     void negative_repositoryThrowsException() {
       var role = role();
 
-      when(keycloakService.getById(ROLE_ID)).thenReturn(role);
+      when(entityService.getById(ROLE_ID)).thenReturn(role);
       doThrow(RuntimeException.class).when(keycloakService).deleteById(ROLE_ID);
 
       assertThrows(RuntimeException.class, () -> facade.deleteById(ROLE_ID));
@@ -234,13 +234,13 @@ class RoleServiceTest {
     void negative_defaultRoleCannotBeDeleted() {
       var role = defaultRole();
 
-      when(keycloakService.getById(ROLE_ID_3)).thenReturn(role);
+      when(entityService.getById(ROLE_ID_3)).thenReturn(role);
 
       assertThatThrownBy(() -> facade.deleteById(ROLE_ID_3))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Default role cannot be created, updated or deleted via roles API.");
 
-      verifyNoInteractions(entityService);
+      verifyNoInteractions(keycloakService);
     }
   }
 


### PR DESCRIPTION
### **Purpose**
Default roles can be deleted. We have to fix this.
https://folio-org.atlassian.net/browse/MODROLESKC-301

### **Approach**
- change source to check role type before deletion (keycloak -> mod-roles-keycloak db)
- fix tests 

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
