### PR TITLE
MODROLESKC-308: Role with null description becomes invalid

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 * Fix corrupted capabilities during Kafka event processing (MODROLESKC-316)
 * Add fetchRoles config parameter for policies to fetch keycloak roles (MODROLESKC-325)
 * Use SECURE_STORE_ENV, not ENV, for secure store key (MODROLESKC-326)
+* Role with null description becomes invalid (MODROLESKC-308)
 
 ## Version `v3.0.0` (14.03.2025)
 * Error with roles migration (MODROLESKC-282)

--- a/src/main/java/org/folio/roles/mapper/LoadableRoleMapper.java
+++ b/src/main/java/org/folio/roles/mapper/LoadableRoleMapper.java
@@ -19,6 +19,7 @@ import org.springframework.data.domain.Page;
 public interface LoadableRoleMapper {
 
   @AuditableEntityMapping
+  @Mapping(target = "description", source = "role.description", defaultValue = "")
   LoadableRoleEntity toRoleEntity(LoadableRole role);
 
   List<LoadableRoleEntity> toRoleEntity(List<LoadableRole> role);

--- a/src/main/java/org/folio/roles/mapper/entity/RoleEntityMapper.java
+++ b/src/main/java/org/folio/roles/mapper/entity/RoleEntityMapper.java
@@ -21,6 +21,7 @@ public interface RoleEntityMapper {
 
   @AuditableEntityMapping
   @Mapping(target = "type", source = "role.type", defaultValue = "REGULAR")
+  @Mapping(target = "description", source = "role.description", defaultValue = "")
   RoleEntity toRoleEntity(Role role);
 
   /**

--- a/src/test/java/org/folio/roles/it/RoleKeycloakIT.java
+++ b/src/test/java/org/folio/roles/it/RoleKeycloakIT.java
@@ -256,6 +256,48 @@ class RoleKeycloakIT extends BaseIntegrationTest {
       .andExpect(jsonPath("$.errors[0].code", is("not_found_error")));
   }
 
+  @Test
+  @KeycloakRealms("classpath:json/keycloak/test-realm.json")
+  void createRole_withNullDescription_positive() throws Exception {
+    var roleToCreate = new Role().name("test role null desc");
+    var roleToCreateAsJson = asJsonString(roleToCreate);
+    var result = mockMvc.perform(post("/roles")
+        .content(roleToCreateAsJson)
+        .header(TENANT, TENANT_ID)
+        .header(USER_ID, USER_ID_HEADER)
+        .contentType(APPLICATION_JSON))
+      .andExpect(status().isCreated())
+      .andExpect(jsonPath("$.id").value(notNullValue()))
+      .andExpect(jsonPath("$.name").value("test role null desc"))
+      .andExpect(jsonPath("$.description").value(""))
+      .andExpect(jsonPath("$.metadata.createdByUserId").value(equalTo(USER_ID_HEADER)))
+      .andReturn();
+
+    var createdRole = parseResponse(result, Role.class);
+    assertNotNull(createdRole.getDescription());
+    assertEquals("", createdRole.getDescription());
+  }
+
+  @Test
+  @KeycloakRealms("classpath:json/keycloak/test-realm.json")
+  void createRole_withEmptyDescription_positive() throws Exception {
+    var roleToCreate = new Role().name("test role empty desc").description("");
+    var result = mockMvc.perform(post("/roles")
+        .content(asJsonString(roleToCreate))
+        .header(TENANT, TENANT_ID)
+        .header(USER_ID, USER_ID_HEADER)
+        .contentType(APPLICATION_JSON))
+      .andExpect(status().isCreated())
+      .andExpect(jsonPath("$.id").value(notNullValue()))
+      .andExpect(jsonPath("$.name").value("test role empty desc"))
+      .andExpect(jsonPath("$.description").value(""))
+      .andReturn();
+
+    var createdRole = parseResponse(result, Role.class);
+    assertNotNull(createdRole.getDescription());
+    assertEquals("", createdRole.getDescription());
+  }
+
   private static Date timestampFrom(String value) {
     return Date.from(LocalDateTime.parse(value).atZone(systemDefault()).toInstant());
   }

--- a/src/test/java/org/folio/roles/service/role/RoleServiceTest.java
+++ b/src/test/java/org/folio/roles/service/role/RoleServiceTest.java
@@ -142,6 +142,32 @@ class RoleServiceTest {
       verifyNoInteractions(keycloakService);
       verifyNoInteractions(entityService);
     }
+
+    @Test
+    void create_withNullDescription() {
+      var role = role();
+      role.setDescription(null);
+      when(keycloakService.create(role)).thenReturn(role);
+      when(entityService.create(role)).thenReturn(role);
+
+      facade.create(role);
+
+      verify(keycloakService).create(role);
+      verify(entityService).create(role);
+    }
+
+    @Test
+    void create_withEmptyDescription() {
+      var role = role();
+      role.setDescription("");
+      when(keycloakService.create(role)).thenReturn(role);
+      when(entityService.create(role)).thenReturn(role);
+
+      facade.create(role);
+
+      verify(keycloakService).create(role);
+      verify(entityService).create(role);
+    }
   }
 
   @Nested


### PR DESCRIPTION
###  Purpose
Fix database constraint violation when creating a role with a null description. This resolves the issue where attempting to make a role without a description field results in a PSQLException: null value in column "description" of relation "role" violates not-null constraint, leaving the role partially created in Keycloak but not in the database, requiring manual cleanup.

Related issue: [MODROLESKC-308](https://folio-org.atlassian.net/browse/MODROLESKC-308) 

   Problem Details:

     - When a role is created with description: null, the database rejects it due to a NOT NULL constraint
     - This causes a partial failure where the role is created in Keycloak but not in the database
     - Subsequent attempts to create the role with a description fail with HTTP 409 Conflict
     - Manual removal from Keycloak is required to recover

   Expected Behavior:

     - Roles should be successfully created with null or empty descriptions without validation errors
     - The description should default to an empty string when not provided

###    Approach

   Added default value mappings to MapStruct entity mappers to automatically
   convert null descriptions to empty strings before persisting to the database.


---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
