### PR TITLE
MODROLESKC-384: Improve cleanup of keycloak records upon role removal

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## Version `v4.1.0` (in progress)
+* Improve cleanup of keycloak records upon role removal (MODROLESKC-384)
+
 ## Version `v4.0.0` (16.04.2025)
 * Added endpoint to create or update default roles via REST API (MODROLESKC-301)
 * Introduce configuration for FSSP (APPPOCTOOL-59)

--- a/src/main/java/org/folio/roles/repository/UserRoleRepository.java
+++ b/src/main/java/org/folio/roles/repository/UserRoleRepository.java
@@ -12,9 +12,13 @@ public interface UserRoleRepository extends JpaCqlRepository<UserRoleEntity, Use
 
   List<UserRoleEntity> findByUserId(UUID userId);
 
+  List<UserRoleEntity> findByRoleId(UUID roleId);
+
   List<UserRoleEntity> findByUserIdAndRoleIdIn(UUID userId, List<UUID> roleIds);
 
   void deleteByUserId(UUID userId);
+
+  void deleteByRoleId(UUID roleId);
 
   void deleteByUserIdAndRoleIdIn(UUID userId, List<UUID> roleIds);
 }

--- a/src/main/java/org/folio/roles/service/permission/RolePermissionService.java
+++ b/src/main/java/org/folio/roles/service/permission/RolePermissionService.java
@@ -1,13 +1,13 @@
 package org.folio.roles.service.permission;
 
-import static java.lang.String.format;
 import static org.apache.commons.collections4.CollectionUtils.isEmpty;
 import static org.folio.roles.domain.dto.PolicyType.ROLE;
 import static org.folio.roles.service.permission.PermissionService.convertToString;
+import static org.folio.roles.service.role.RolePolicyNameProvider.getPermissionNameGenerator;
+import static org.folio.roles.service.role.RolePolicyNameProvider.getPolicyName;
 
 import java.util.List;
 import java.util.UUID;
