### PR TITLE
MODROLESKC-316: add idempotency for Capability event processing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 * BE permission is not properly converted to capabilities after migration to Eureka (MODROLESKC-323)
 * Ability to view Authorization roles and policies (MODROLESKC-314)
 * Add integration test for replace cross-module dummy capabilities (MODROLESKC-305)
+* Fix corrupted capabilities during Kafka event processing (MODROLESKC-316)
 
 ## Version `v3.0.0` (14.03.2025)
 * Error with roles migration (MODROLESKC-282)

--- a/src/main/java/org/folio/roles/mapper/entity/CapabilityEntityMapper.java
+++ b/src/main/java/org/folio/roles/mapper/entity/CapabilityEntityMapper.java
@@ -10,6 +10,8 @@ import org.folio.roles.domain.entity.EmbeddableEndpoint;
 import org.folio.roles.mapper.AuditableEntityMapping;
 import org.folio.roles.mapper.AuditableMapping;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 
 /**
  * Mapper for mapping {@link Capability} objects to {@link CapabilityEntity} objects and vice versa.
@@ -26,4 +28,7 @@ public interface CapabilityEntityMapper {
   Capability convert(CapabilityEntity entity);
 
   List<Capability> convert(List<CapabilityEntity> entities);
+
+  @Mapping(target = "id", ignore = true)
+  void update(Capability source, @MappingTarget Capability target);
 }

--- a/src/main/java/org/folio/roles/service/capability/CapabilityEventHandler.java
+++ b/src/main/java/org/folio/roles/service/capability/CapabilityEventHandler.java
@@ -38,6 +38,7 @@ public class CapabilityEventHandler extends AbstractCapabilityEventHandler {
   private final RoleCapabilityService roleCapabilityService;
   private final UserPermissionService userPermissionService;
   private final UserCapabilityService userCapabilityService;
+  private final CapabilityResolver capabilityResolver;
 
   /**
    * Handles update event for capability.
@@ -85,6 +86,12 @@ public class CapabilityEventHandler extends AbstractCapabilityEventHandler {
   @TransactionalEventListener(condition = "#event.type == T(org.folio.roles.domain.model.event.DomainEventType).DELETE")
   public void handleCapabilityDeletedEvent(CapabilityEvent event) {
     var deprecatedCapability = event.getOldObject();
+    if (capabilityResolver.isCapabilityPermissionCorrupted(deprecatedCapability)) {
+      log.warn("Capability is corrupted, skipping capability deletion: capabilityName = {}, permission = {}",
+        deprecatedCapability.getName(), deprecatedCapability.getPermission());
+      return;
+    }
+
     var capabilityId = deprecatedCapability.getId();
     var deprecatedEndpoints = getCapabilityEndpoints(deprecatedCapability);
 

--- a/src/main/java/org/folio/roles/service/capability/CapabilityResolver.java
+++ b/src/main/java/org/folio/roles/service/capability/CapabilityResolver.java
@@ -1,0 +1,38 @@
+package org.folio.roles.service.capability;
+
+import static java.util.Objects.requireNonNull;
+import static org.folio.common.utils.permission.PermissionUtils.hasNoRequiredFields;
+import static org.folio.roles.utils.CapabilityUtils.getCapabilityName;
+
+import lombok.RequiredArgsConstructor;
+import org.folio.common.utils.permission.PermissionUtils;
+import org.folio.common.utils.permission.model.PermissionData;
+import org.folio.roles.domain.dto.Capability;
+import org.folio.roles.service.permission.PermissionOverrider;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CapabilityResolver {
+
+  private final PermissionOverrider permissionOverrider;
+
+  public boolean isCapabilityPermissionCorrupted(Capability capability) {
+    requireNonNull(capability.getPermission(), "Permission cannot be null");
+
+    var permission = capability.getPermission();
+    var permissionData = extractPermissionData(permission);
+    if (hasNoRequiredFields(permissionData)) {
+      throw new IllegalArgumentException(); //todo what is right behaviour here?
+    }
+
+    var expectedName = getCapabilityName(permissionData);
+    return !expectedName.equals(capability.getName());
+  }
+
+  private PermissionData extractPermissionData(String permissionName) {
+    var mappings = permissionOverrider.getPermissionMappings();
+    var permissionData = mappings.get(permissionName);
+    return permissionData != null ? permissionData : PermissionUtils.extractPermissionData(permissionName);
+  }
+}

--- a/src/main/java/org/folio/roles/service/capability/CapabilityResolver.java
+++ b/src/main/java/org/folio/roles/service/capability/CapabilityResolver.java
@@ -5,12 +5,14 @@ import static org.folio.common.utils.permission.PermissionUtils.hasNoRequiredFie
 import static org.folio.roles.utils.CapabilityUtils.getCapabilityName;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.folio.common.utils.permission.PermissionUtils;
 import org.folio.common.utils.permission.model.PermissionData;
 import org.folio.roles.domain.dto.Capability;
 import org.folio.roles.service.permission.PermissionOverrider;
 import org.springframework.stereotype.Service;
 
+@Log4j2
 @Service
 @RequiredArgsConstructor
 public class CapabilityResolver {
@@ -23,7 +25,8 @@ public class CapabilityResolver {
     var permission = capability.getPermission();
     var permissionData = extractPermissionData(permission);
     if (hasNoRequiredFields(permissionData)) {
-      throw new IllegalArgumentException(); //todo what is right behaviour here?
+      log.warn("Permission data is missing required fields: {}", permission);
+      throw new IllegalStateException("Permission data is missing required fields: " + permission);
     }
 
     var expectedName = getCapabilityName(permissionData);

--- a/src/test/java/org/folio/roles/integration/kafka/CapabilitySetDescriptorServiceTest.java
+++ b/src/test/java/org/folio/roles/integration/kafka/CapabilitySetDescriptorServiceTest.java
@@ -30,7 +30,9 @@ import org.folio.roles.domain.model.event.DomainEvent;
 import org.folio.roles.integration.kafka.mapper.CapabilitySetMapper;
 import org.folio.roles.integration.kafka.model.CapabilitySetDescriptor;
 import org.folio.roles.integration.kafka.model.ResourceEventType;
+import org.folio.roles.mapper.entity.CapabilityEntityMapper;
 import org.folio.roles.repository.PermissionRepository;
+import org.folio.roles.service.capability.CapabilityResolver;
 import org.folio.roles.service.capability.CapabilityService;
 import org.folio.roles.service.capability.CapabilitySetService;
 import org.folio.roles.support.TestUtils;
@@ -61,6 +63,8 @@ class CapabilitySetDescriptorServiceTest {
   @Mock private CapabilitySetService capabilitySetService;
   @Mock private ApplicationEventPublisher applicationEventPublisher;
   @Mock private PermissionRepository permissionRepository;
+  @Mock private CapabilityResolver capabilityResolver;
+  @Mock private CapabilityEntityMapper capabilityMapper;
   @Captor private ArgumentCaptor<DomainEvent> eventCaptor;
 
   @BeforeEach
@@ -68,7 +72,7 @@ class CapabilitySetDescriptorServiceTest {
     var folioExecutionContext = new DefaultFolioExecutionContext(new TestModRolesKeycloakModuleMetadata(), emptyMap());
     this.capabilitySetDescriptorService = new CapabilitySetDescriptorService(
       capabilityService, mapper, capabilitySetService, folioExecutionContext, applicationEventPublisher,
-      permissionRepository);
+      permissionRepository, capabilityResolver, capabilityMapper);
   }
 
   @AfterEach

--- a/src/test/java/org/folio/roles/it/CapabilityReplacesIntegrityIT.java
+++ b/src/test/java/org/folio/roles/it/CapabilityReplacesIntegrityIT.java
@@ -1,0 +1,96 @@
+package org.folio.roles.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Durations.FIVE_HUNDRED_MILLISECONDS;
+import static org.awaitility.Durations.ONE_MINUTE;
+import static org.folio.common.utils.CollectionUtils.mapItems;
+import static org.folio.roles.support.TestConstants.TENANT_ID;
+import static org.folio.roles.utils.TestValues.readValue;
+import static org.folio.test.TestUtils.parseResponse;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
+
+import java.util.UUID;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionFactory;
+import org.folio.roles.base.BaseIntegrationTest;
+import org.folio.roles.domain.dto.Capabilities;
+import org.folio.roles.domain.dto.Capability;
+import org.folio.roles.integration.kafka.model.ResourceEvent;
+import org.folio.test.types.IntegrationTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.context.jdbc.Sql;
+
+@IntegrationTest
+@Sql(executionPhase = AFTER_TEST_METHOD, scripts = {
+  "classpath:/sql/truncate-capability-tables.sql",
+  "classpath:/sql/truncate-permission-table.sql"
+})
+class CapabilityReplacesIntegrityIT extends BaseIntegrationTest {
+
+  private static final UUID CORRUPTED_CAPABILITY_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+  private static final UUID LEGITIMATE_OLD_CAPABILITY_ID = UUID.fromString("00000000-0000-0000-0000-000000000002");
+  private static final String PERMISSION_TO_REPLACE = "old-feature.item.view";
+
+  @Autowired private KafkaTemplate<String, Object> kafkaTemplate;
+
+  @BeforeAll
+  static void beforeAll() {
+    enableTenant(TENANT_ID);
+  }
+
+  @AfterAll
+  static void afterAll() {
+    removeTenant(TENANT_ID);
+  }
+
+  @CsvSource({
+    "json/kafka-events/corrupted-capabilities/replacement-event-create.json",
+    "json/kafka-events/corrupted-capabilities/replacement-event-update.json"
+  })
+  @ParameterizedTest(name = "[{index}] name={0}")
+  @DisplayName("Verify that 'replaces' does not delete a corrupted capability")
+  @Sql(scripts = "classpath:/sql/corrupted-capabilities/populate-data-replacement.sql")
+  void replacement_positive_shouldNotDeleteCorruptedCapability(String eventPath) throws Exception {
+    // Step 1: verify initial state
+    var corruptedCapability = getCapabilityById(CORRUPTED_CAPABILITY_ID);
+    assertThat(corruptedCapability.getPermission()).isEqualTo(PERMISSION_TO_REPLACE);
+
+    var legitimateOldCapability = getCapabilityById(LEGITIMATE_OLD_CAPABILITY_ID);
+    assertThat(legitimateOldCapability.getPermission()).isEqualTo(PERMISSION_TO_REPLACE);
+
+    // Step 2: send event that replaces the "old-feature.item.view" permission
+    sendCapabilityEvent(eventPath);
+
+    // Step 3: assert that the corrupted capability is not deleted
+    await().untilAsserted(() -> {
+      var capabilities = getCapabilitiesByPermission(PERMISSION_TO_REPLACE);
+      assertThat(capabilities.getTotalRecords()).isEqualTo(2);
+      assertThat(mapItems(capabilities.getCapabilities(), Capability::getId)).contains(CORRUPTED_CAPABILITY_ID);
+    });
+  }
+
+  private void sendCapabilityEvent(String filePath) {
+    var capabilityEvent = readValue(filePath, ResourceEvent.class);
+    kafkaTemplate.send(FOLIO_IT_CAPABILITIES_TOPIC, capabilityEvent);
+  }
+
+  private static Capability getCapabilityById(UUID id) throws Exception {
+    var mvcResult = doGet("/capabilities/{id}?includeDummy=true", id).andReturn();
+    return parseResponse(mvcResult, Capability.class);
+  }
+
+  private static Capabilities getCapabilitiesByPermission(String permission) throws Exception {
+    var mvcResult = doGet("/capabilities?includeDummy=true&query=permission==" + permission).andReturn();
+    return parseResponse(mvcResult, Capabilities.class);
+  }
+
+  private static ConditionFactory await() {
+    return Awaitility.await().atMost(ONE_MINUTE).pollInterval(FIVE_HUNDRED_MILLISECONDS);
+  }
+}

--- a/src/test/java/org/folio/roles/it/KafkaCapabilityEventUpsertIT.java
+++ b/src/test/java/org/folio/roles/it/KafkaCapabilityEventUpsertIT.java
@@ -1,0 +1,113 @@
+package org.folio.roles.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Durations.FIVE_HUNDRED_MILLISECONDS;
+import static org.awaitility.Durations.ONE_MINUTE;
+import static org.folio.roles.support.TestConstants.TENANT_ID;
+import static org.folio.roles.utils.TestValues.readValue;
+import static org.folio.test.TestUtils.parseResponse;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
+
+import java.util.UUID;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionFactory;
+import org.folio.roles.base.BaseIntegrationTest;
+import org.folio.roles.domain.dto.Capabilities;
+import org.folio.roles.domain.dto.Capability;
+import org.folio.roles.domain.dto.CapabilitySet;
+import org.folio.roles.integration.kafka.model.ResourceEvent;
+import org.folio.test.types.IntegrationTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.context.jdbc.Sql;
+
+@IntegrationTest
+@Sql(executionPhase = AFTER_TEST_METHOD, scripts = {
+  "classpath:/sql/truncate-capability-tables.sql",
+  "classpath:/sql/truncate-permission-table.sql"
+})
+class KafkaCapabilityEventUpsertIT extends BaseIntegrationTest {
+
+  private static final UUID CAPABILITY_ID = UUID.fromString("77777777-7777-7777-7777-777777777777");
+  private static final String CORRUPTED_PERMISSION_NAME = "wrong.capability.permission";
+  private static final String CORRECT_CAPABILITY_PERMISSION_NAME = "test.sub-capability.view";
+  private static final UUID DUMMY_CAPABILITY_ID = UUID.fromString("55555555-5555-5555-5555-555555555555");
+  private static final String CORRECT_DUMMY_CAPABILITY_PERMISSION = "test.dummy.capability.view";
+  private static final UUID CAPABILITY_SET_ID = UUID.fromString("88888888-8888-8888-8888-888888888888");
+  private static final String CORRECT_CAPABILITY_SET_PERMISSION = "test.capability-set.all";
+
+  @Autowired private KafkaTemplate<String, Object> kafkaTemplate;
+
+  @BeforeAll
+  static void beforeAll() {
+    enableTenant(TENANT_ID);
+  }
+
+  @AfterAll
+  static void afterAll() {
+    removeTenant(TENANT_ID);
+  }
+
+  @CsvSource({
+    "json/kafka-events/corrupted-capabilities/correct-capability-event-create.json",
+    "json/kafka-events/corrupted-capabilities/correct-capability-event-update.json"
+  })
+  @ParameterizedTest(name = "[{index}] name={0}")
+  @DisplayName("Verify that a corrupted capabilities data is fixed by a new Kafka event")
+  @Sql(scripts = "classpath:/sql/corrupted-capabilities/populate-corrupted-capabilities-and-sets.sql")
+  void handleCapabilityEvent_positive_fixCorruptedCapabilitiesData(String eventPath) throws Exception {
+    // Step 1: Verify initial corrupted state via API
+    var initialCapability = getCapabilityById(CAPABILITY_ID);
+    assertThat(initialCapability.getPermission()).isEqualTo(CORRUPTED_PERMISSION_NAME);
+    var capabilities = getCapabilitiesByPermission(CORRUPTED_PERMISSION_NAME);
+    assertThat(capabilities.getTotalRecords()).isEqualTo(1);
+
+    // Step 2: Send repairing Kafka event
+    sendCapabilityEvent(eventPath);
+
+    // Step 3: Wait and verify that the capability has been repaired
+    await().untilAsserted(() -> {
+      // Assert that the capability has been updated with the correct permission
+      var repearedCapability = getCapabilityById(CAPABILITY_ID);
+      assertThat(repearedCapability.getPermission()).isEqualTo(CORRECT_CAPABILITY_PERMISSION_NAME);
+      assertThat(repearedCapability.getDummyCapability()).isFalse();
+
+      // Assert that the capability set has been updated with the correct permission
+      var capabilitySet = getCapabilitySetById(CAPABILITY_SET_ID);
+      assertThat(capabilitySet.getPermission()).isEqualTo(CORRECT_CAPABILITY_SET_PERMISSION);
+
+      // Assert that the dummy capability has been update with the correct permission
+      var dummyCapability = getCapabilityById(DUMMY_CAPABILITY_ID);
+      assertThat(dummyCapability.getPermission()).isEqualTo(CORRECT_DUMMY_CAPABILITY_PERMISSION);
+    });
+  }
+
+  private void sendCapabilityEvent(String filePath) {
+    var capabilityEvent = readValue(filePath, ResourceEvent.class);
+    kafkaTemplate.send(FOLIO_IT_CAPABILITIES_TOPIC, capabilityEvent);
+  }
+
+  private static Capability getCapabilityById(UUID id) throws Exception {
+    var mvcResult = doGet("/capabilities/{id}", id).andReturn();
+    return parseResponse(mvcResult, Capability.class);
+  }
+
+  private static Capabilities getCapabilitiesByPermission(String permission) throws Exception {
+    var mvcResult = doGet("/capabilities?includeDummy=true&query=permission==" + permission).andReturn();
+    return parseResponse(mvcResult, Capabilities.class);
+  }
+
+  private static CapabilitySet getCapabilitySetById(UUID id) throws Exception {
+    var mvcResult = doGet("/capability-sets/{id}", id).andReturn();
+    return parseResponse(mvcResult, CapabilitySet.class);
+  }
+
+  private static ConditionFactory await() {
+    return Awaitility.await().atMost(ONE_MINUTE).pollInterval(FIVE_HUNDRED_MILLISECONDS);
+  }
+}

--- a/src/test/java/org/folio/roles/service/capability/CapabilityResolverTest.java
+++ b/src/test/java/org/folio/roles/service/capability/CapabilityResolverTest.java
@@ -1,0 +1,79 @@
+package org.folio.roles.service.capability;
+
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.folio.roles.support.CapabilityUtils.capability;
+import static org.mockito.Mockito.when;
+
+import org.folio.roles.service.permission.PermissionOverrider;
+import org.folio.roles.support.TestUtils;
+import org.folio.test.types.UnitTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class CapabilityResolverTest {
+
+  @InjectMocks private CapabilityResolver capabilityResolver;
+  @Mock private PermissionOverrider permissionOverrider;
+
+  @BeforeEach
+  void setUp() {
+    when(permissionOverrider.getPermissionMappings()).thenReturn(emptyMap());
+  }
+
+  @AfterEach
+  void tearDown() {
+    TestUtils.verifyNoMoreInteractions(this);
+  }
+
+  @Nested
+  @DisplayName("isCapabilityPermissionCorrupted")
+  class IsCapabilityPermissionCorrupted {
+
+    @Test
+    @DisplayName("positive - should return false for not corrupted capability")
+    void positive_shouldReturnFalse() {
+      var capability = capability();
+      capability.setName("test_resource_items_get.execute");
+      capability.setPermission("test.resource.items.get");
+
+      var result = capabilityResolver.isCapabilityPermissionCorrupted(capability);
+
+      assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("negative - should return true for corrupted capability")
+    void negative_shouldReturnTrue() {
+      var capability = capability();
+      capability.setName("wrong.name");
+      capability.setPermission("test.resource.item.get");
+
+      var result = capabilityResolver.isCapabilityPermissionCorrupted(capability);
+
+      assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("negative - should throw exception for invalid permission format")
+    void negative_shouldThrowException() {
+      var capability = capability();
+      capability.setName("any.name");
+      capability.setPermission("invalid-permission-format");
+
+      assertThatThrownBy(() -> capabilityResolver.isCapabilityPermissionCorrupted(capability))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Permission data is missing required fields: invalid-permission-format");
+    }
+  }
+}

--- a/src/test/resources/json/kafka-events/corrupted-capabilities/correct-capability-event-create.json
+++ b/src/test/resources/json/kafka-events/corrupted-capabilities/correct-capability-event-create.json
@@ -1,0 +1,37 @@
+{
+  "type": "CREATE",
+  "tenant": "test",
+  "resourceName": "Capability",
+  "new": {
+    "moduleId": "test-module-1.0.0",
+    "applicationId": "test-app-1.0.0",
+    "resources": [
+      {
+        "permission": {
+          "permissionName": "test.sub-capability.view",
+          "displayName": "Test Sub-Capability View",
+          "description": "A corrected capability from an event",
+          "visible": true
+        },
+        "endpoints": [
+          {
+            "path": "/test/sub-capability",
+            "method": "GET"
+          }
+        ]
+      },
+      {
+        "permission": {
+          "permissionName": "test.capability-set.all",
+          "displayName": "Test Sub-Capability Edit",
+          "description": "A corrected capability from an event",
+          "subPermissions": [
+            "test.sub-capability.view",
+            "test.dummy.capability.view"
+          ],
+          "visible": true
+        }
+      }
+    ]
+  }
+}

--- a/src/test/resources/json/kafka-events/corrupted-capabilities/correct-capability-event-update.json
+++ b/src/test/resources/json/kafka-events/corrupted-capabilities/correct-capability-event-update.json
@@ -1,0 +1,70 @@
+{
+  "type": "UPDATE",
+  "tenant": "test",
+  "resourceName": "Capability",
+  "new": {
+    "moduleId": "test-module-2.0.0",
+    "applicationId": "test-app-2.0.0",
+    "resources": [
+      {
+        "permission": {
+          "permissionName": "test.sub-capability.view",
+          "displayName": "Test Sub-Capability View",
+          "description": "A corrected capability from an event",
+          "visible": true
+        },
+        "endpoints": [
+          {
+            "path": "/test/sub-capability",
+            "method": "GET"
+          }
+        ]
+      },
+      {
+        "permission": {
+          "permissionName": "test.capability-set.all",
+          "displayName": "Test Sub-Capability Edit",
+          "description": "A corrected capability from an event",
+          "subPermissions": [
+            "test.sub-capability.view",
+            "test.dummy.capability.view"
+          ],
+          "visible": true
+        }
+      }
+    ]
+  },
+  "old": {
+    "moduleId": "test-module-1.0.0",
+    "applicationId": "test-app-1.0.0",
+    "resources": [
+      {
+        "permission": {
+          "permissionName": "test.sub-capability.view",
+          "displayName": "Test Sub-Capability View",
+          "description": "A corrected capability from an event",
+          "visible": true
+        },
+        "endpoints": [
+          {
+            "path": "/test/sub-capability",
+            "method": "GET"
+          }
+        ]
+      },
+      {
+        "permission": {
+          "permissionName": "test.capability-set.all",
+          "displayName": "Test Sub-Capability Edit",
+          "description": "A corrected capability from an event",
+          "subPermissions": [
+            "test.sub-capability.view",
+            "test.dummy.capability.view",
+            "new.dummy.capability.view"
+          ],
+          "visible": true
+        }
+      }
+    ]
+  }
+}

--- a/src/test/resources/json/kafka-events/corrupted-capabilities/replacement-event-create.json
+++ b/src/test/resources/json/kafka-events/corrupted-capabilities/replacement-event-create.json
@@ -1,0 +1,20 @@
+{
+  "type": "CREATE",
+  "tenant": "test",
+  "resourceName": "Capability",
+  "new": {
+    "moduleId": "mod-items-1.0.0",
+    "applicationId": "app-items-1.0.0",
+    "resources": [
+      {
+        "permission": {
+          "permissionName": "upgraded-feature.item.manage",
+          "displayName": "Upgraded Feature",
+          "replaces": [
+            "old-feature.item.view"
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/src/test/resources/json/kafka-events/corrupted-capabilities/replacement-event-update.json
+++ b/src/test/resources/json/kafka-events/corrupted-capabilities/replacement-event-update.json
@@ -1,0 +1,35 @@
+{
+  "type": "UPDATE",
+  "tenant": "test",
+  "resourceName": "Capability",
+  "new": {
+    "moduleId": "mod-items-2.0.0",
+    "applicationId": "app-items-2.0.0",
+    "resources": [
+      {
+        "permission": {
+          "permissionName": "upgraded-feature.item.manage",
+          "displayName": "Upgraded Feature",
+          "replaces": [
+            "old-feature.item.view"
+          ]
+        }
+      }
+    ]
+  },
+  "old": {
+    "moduleId": "mod-items-1.0.0",
+    "applicationId": "app-items-1.0.0",
+    "resources": [
+      {
+        "permission": {
+          "permissionName": "upgraded-feature.item.manage",
+          "displayName": "Upgraded Feature",
+          "replaces": [
+            "old-feature.item.view"
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/src/test/resources/json/keycloak/role-loadable-processing-realm.json
+++ b/src/test/resources/json/keycloak/role-loadable-processing-realm.json
@@ -341,6 +341,24 @@
                 "name": "GET"
               }
             ]
+          },
+          {
+            "name": "/nested/items",
+            "ownerManagedAccess": false,
+            "attributes": {
+              "folio_permissions": [
+                "GET#nested.permission.get"
+              ]
+            },
+            "_id": "a1b2c3d4-e5f6-7890-1234-567890abcdee",
+            "uris": [
+              "/nested/items"
+            ],
+            "scopes": [
+              {
+                "name": "GET"
+              }
+            ]
           }
         ],
         "scopes": [

--- a/src/test/resources/sql/corrupted-capabilities/populate-corrupted-capabilities-and-sets.sql
+++ b/src/test/resources/sql/corrupted-capabilities/populate-corrupted-capabilities-and-sets.sql
@@ -1,0 +1,42 @@
+SET SEARCH_PATH = 'test_mod_roles_keycloak';
+
+-- Create a capability set that is has a wrong folio_permission
+INSERT INTO capability_set (id, name, resource, action, type, folio_permission, application_id, module_id)
+VALUES ('88888888-8888-8888-8888-888888888888',
+        'test_capability-set_all.execute',
+        'Test Capability Set',
+        'MANAGE',
+        'DATA',
+        'wrong.capability-set.permission', -- this is wrong, it should be 'test.capability-set.all'
+        'test-app-1.0.0',
+        'test-module-1.0.0');
+
+-- Create a capability that is part of the capability set and has a wrong folio_permission
+INSERT INTO capability (id, name, resource, action, type, folio_permission, dummy_capability, application_id, module_id)
+VALUES ('77777777-7777-7777-7777-777777777777', -- corrupted "real" capability
+        'test_sub-capability_view.execute',
+        'Dummy Resource',
+        'VIEW',
+        'DATA',
+        'wrong.capability.permission', -- this is wrong, it should be 'test.sub-capability.view'
+        false,
+        'test-app-1.0.0',
+        'test-module-1.0.0'),
+        ('66666666-6666-6666-6666-666666666666', -- technical capability for the capability set
+        'test_capability-set_all.execute',
+        'Test Capability Set',
+        'MANAGE',
+        'DATA',
+        'wrong.capability-set.permission',
+        false,
+        'test-app-1.0.0',
+        'test-module-1.0.0'),
+        ('55555555-5555-5555-5555-555555555555', -- corrupted "dummy" capability
+        'test_dummy_capability_view.execute',
+        'Dummy Resource',
+        'VIEW',
+        'DATA',
+        'wrong.dummy.capability.view', -- this is wrong, it should be 'test.dummy.capability.view'
+        true,
+        'test-app-1.0.0',
+        'test-module-1.0.0');

--- a/src/test/resources/sql/corrupted-capabilities/populate-data-replacement.sql
+++ b/src/test/resources/sql/corrupted-capabilities/populate-data-replacement.sql
@@ -1,0 +1,24 @@
+SET SEARCH_PATH = 'test_mod_roles_keycloak';
+
+INSERT INTO capability (id, name, resource, action, type, folio_permission, dummy_capability, application_id, module_id)
+VALUES ('00000000-0000-0000-0000-000000000002',
+        'old-feature.item.view',
+        'Old Feature Item',
+        'VIEW',
+        'DATA',
+        'old-feature.item.view', -- correct permission
+        false,
+        'old-module-1.0.0',
+        'old-app-1.0.0');
+
+-- The bug caused its 'folio_permission' to point to the OLD feature's permission
+INSERT INTO capability (id, name, resource, action, type, folio_permission, dummy_capability, application_id, module_id)
+VALUES ('00000000-0000-0000-0000-000000000001',
+        'new-feature.item.view', -- The name is for a new feature
+        'Dummy New Feature',
+        'VIEW',
+        'DATA',
+        'old-feature.item.view', -- this is wrong folio_permission. It should be 'new-feature.item.view'
+        true,
+        'new-module-1.0.0',
+        'new-app-1.0.0');


### PR DESCRIPTION
### **Purpose**
For existing systems, the database likely contains corrupted data from the old logic. We need to analyze this and create a strategy to fix the old dummy capabilities that have the wrong folio_permission.

https://folio-org.atlassian.net/browse/MODROLESKC-316
### **Approach**
- update corrupted capabilities
- add tests that cover updating corrupted records
- skip deletion of corrupted capabilities 

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [x] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
