### PR TITLE
MODROLESKC-323: BE permission is not properly converted to capabilities after migration to Eureka

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * Provide "Data Import" role with permission for central tenant record update through data import (MODROLESKC-304)
 * Fix missing permission for loadable role, fix duplicated capabilities by permission name (MODROLESKC-313)
 * Implement replacement for dummy capabilities (MODROLESKC-306)
+* BE permission is not properly converted to capabilities after migration to Eureka (MODROLESKC-323)
 
 ## Version `v3.0.0` (14.03.2025)
 * Error with roles migration (MODROLESKC-282)

--- a/src/main/java/org/folio/roles/service/migration/RolePermissionAssignor.java
+++ b/src/main/java/org/folio/roles/service/migration/RolePermissionAssignor.java
@@ -51,7 +51,7 @@ public class RolePermissionAssignor {
   private void assignCapabilitiesAndSets(UUID roleId, UserPermissions userPermissions) {
     log.debug("Assigning capabilities/capability sets for role: roleId = {}", roleId);
     var permissions = userPermissions.getPermissions();
-    var capabilitiesByPermissions = capabilityService.findByPermissionNamesNoTechnical(permissions);
+    var capabilitiesByPermissions = capabilityService.findByPermissionNames(permissions);
     var notFoundPermissions = difference(permissions, mapItems(capabilitiesByPermissions, Capability::getPermission));
     var capabilities = union(capabilitiesByPermissions, userPermissions.getManageCapabilities());
     if (isNotEmpty(capabilities)) {

--- a/src/main/java/org/folio/roles/service/migration/RolePermissionAssignor.java
+++ b/src/main/java/org/folio/roles/service/migration/RolePermissionAssignor.java
@@ -7,6 +7,7 @@ import static org.folio.roles.utils.CollectionUtils.union;
 import static org.folio.roles.utils.CollectionUtils.unionUniqueValues;
 
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -55,7 +56,7 @@ public class RolePermissionAssignor {
     var notFoundPermissions = difference(permissions, mapItems(capabilitiesByPermissions, Capability::getPermission));
     var capabilities = union(capabilitiesByPermissions, userPermissions.getManageCapabilities());
     if (isNotEmpty(capabilities)) {
-      roleCapabilityService.create(roleId, mapItems(capabilities, Capability::getId), true);
+      roleCapabilityService.create(roleId, mapItems(new LinkedHashSet<>(capabilities), Capability::getId), true);
     }
 
     var sets = capabilitySetService.findByPermissionNames(permissions);


### PR DESCRIPTION
### **Purpose**
Fix for [MODROLESKC-323](https://folio-org.atlassian.net/browse/MODROLESKC-323)

### **Approach**
- Do not filter out technical capabilities during the migration

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