-import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.folio.roles.domain.dto.Endpoint;
@@ -64,14 +64,6 @@ public class RolePermissionService implements PermissionService {
   @Transactional(readOnly = true)
   public List<Endpoint> getAssignedEndpoints(UUID roleId, List<UUID> excludedCapabilityIds, List<UUID> excludedSetIds) {
     return capabilityEndpointService.getRoleAssignedEndpoints(roleId, excludedCapabilityIds, excludedSetIds);
-  }
-
-  private static Function<Endpoint, String> getPermissionNameGenerator(UUID roleId) {
-    return endpoint -> format("%s access for role '%s' to '%s'", endpoint.getMethod(), roleId, endpoint.getPath());
-  }
-
-  private static String getPolicyName(UUID roleId) {
-    return "Policy for role: " + roleId;
   }
 
   private static Policy createNewRolePolicy(UUID roleId) {

--- a/src/main/java/org/folio/roles/service/role/RolePolicyNameProvider.java
+++ b/src/main/java/org/folio/roles/service/role/RolePolicyNameProvider.java
@@ -1,0 +1,37 @@
+package org.folio.roles.service.role;
+
+import static java.lang.String.format;
+
+import java.util.UUID;
+import java.util.function.Function;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.folio.roles.domain.dto.Endpoint;
+
+/**
+ * Centralized naming convention for the auto-generated Keycloak policy and permissions
+ * associated with a role.
+ *
+ * <p>Both {@code RoleService} (cleanup on role deletion) and
+ * {@code RolePermissionService} (creation/deletion of role permissions) must agree on these
+ * names. Keeping them in one place prevents silent drift that would cause cleanup to skip
+ * records it should remove.</p>
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class RolePolicyNameProvider {
+
+  /**
+   * Returns the canonical name of the Keycloak policy that backs the given role.
+   */
+  public static String getPolicyName(UUID roleId) {
+    return "Policy for role: " + roleId;
+  }
+
+  /**
+   * Returns a function that, given an endpoint, produces the canonical Keycloak permission
+   * name for the role/endpoint pair.
+   */
+  public static Function<Endpoint, String> getPermissionNameGenerator(UUID roleId) {
+    return endpoint -> format("%s access for role '%s' to '%s'", endpoint.getMethod(), roleId, endpoint.getPath());
+  }
+}

--- a/src/main/java/org/folio/roles/service/role/RoleService.java
+++ b/src/main/java/org/folio/roles/service/role/RoleService.java
@@ -1,15 +1,15 @@
 package org.folio.roles.service.role;
 
-import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static org.folio.common.utils.CollectionUtils.mapItems;
 import static org.folio.roles.domain.dto.PolicyType.ROLE;
+import static org.folio.roles.service.role.RolePolicyNameProvider.getPermissionNameGenerator;
+import static org.folio.roles.service.role.RolePolicyNameProvider.getPolicyName;
 
 import jakarta.persistence.EntityNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.collections4.ListUtils;
@@ -158,17 +158,15 @@ public class RoleService {
     var actualRole = entityService.getById(id);
     checkIfRoleHasDefaultType(actualRole);
     var cleanupData = cleanupRoleData(actualRole);
-    var roleDeletedFromDb = false;
     try {
       entityService.deleteById(id);
-      roleDeletedFromDb = true;
       keycloakService.deleteById(id);
     } catch (Exception e) {
-      log.debug("Rollback deleted policy in db: id = {}, name = {}", actualRole.getId(), actualRole.getName());
+      log.debug("Rollback role deletion: id = {}, name = {}", actualRole.getId(), actualRole.getName());
+      // DB-side state (role row, policy row, user_role rows) is restored automatically by the
+      // surrounding @Transactional rollback. We only need to compensate the Keycloak-side
+      // mutations performed by cleanupRoleData (user-role unlinks + policy/permissions deletion).
       rollbackRoleCleanup(actualRole, cleanupData);
-      if (roleDeletedFromDb) {
-        entityService.create(actualRole);
-      }
       throw e;
     }
   }
@@ -254,6 +252,9 @@ public class RoleService {
         keycloakPolicyService.create(policy);
       }
       if (cleanupData.permissionsDeletionAttempted) {
+        // createPermission() in KeycloakAuthorizationService treats Keycloak 409 CONFLICT as
+        // success, so re-creating the full set of permissions is safe even when only a subset
+        // was actually deleted before the original failure.
         keycloakAuthService.createPermissions(policy, cleanupData.endpoints, getPermissionNameGenerator(roleId));
       }
     } catch (Exception e) {
@@ -267,14 +268,6 @@ public class RoleService {
 
   private static Roles buildRoles(PageResult<Role> roles) {
     return new Roles().roles(roles.getRecords()).totalRecords(roles.getTotalRecords());
-  }
-
-  private static Function<Endpoint, String> getPermissionNameGenerator(UUID roleId) {
-    return endpoint -> format("%s access for role '%s' to '%s'", endpoint.getMethod(), roleId, endpoint.getPath());
-  }
-
-  private static String getPolicyName(UUID roleId) {
-    return "Policy for role: " + roleId;
   }
 
   private static void checkIfRoleHasDefaultType(Role role) {

--- a/src/main/java/org/folio/roles/service/role/RoleService.java
+++ b/src/main/java/org/folio/roles/service/role/RoleService.java
@@ -289,7 +289,7 @@ public class RoleService {
     return RoleType.DEFAULT == role.getType();
   }
 
-  private static class RoleCleanupData {
+  private static final class RoleCleanupData {
 
     private final List<UUID> unlinkedUserIds = new ArrayList<>();
     private Policy policy;

--- a/src/main/java/org/folio/roles/service/role/RoleService.java
+++ b/src/main/java/org/folio/roles/service/role/RoleService.java
@@ -1,20 +1,34 @@
 package org.folio.roles.service.role;
 
+import static java.lang.String.format;
+import static java.util.Collections.emptyList;
 import static org.folio.common.utils.CollectionUtils.mapItems;
+import static org.folio.roles.domain.dto.PolicyType.ROLE;
 
 import jakarta.persistence.EntityNotFoundException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.collections4.ListUtils;
+import org.folio.roles.domain.dto.Endpoint;
+import org.folio.roles.domain.dto.Policy;
 import org.folio.roles.domain.dto.Role;
 import org.folio.roles.domain.dto.RoleType;
 import org.folio.roles.domain.dto.Roles;
+import org.folio.roles.domain.dto.UserRole;
 import org.folio.roles.domain.model.PageResult;
 import org.folio.roles.exception.RequestValidationException;
 import org.folio.roles.exception.ServiceException;
+import org.folio.roles.integration.keyclock.KeycloakAuthorizationService;
+import org.folio.roles.integration.keyclock.KeycloakPolicyService;
 import org.folio.roles.integration.keyclock.KeycloakRoleService;
+import org.folio.roles.integration.keyclock.KeycloakRolesUserService;
+import org.folio.roles.service.capability.CapabilityEndpointService;
+import org.folio.roles.service.policy.PolicyEntityService;
+import org.folio.roles.service.policy.PolicyService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
@@ -25,7 +39,14 @@ import org.springframework.util.Assert;
 public class RoleService {
 
   private final KeycloakRoleService keycloakService;
+  private final KeycloakRolesUserService keycloakRolesUserService;
+  private final KeycloakAuthorizationService keycloakAuthService;
+  private final KeycloakPolicyService keycloakPolicyService;
   private final RoleEntityService entityService;
+  private final UserRoleEntityService userRoleEntityService;
+  private final PolicyEntityService policyEntityService;
+  private final PolicyService policyService;
+  private final CapabilityEndpointService capabilityEndpointService;
 
   /**
    * Find one role by ID.
@@ -136,13 +157,107 @@ public class RoleService {
   public void deleteById(UUID id) {
     var actualRole = entityService.getById(id);
     checkIfRoleHasDefaultType(actualRole);
-    entityService.deleteById(id);
+    var cleanupData = cleanupRoleData(actualRole);
+    var roleDeletedFromDb = false;
     try {
+      entityService.deleteById(id);
+      roleDeletedFromDb = true;
       keycloakService.deleteById(id);
     } catch (Exception e) {
       log.debug("Rollback deleted policy in db: id = {}, name = {}", actualRole.getId(), actualRole.getName());
-      entityService.create(actualRole);
+      rollbackRoleCleanup(actualRole, cleanupData);
+      if (roleDeletedFromDb) {
+        entityService.create(actualRole);
+      }
       throw e;
+    }
+  }
+
+  private RoleCleanupData cleanupRoleData(Role role) {
+    var roleId = role.getId();
+    var cleanupData = new RoleCleanupData();
+    var policy = findRolePolicy(roleId);
+    if (policy != null) {
+      cleanupData.policy = policy;
+      cleanupData.endpoints = capabilityEndpointService.getRoleAssignedEndpoints(roleId, emptyList(), emptyList());
+    }
+
+    try {
+      cleanupUsersFromRole(role, cleanupData);
+      userRoleEntityService.deleteByRoleId(roleId);
+      deleteRolePolicyData(roleId, cleanupData);
+      return cleanupData;
+    } catch (Exception e) {
+      rollbackRoleCleanup(role, cleanupData);
+      throw e;
+    }
+  }
+
+  private void cleanupUsersFromRole(Role role, RoleCleanupData cleanupData) {
+    var roleId = role.getId();
+    var assignedUserRoles = userRoleEntityService.findByRoleId(roleId);
+    for (var userId : mapItems(assignedUserRoles, UserRole::getUserId)) {
+      keycloakRolesUserService.unlinkRolesFromUser(userId, List.of(role));
+      cleanupData.unlinkedUserIds.add(userId);
+    }
+  }
+
+  private Policy findRolePolicy(UUID roleId) {
+    var policyName = getPolicyName(roleId);
+    var policyOptional = policyEntityService.findByName(policyName);
+    if (policyOptional.isEmpty()) {
+      log.debug("Role policy is not found. Cleanup of permissions and policy is skipped: roleId = {}", roleId);
+      return null;
+    }
+
+    var policy = policyOptional.get();
+    if (policy.getType() != ROLE) {
+      log.warn("Role policy has unexpected type. Cleanup of permissions and policy is skipped: roleId = {}, type = {}",
+        roleId, policy.getType());
+      return null;
+    }
+
+    return policy;
+  }
+
+  private void deleteRolePolicyData(UUID roleId, RoleCleanupData cleanupData) {
+    var policy = cleanupData.policy;
+    if (policy == null) {
+      return;
+    }
+
+    cleanupData.permissionsDeletionAttempted = true;
+    keycloakAuthService.deletePermissions(policy, cleanupData.endpoints, getPermissionNameGenerator(roleId));
+    policyService.deleteById(policy.getId());
+    cleanupData.policyDeleted = true;
+  }
+
+  private void rollbackRoleCleanup(Role role, RoleCleanupData cleanupData) {
+    rollbackRolePolicyCleanup(role.getId(), cleanupData);
+    for (var userId : cleanupData.unlinkedUserIds) {
+      try {
+        keycloakRolesUserService.assignRolesToUser(userId, List.of(role));
+      } catch (Exception e) {
+        log.warn("Failed to restore role assignment in Keycloak: roleId = {}, userId = {}", role.getId(), userId, e);
+      }
+    }
+  }
+
+  private void rollbackRolePolicyCleanup(UUID roleId, RoleCleanupData cleanupData) {
+    var policy = cleanupData.policy;
+    if (policy == null) {
+      return;
+    }
+
+    try {
+      if (cleanupData.policyDeleted) {
+        keycloakPolicyService.create(policy);
+      }
+      if (cleanupData.permissionsDeletionAttempted) {
+        keycloakAuthService.createPermissions(policy, cleanupData.endpoints, getPermissionNameGenerator(roleId));
+      }
+    } catch (Exception e) {
+      log.warn("Failed to restore role policy data in Keycloak: roleId = {}", roleId, e);
     }
   }
 
@@ -152,6 +267,14 @@ public class RoleService {
 
   private static Roles buildRoles(PageResult<Role> roles) {
     return new Roles().roles(roles.getRecords()).totalRecords(roles.getTotalRecords());
+  }
+
+  private static Function<Endpoint, String> getPermissionNameGenerator(UUID roleId) {
+    return endpoint -> format("%s access for role '%s' to '%s'", endpoint.getMethod(), roleId, endpoint.getPath());
+  }
+
+  private static String getPolicyName(UUID roleId) {
+    return "Policy for role: " + roleId;
   }
 
   private static void checkIfRoleHasDefaultType(Role role) {
@@ -164,5 +287,14 @@ public class RoleService {
 
   private static boolean hasDefaultRoleType(Role role) {
     return RoleType.DEFAULT == role.getType();
+  }
+
+  private static class RoleCleanupData {
+
+    private final List<UUID> unlinkedUserIds = new ArrayList<>();
+    private Policy policy;
+    private List<Endpoint> endpoints = emptyList();
+    private boolean permissionsDeletionAttempted;
+    private boolean policyDeleted;
   }
 }

--- a/src/main/java/org/folio/roles/service/role/UserRoleEntityService.java
+++ b/src/main/java/org/folio/roles/service/role/UserRoleEntityService.java
@@ -78,9 +78,20 @@ public class UserRoleEntityService {
     log.debug("User roles have been deleted: userId = {}", userId);
   }
 
+  public void deleteByRoleId(UUID roleId) {
+    repository.deleteByRoleId(roleId);
+    log.debug("User roles have been deleted: roleId = {}", roleId);
+  }
+
   @Transactional(readOnly = true)
   public List<UserRole> findByUserId(UUID userId) {
     var rolesUserEntity = repository.findByUserId(userId);
+    return mapper.toDto(rolesUserEntity);
+  }
+
+  @Transactional(readOnly = true)
+  public List<UserRole> findByRoleId(UUID roleId) {
+    var rolesUserEntity = repository.findByRoleId(roleId);
     return mapper.toDto(rolesUserEntity);
   }
 

--- a/src/test/java/org/folio/roles/KeycloakTestClient.java
+++ b/src/test/java/org/folio/roles/KeycloakTestClient.java
@@ -65,7 +65,7 @@ public class KeycloakTestClient {
   public List<String> getPermissionNames() {
     var headers = Map.<String, Collection<String>>of(TENANT, List.of(TENANT_ID));
     try (var ignored = new FolioExecutionContextSetter(folioModuleMetadata, headers)) {
-      var keycloakPermissions = findKeycloakPermissions();
+      var keycloakPermissions = findKeycloakAuthorizationNames("permission");
       log.info("Found permissions: {}", keycloakPermissions);
       return keycloakPermissions;
     } catch (Exception exception) {
@@ -73,8 +73,20 @@ public class KeycloakTestClient {
     }
   }
 
-  private List<String> findKeycloakPermissions() throws Exception {
-    var request = keycloakPermissionsRequest();
+  @SneakyThrows
+  public List<String> getPolicyNames() {
+    var headers = Map.<String, Collection<String>>of(TENANT, List.of(TENANT_ID));
+    try (var ignored = new FolioExecutionContextSetter(folioModuleMetadata, headers)) {
+      var keycloakPolicies = findKeycloakAuthorizationNames("policy");
+      log.info("Found policies: {}", keycloakPolicies);
+      return keycloakPolicies;
+    } catch (Exception exception) {
+      throw new AssertionError("Failed to find keycloak policies", exception);
+    }
+  }
+
+  private List<String> findKeycloakAuthorizationNames(String type) throws Exception {
+    var request = keycloakAuthorizationRequest(type);
     var response = httpClient.send(request, BodyHandlers.ofString());
     assertThat(response.statusCode()).isEqualTo(200);
 
@@ -88,8 +100,8 @@ public class KeycloakTestClient {
       .collect(toList());
   }
 
-  private HttpRequest keycloakPermissionsRequest() {
-    var path = "/admin/realms/{realm}/clients/{clientId}/authz/resource-server/permission";
+  private HttpRequest keycloakAuthorizationRequest(String type) {
+    var path = "/admin/realms/{realm}/clients/{clientId}/authz/resource-server/" + type;
     var uri = fromUriString(keycloakConfiguration.getBaseUrl() + path)
       .queryParam("first", 0)
       .queryParam("last", 100)

--- a/src/test/java/org/folio/roles/it/RoleKeycloakIT.java
+++ b/src/test/java/org/folio/roles/it/RoleKeycloakIT.java
@@ -2,8 +2,8 @@ package org.folio.roles.it;
 
 import static java.time.ZoneId.systemDefault;
 import static java.util.UUID.fromString;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.apache.commons.collections4.IterableUtils.find;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.roles.support.RoleCapabilitySetUtils.roleCapabilitySets;
 import static org.folio.roles.support.TestConstants.TENANT_ID;
 import static org.folio.roles.support.TestConstants.USER_ID_HEADER;
@@ -195,7 +195,8 @@ class RoleKeycloakIT extends BaseIntegrationTest {
     doDelete("/roles/{id}", ROLE_1.getId());
 
     assertThat(kcTestClient.getPolicyNames()).doesNotContain(ROLE_1_POLICY_NAME);
-    assertThat(kcTestClient.getPermissionNames()).doesNotContain(ROLE_1_GET_PERMISSION_NAME, ROLE_1_POST_PERMISSION_NAME);
+    assertThat(kcTestClient.getPermissionNames())
+      .doesNotContain(ROLE_1_GET_PERMISSION_NAME, ROLE_1_POST_PERMISSION_NAME);
 
     attemptGet("/roles/{id}", ROLE_1.getId())
       .andExpect(status().isNotFound())

--- a/src/test/java/org/folio/roles/it/RoleKeycloakIT.java
+++ b/src/test/java/org/folio/roles/it/RoleKeycloakIT.java
@@ -2,6 +2,7 @@ package org.folio.roles.it;
 
 import static java.time.ZoneId.systemDefault;
 import static java.util.UUID.fromString;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.apache.commons.collections4.IterableUtils.find;
 import static org.folio.roles.support.RoleCapabilitySetUtils.roleCapabilitySets;
 import static org.folio.roles.support.TestConstants.TENANT_ID;
@@ -30,6 +31,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.time.LocalDateTime;
 import java.util.Date;
+import java.util.UUID;
+import org.folio.roles.KeycloakTestClient;
 import org.folio.roles.base.BaseIntegrationTest;
 import org.folio.roles.domain.dto.Role;
 import org.folio.roles.domain.dto.RoleType;
@@ -56,6 +59,13 @@ class RoleKeycloakIT extends BaseIntegrationTest {
     .name("role1")
     .description("role1_description");
 
+  private static final String ROLE_1_POLICY_NAME = "Policy for role: " + ROLE_1.getId();
+  private static final String ROLE_1_GET_PERMISSION_NAME =
+    "GET access for role '" + ROLE_1.getId() + "' to '/foo/items/{id}'";
+  private static final String ROLE_1_POST_PERMISSION_NAME =
+    "POST access for role '" + ROLE_1.getId() + "' to '/foo/items'";
+  private static final UUID ROLE_1_USER_ID = fromString("8c6d12fa-33a7-48c9-8769-71168d441345");
+
   private static final Role ROLE_2 = new Role()
     .id(fromString("2e985e76-e9ca-401c-ad8e-0d121a22222e"))
     .name("role2")
@@ -67,6 +77,7 @@ class RoleKeycloakIT extends BaseIntegrationTest {
     .description("role3_description");
 
   @Autowired private Keycloak keycloak;
+  @Autowired private KeycloakTestClient kcTestClient;
 
   @BeforeAll
   static void beforeAll() {
@@ -178,7 +189,13 @@ class RoleKeycloakIT extends BaseIntegrationTest {
     "classpath:/sql/populate-role-policy.sql"
   })
   void deleteRole_positive() throws Exception {
+    assertThat(kcTestClient.getPolicyNames()).contains(ROLE_1_POLICY_NAME);
+    assertThat(kcTestClient.getPermissionNames()).contains(ROLE_1_GET_PERMISSION_NAME, ROLE_1_POST_PERMISSION_NAME);
+
     doDelete("/roles/{id}", ROLE_1.getId());
+
+    assertThat(kcTestClient.getPolicyNames()).doesNotContain(ROLE_1_POLICY_NAME);
+    assertThat(kcTestClient.getPermissionNames()).doesNotContain(ROLE_1_GET_PERMISSION_NAME, ROLE_1_POST_PERMISSION_NAME);
 
     attemptGet("/roles/{id}", ROLE_1.getId())
       .andExpect(status().isNotFound())
@@ -192,7 +209,7 @@ class RoleKeycloakIT extends BaseIntegrationTest {
       .andExpect(jsonPath("$.errors[0].type", is("EntityNotFoundException")))
       .andExpect(jsonPath("$.errors[0].code", is("not_found_error")));
 
-    doGet("/roles/users/{userId}", fromString("8c6d12fa-33a7-48c9-8769-71168d441345"))
+    doGet("/roles/users/{userId}", ROLE_1_USER_ID)
       .andExpect(content().contentType(APPLICATION_JSON))
       .andExpect(content().json(asJsonString(userRoles())));
 

--- a/src/test/java/org/folio/roles/service/role/RoleServiceTest.java
+++ b/src/test/java/org/folio/roles/service/role/RoleServiceTest.java
@@ -3,9 +3,12 @@ package org.folio.roles.service.role;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.folio.roles.domain.dto.HttpMethod.GET;
 import static org.folio.roles.domain.dto.RoleType.CONSORTIUM;
 import static org.folio.roles.domain.dto.RoleType.DEFAULT;
 import static org.folio.roles.domain.dto.RoleType.REGULAR;
+import static org.folio.roles.support.EndpointUtils.endpoint;
+import static org.folio.roles.support.PolicyUtils.rolePolicy;
 import static org.folio.roles.support.RoleUtils.ROLE_DESCRIPTION;
 import static org.folio.roles.support.RoleUtils.ROLE_DESCRIPTION_2;
 import static org.folio.roles.support.RoleUtils.ROLE_DESCRIPTION_3;
@@ -18,10 +21,13 @@ import static org.folio.roles.support.RoleUtils.ROLE_NAME_3;
 import static org.folio.roles.support.RoleUtils.consortiumRole;
 import static org.folio.roles.support.RoleUtils.defaultRole;
 import static org.folio.roles.support.RoleUtils.role;
+import static org.folio.roles.support.TestConstants.USER_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -30,15 +36,28 @@ import static org.mockito.Mockito.when;
 
 import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import org.folio.roles.domain.dto.Endpoint;
 import org.folio.roles.domain.dto.Role;
+import org.folio.roles.domain.dto.UserRole;
 import org.folio.roles.domain.model.PageResult;
 import org.folio.roles.exception.ServiceException;
+import org.folio.roles.integration.keyclock.KeycloakAuthorizationService;
+import org.folio.roles.integration.keyclock.KeycloakPolicyService;
 import org.folio.roles.integration.keyclock.KeycloakRoleService;
+import org.folio.roles.integration.keyclock.KeycloakRolesUserService;
+import org.folio.roles.service.capability.CapabilityEndpointService;
+import org.folio.roles.service.policy.PolicyEntityService;
+import org.folio.roles.service.policy.PolicyService;
 import org.folio.test.types.UnitTest;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -48,9 +67,24 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class RoleServiceTest {
 
   @Mock private KeycloakRoleService keycloakService;
+  @Mock private KeycloakRolesUserService keycloakRolesUserService;
+  @Mock private KeycloakAuthorizationService keycloakAuthService;
+  @Mock private KeycloakPolicyService keycloakPolicyService;
   @Mock private RoleEntityService entityService;
+  @Mock private UserRoleEntityService userRoleEntityService;
+  @Mock private PolicyEntityService policyEntityService;
+  @Mock private PolicyService policyService;
+  @Mock private CapabilityEndpointService capabilityEndpointService;
+
+  @Captor private ArgumentCaptor<Function<Endpoint, String>> nameGeneratorCaptor;
 
   @InjectMocks private RoleService facade;
+
+  @AfterEach
+  void tearDown() {
+    verifyNoMoreInteractions(keycloakRolesUserService, keycloakAuthService, keycloakPolicyService,
+      userRoleEntityService, policyEntityService, policyService, capabilityEndpointService);
+  }
 
   @Nested
   @DisplayName("getById")
@@ -405,20 +439,144 @@ class RoleServiceTest {
 
       facade.deleteById(ROLE_ID);
 
+      verify(userRoleEntityService).findByRoleId(ROLE_ID);
+      verify(userRoleEntityService).deleteByRoleId(ROLE_ID);
+      verify(policyEntityService).findByName("Policy for role: " + ROLE_ID);
       verify(entityService).deleteById(ROLE_ID);
       verify(keycloakService).deleteById(ROLE_ID);
     }
 
     @Test
-    void negative_repositoryThrowsException() {
+    void positive_assignedUsersAndRolePolicy_existInKeycloakAndDbAreCleanedUp() {
       var role = role();
+      var userRole = new UserRole().userId(USER_ID).roleId(ROLE_ID);
+      var policyName = "Policy for role: " + ROLE_ID;
+      var policy = rolePolicy(policyName);
+      var endpoint = endpoint("/foo/entities", GET);
+      var endpoints = List.of(endpoint);
 
       when(entityService.getById(ROLE_ID)).thenReturn(role);
+      when(userRoleEntityService.findByRoleId(ROLE_ID)).thenReturn(List.of(userRole));
+      when(policyEntityService.findByName(policyName)).thenReturn(Optional.of(policy));
+      when(capabilityEndpointService.getRoleAssignedEndpoints(ROLE_ID, emptyList(), emptyList())).thenReturn(endpoints);
+
+      facade.deleteById(ROLE_ID);
+
+      var inOrder = inOrder(policyEntityService, capabilityEndpointService, userRoleEntityService,
+        keycloakRolesUserService, keycloakAuthService, policyService, entityService, keycloakService);
+      inOrder.verify(policyEntityService).findByName(policyName);
+      inOrder.verify(capabilityEndpointService).getRoleAssignedEndpoints(ROLE_ID, emptyList(), emptyList());
+      inOrder.verify(userRoleEntityService).findByRoleId(ROLE_ID);
+      inOrder.verify(keycloakRolesUserService).unlinkRolesFromUser(USER_ID, List.of(role));
+      inOrder.verify(userRoleEntityService).deleteByRoleId(ROLE_ID);
+      inOrder.verify(keycloakAuthService).deletePermissions(eq(policy), eq(endpoints), nameGeneratorCaptor.capture());
+      inOrder.verify(policyService).deleteById(policy.getId());
+      inOrder.verify(entityService).deleteById(ROLE_ID);
+      inOrder.verify(keycloakService).deleteById(ROLE_ID);
+
+      var policyNameGenerator = nameGeneratorCaptor.getValue();
+      assertThat(policyNameGenerator.apply(endpoint)).isEqualTo("GET access for role '%s' to '/foo/entities'", ROLE_ID);
+    }
+
+    @Test
+    void negative_repositoryThrowsException() {
+      var role = role();
+      var userRole = new UserRole().userId(USER_ID).roleId(ROLE_ID);
+      var policyName = "Policy for role: " + ROLE_ID;
+      var policy = rolePolicy(policyName);
+      var endpoints = List.of(endpoint("/foo/entities", GET));
+
+      when(entityService.getById(ROLE_ID)).thenReturn(role);
+      when(userRoleEntityService.findByRoleId(ROLE_ID)).thenReturn(List.of(userRole));
+      when(policyEntityService.findByName(policyName)).thenReturn(Optional.of(policy));
+      when(capabilityEndpointService.getRoleAssignedEndpoints(ROLE_ID, emptyList(), emptyList())).thenReturn(endpoints);
       doThrow(RuntimeException.class).when(keycloakService).deleteById(ROLE_ID);
 
       assertThrows(RuntimeException.class, () -> facade.deleteById(ROLE_ID));
+      verify(userRoleEntityService).findByRoleId(ROLE_ID);
+      verify(userRoleEntityService).deleteByRoleId(ROLE_ID);
+      verify(policyEntityService).findByName(policyName);
+      verify(capabilityEndpointService).getRoleAssignedEndpoints(ROLE_ID, emptyList(), emptyList());
+      verify(keycloakRolesUserService).unlinkRolesFromUser(USER_ID, List.of(role));
+      verify(keycloakAuthService).deletePermissions(eq(policy), eq(endpoints), any());
+      verify(policyService).deleteById(policy.getId());
       verify(entityService).deleteById(ROLE_ID);
       verify(entityService).create(role);
+      verify(keycloakPolicyService).create(policy);
+      verify(keycloakAuthService).createPermissions(eq(policy), eq(endpoints), any());
+      verify(keycloakRolesUserService).assignRolesToUser(USER_ID, List.of(role));
+    }
+
+    @Test
+    void negative_userUnlinkFails_roleDeletionIsNotAttempted() {
+      var role = role();
+      var userRole = new UserRole().userId(USER_ID).roleId(ROLE_ID);
+
+      when(entityService.getById(ROLE_ID)).thenReturn(role);
+      when(userRoleEntityService.findByRoleId(ROLE_ID)).thenReturn(List.of(userRole));
+      doThrow(RuntimeException.class).when(keycloakRolesUserService).unlinkRolesFromUser(USER_ID, List.of(role));
+
+      assertThrows(RuntimeException.class, () -> facade.deleteById(ROLE_ID));
+
+      verify(policyEntityService).findByName("Policy for role: " + ROLE_ID);
+      verify(userRoleEntityService).findByRoleId(ROLE_ID);
+      verify(keycloakRolesUserService).unlinkRolesFromUser(USER_ID, List.of(role));
+      verifyNoInteractions(policyService, keycloakService);
+    }
+
+    @Test
+    void negative_permissionDeletionFails_previousUserUnlinkIsRestoredAndRolePolicyIsNotRecreated() {
+      var role = role();
+      var userRole = new UserRole().userId(USER_ID).roleId(ROLE_ID);
+      var policyName = "Policy for role: " + ROLE_ID;
+      var policy = rolePolicy(policyName);
+      var endpoints = List.of(endpoint("/foo/entities", GET));
+
+      when(entityService.getById(ROLE_ID)).thenReturn(role);
+      when(userRoleEntityService.findByRoleId(ROLE_ID)).thenReturn(List.of(userRole));
+      when(policyEntityService.findByName(policyName)).thenReturn(Optional.of(policy));
+      when(capabilityEndpointService.getRoleAssignedEndpoints(ROLE_ID, emptyList(), emptyList())).thenReturn(endpoints);
+      doThrow(RuntimeException.class).when(keycloakAuthService).deletePermissions(eq(policy), eq(endpoints), any());
+
+      assertThrows(RuntimeException.class, () -> facade.deleteById(ROLE_ID));
+
+      verify(policyEntityService).findByName(policyName);
+      verify(capabilityEndpointService).getRoleAssignedEndpoints(ROLE_ID, emptyList(), emptyList());
+      verify(userRoleEntityService).findByRoleId(ROLE_ID);
+      verify(keycloakRolesUserService).unlinkRolesFromUser(USER_ID, List.of(role));
+      verify(userRoleEntityService).deleteByRoleId(ROLE_ID);
+      verify(keycloakAuthService).deletePermissions(eq(policy), eq(endpoints), any());
+      verify(keycloakAuthService).createPermissions(eq(policy), eq(endpoints), any());
+      verify(keycloakRolesUserService).assignRolesToUser(USER_ID, List.of(role));
+      verifyNoInteractions(policyService, keycloakService);
+    }
+
+    @Test
+    void negative_policyDeletionFails_previousUserUnlinkAndPermissionsAreRestoredAndRolePolicyIsNotRecreated() {
+      var role = role();
+      var userRole = new UserRole().userId(USER_ID).roleId(ROLE_ID);
+      var policyName = "Policy for role: " + ROLE_ID;
+      var policy = rolePolicy(policyName);
+      var endpoints = List.of(endpoint("/foo/entities", GET));
+
+      when(entityService.getById(ROLE_ID)).thenReturn(role);
+      when(userRoleEntityService.findByRoleId(ROLE_ID)).thenReturn(List.of(userRole));
+      when(policyEntityService.findByName(policyName)).thenReturn(Optional.of(policy));
+      when(capabilityEndpointService.getRoleAssignedEndpoints(ROLE_ID, emptyList(), emptyList())).thenReturn(endpoints);
+      doThrow(RuntimeException.class).when(policyService).deleteById(policy.getId());
+
+      assertThrows(RuntimeException.class, () -> facade.deleteById(ROLE_ID));
+
+      verify(policyEntityService).findByName(policyName);
+      verify(capabilityEndpointService).getRoleAssignedEndpoints(ROLE_ID, emptyList(), emptyList());
+      verify(userRoleEntityService).findByRoleId(ROLE_ID);
+      verify(keycloakRolesUserService).unlinkRolesFromUser(USER_ID, List.of(role));
+      verify(userRoleEntityService).deleteByRoleId(ROLE_ID);
+      verify(keycloakAuthService).deletePermissions(eq(policy), eq(endpoints), any());
+      verify(policyService).deleteById(policy.getId());
+      verify(keycloakAuthService).createPermissions(eq(policy), eq(endpoints), any());
+      verify(keycloakRolesUserService).assignRolesToUser(USER_ID, List.of(role));
+      verifyNoInteractions(keycloakService);
     }
 
     @Test

--- a/src/test/java/org/folio/roles/service/role/RoleServiceTest.java
+++ b/src/test/java/org/folio/roles/service/role/RoleServiceTest.java
@@ -28,6 +28,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -501,7 +502,7 @@ class RoleServiceTest {
       verify(keycloakAuthService).deletePermissions(eq(policy), eq(endpoints), any());
       verify(policyService).deleteById(policy.getId());
       verify(entityService).deleteById(ROLE_ID);
-      verify(entityService).create(role);
+      verify(entityService, never()).create(role);
       verify(keycloakPolicyService).create(policy);
       verify(keycloakAuthService).createPermissions(eq(policy), eq(endpoints), any());
       verify(keycloakRolesUserService).assignRolesToUser(USER_ID, List.of(role));
@@ -521,6 +522,7 @@ class RoleServiceTest {
       verify(policyEntityService).findByName("Policy for role: " + ROLE_ID);
       verify(userRoleEntityService).findByRoleId(ROLE_ID);
       verify(keycloakRolesUserService).unlinkRolesFromUser(USER_ID, List.of(role));
+      verify(keycloakRolesUserService, never()).assignRolesToUser(any(), any());
       verifyNoInteractions(policyService, keycloakService);
     }
 

--- a/src/test/java/org/folio/roles/service/role/UserRoleEntityServiceTest.java
+++ b/src/test/java/org/folio/roles/service/role/UserRoleEntityServiceTest.java
@@ -129,6 +129,18 @@ class UserRoleEntityServiceTest {
   }
 
   @Nested
+  @DisplayName("deleteByRoleId")
+  class DeleteByRoleId {
+
+    @Test
+    void positive() {
+      service.deleteByRoleId(ROLE_ID);
+
+      verify(repository).deleteByRoleId(ROLE_ID);
+    }
+  }
+
+  @Nested
   @DisplayName("findByUserId")
   class FindByUserId {
 
@@ -147,6 +159,31 @@ class UserRoleEntityServiceTest {
     void negative_entityNotFound() {
       when(repository.findByUserId(any(UUID.class))).thenReturn(emptyList());
       var result = service.findByUserId(USER_ID);
+      assertThat(result).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("findByRoleId")
+  class FindByRoleId {
+
+    @Test
+    void positive() {
+      var rolesUserEntity = userRoleEntity();
+      when(repository.findByRoleId(ROLE_ID)).thenReturn(List.of(rolesUserEntity));
+
+      var result = service.findByRoleId(ROLE_ID);
+
+      var expectedUserRole = userRole(USER_ID, ROLE_ID).metadata(new Metadata());
+      assertThat(result).containsExactly(expectedUserRole);
+    }
+
+    @Test
+    void negative_entityNotFound() {
+      when(repository.findByRoleId(ROLE_ID)).thenReturn(emptyList());
+
+      var result = service.findByRoleId(ROLE_ID);
+
       assertThat(result).isEmpty();
     }
   }

--- a/src/test/resources/json/keycloak/test-realm-roles.json
+++ b/src/test/resources/json/keycloak/test-realm-roles.json
@@ -4,6 +4,100 @@
   "verifyEmail": false,
   "loginWithEmailAllowed": false,
   "duplicateEmailsAllowed": true,
+  "users": [
+    {
+      "id": "00000000-0000-0000-0000-000000000001",
+      "username": "user1-for-role-deletion",
+      "enabled": true,
+      "attributes": {
+        "user_id": [
+          "8c6d12fa-33a7-48c9-8769-71168d441345"
+        ]
+      },
+      "realmRoles": [
+        "role1"
+      ]
+    }
+  ],
+  "clients": [
+    {
+      "id": "00000000-0000-0000-0000-000000000010",
+      "clientId": "test-login-application",
+      "description": "Client for role deletion cleanup",
+      "clientAuthenticatorType": "client-secret",
+      "secret": "kc-client-password",
+      "redirectUris": [ "/*" ],
+      "fullScopeAllowed": true,
+      "authorizationSettings": {
+        "allowRemoteResourceManagement": true,
+        "policyEnforcementMode": "ENFORCING",
+        "resources": [
+          {
+            "_id": "994b345b-09b2-416d-ac72-252155be4664",
+            "name": "/foo/items/{id}",
+            "displayName": "/foo/items/{id}",
+            "scopes": [
+              { "name": "GET" }
+            ]
+          },
+          {
+            "_id": "44147c30-e76e-4468-adff-e403bd175aca",
+            "name": "/foo/items",
+            "displayName": "/foo/items",
+            "scopes": [
+              { "name": "POST" }
+            ]
+          }
+        ],
+        "scopes": [
+          {
+            "id": "fcf915d3-0a7f-4ee1-bb8a-fc60aa93a4d6",
+            "name": "POST"
+          },
+          {
+            "id": "859b3f82-99aa-48d6-b3d6-9b5d222c3c00",
+            "name": "GET"
+          }
+        ],
+        "policies": [
+          {
+            "id": "dec68c30-4f93-4481-95bd-9ec587b15c1c",
+            "name": "Policy for role: 1e985e76-e9ca-401c-ad8e-0d121a11111e",
+            "description": "System generated policy for role: 1e985e76-e9ca-401c-ad8e-0d121a11111e",
+            "type": "role",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "roles": "[{\"id\":\"role1\",\"required\":false}]"
+            }
+          },
+          {
+            "name": "GET access for role '1e985e76-e9ca-401c-ad8e-0d121a11111e' to '/foo/items/{id}'",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"/foo/items/{id}\"]",
+              "scopes": "[\"GET\"]",
+              "applyPolicies": "[\"Policy for role: 1e985e76-e9ca-401c-ad8e-0d121a11111e\"]"
+            }
+          },
+          {
+            "name": "POST access for role '1e985e76-e9ca-401c-ad8e-0d121a11111e' to '/foo/items'",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"/foo/items\"]",
+              "scopes": "[\"POST\"]",
+              "applyPolicies": "[\"Policy for role: 1e985e76-e9ca-401c-ad8e-0d121a11111e\"]"
+            }
+          }
+        ],
+        "decisionStrategy": "AFFIRMATIVE"
+      }
+    }
+  ],
   "roles": {
     "realm": [
       {

--- a/src/test/resources/sql/populate-role-capability-and-capability-set-for-deletion.sql
+++ b/src/test/resources/sql/populate-role-capability-and-capability-set-for-deletion.sql
@@ -19,6 +19,10 @@ INSERT INTO test_mod_roles_keycloak.role_capability(role_id, capability_id)
 VALUES ('1e985e76-e9ca-401c-ad8e-0d121a11111e', '8d2da27c-1d56-48b6-958d-2bfae6d79dc8'),
        ('1e985e76-e9ca-401c-ad8e-0d121a11111e', 'e2628d7d-059a-46a1-a5ea-10a5a37b1af2');
 
+INSERT INTO test_mod_roles_keycloak.capability_endpoint(capability_id, path, method)
+VALUES ('8d2da27c-1d56-48b6-958d-2bfae6d79dc8', '/foo/items', 'POST'),
+       ('e2628d7d-059a-46a1-a5ea-10a5a37b1af2', '/foo/items/{id}', 'GET');
+
 INSERT INTO test_mod_roles_keycloak.capability_set
   (id, name, description, resource, action, type, application_id, created_by_user_id)
 VALUES ('8d2da27c-1d56-48b6-958d-2bfae6d79dc8', 'foo_item.create',


### PR DESCRIPTION
### **Purpose**
Ensure role deletion fully cleans up role-related authorization data in Keycloak and local storage.

Related issue: https://folio-org.atlassian.net/browse/MODROLESKC-384

### **Approach**
Added cleanup of role user assignments, generated role permissions, and the generated role policy during role deletion, with compensating Keycloak rollback when cleanup or deletion fails.

Centralized role policy and permission naming in `RolePolicyNameProvider` so creation and deletion paths use the same convention. Added unit and integration coverage for successful cleanup and rollback scenarios.

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
