### PR TITLE
MODROLESKC-326 - revert Use SECURE_STORE_ENV, not ENV, for secure store key

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,6 @@
 * Add integration test for replace cross-module dummy capabilities (MODROLESKC-305)
 * Fix corrupted capabilities during Kafka event processing (MODROLESKC-316)
 * Add fetchRoles config parameter for policies to fetch keycloak roles (MODROLESKC-325)
-* Use SECURE_STORE_ENV, not ENV, for secure store key (MODROLESKC-326)
 
 ## Version `v3.0.0` (14.03.2025)
 * Error with roles migration (MODROLESKC-282)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mod-roles-keycloak
 
-Copyright (C) 2023-2025 The Open Library Foundation
+Copyright (C) 2023-2023 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License, Version 2.0. See the file "[LICENSE](LICENSE)" for
 more information.
@@ -45,10 +45,6 @@ metadata about who and when created a record.
 See also configurations from https://github.com/folio-org/folio-spring-support/tree/release/v8.1/folio-spring-system-user - FOLIO_ENVIRONMENT, FOLIO_OKAPI_URL, FOLIO_SYSTEM_USER_USERNAME, FOLIO_SYSTEM_USER_PASSWORD.
 
 ### Secure storage environment variables
-
-| Name                | Default value | Description                                                                                                                                                    |
-|:--------------------|:--------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| SECURE_STORE_ENV    | folio         | First segment of the secure store key, for example `prod` or `test`. Defaults to `folio`. In Ramsons and Sunflower defaults to ENV with fall-back `folio`.     |
 
 #### AWS-SSM
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -78,7 +78,6 @@ application:
     migration:
       users-batch-size: ${KC_MIGRATION_USERS_BATCH_SIZE:100}
   secret-store:
-    environment: ${SECURE_STORE_ENV:folio}
     type: ${SECRET_STORE_TYPE}
     aws-ssm:
       region: ${SECRET_STORE_AWS_SSM_REGION:}


### PR DESCRIPTION
### **Purpose**
Revert Use SECURE_STORE_ENV, not ENV, for secure store key

### **Approach**
Revert Use SECURE_STORE_ENV, not ENV, for secure store key 

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
