### PR TITLE
create stub before the method which triggers this stub is called

### DIFF
--- a/src/test/java/org/folio/roles/it/KafkaMessageListenerIT.java
+++ b/src/test/java/org/folio/roles/it/KafkaMessageListenerIT.java
@@ -170,7 +170,7 @@ class KafkaMessageListenerIT extends BaseIntegrationTest {
       .andExpect(jsonPath("$.totalRecords", is(1)))
       .andReturn();
 
-    var foundCapabilitySet = parseResponse(searchResult, CapabilitySets.class).getCapabilitySets().get(0);
+    var foundCapabilitySet = parseResponse(searchResult, CapabilitySets.class).getCapabilitySets().getFirst();
     assertThat(foundCapabilitySet.getCapabilities()).hasSize(7);
 
     doGet("/capability-sets/{id}/capabilities", foundCapabilitySet.getId())
@@ -275,9 +275,10 @@ class KafkaMessageListenerIT extends BaseIntegrationTest {
   @ParameterizedTest(name = "[{index}] name={0}")
   @DisplayName("handleCapabilityEvent_negative_parameterizedForNonRetryableExceptions")
   void handleCapabilityEvent_negative_parameterized(@SuppressWarnings("unused") String name, Throwable throwable) {
+    doThrow(throwable).when(capabilityService).update(eq(ResourceEventType.CREATE), anyList(), anyList());
+
     var capabilityEvent = readValue("json/kafka-events/be-capability-event.json", ResourceEvent.class);
     kafkaTemplate.send(FOLIO_IT_CAPABILITIES_TOPIC, capabilityEvent);
-    doThrow(throwable).when(capabilityService).update(eq(ResourceEventType.CREATE), anyList(), anyList());
 
     awaitFor(FIVE_HUNDRED_MILLISECONDS);
 


### PR DESCRIPTION
### **Purpose**
Resolve an issue during build:
```
[ERROR]   KafkaMessageListenerIT.handleCapabilityEvent_negative_parameterized:280 » UnfinishedStubbing 
Unfinished stubbing detected here:
-> at org.folio.roles.it.KafkaMessageListenerIT.handleCapabilityEvent_negative_parameterized(KafkaMessageListenerIT.java:280)

E.g. thenReturn() may be missing.
Examples of correct stubbing:
    when(mock.isOk()).thenReturn(true);
    when(mock.isOk()).thenThrow(exception);
    doThrow(exception).when(mock).someVoidMethod();
Hints:
 1. missing thenReturn()
 2. you are trying to stub a final method, which is not supported
 3. you are stubbing the behaviour of another mock inside before 'thenReturn' instruction is completed
```

### **Approach**
* create stub before the method which triggers this stub is called

---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
- [ ] - [ ] 