### PR TITLE
MODROLESKC-347: FIX - Missing permissions for system user roles

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## Version `v4.1.0` (IN PROGRESS)
+* Fix race condition that could leave default loadable-role permissions without assigned capabilities during tenant initialization (MODROLESKC-347)
+
 ## Version `v4.0.0` (16.04.2025)
 * Added endpoint to create or update default roles via REST API (MODROLESKC-301)
 * Introduce configuration for FSSP (APPPOCTOOL-59)

--- a/src/main/java/org/folio/roles/service/loadablerole/LoadablePermissionService.java
+++ b/src/main/java/org/folio/roles/service/loadablerole/LoadablePermissionService.java
@@ -1,10 +1,13 @@
 package org.folio.roles.service.loadablerole;
 
+import static org.apache.commons.collections4.CollectionUtils.isEmpty;
+
 import java.util.Collection;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.folio.roles.domain.dto.LoadablePermission;
+import org.folio.roles.domain.entity.key.LoadablePermissionKey;
 import org.folio.roles.mapper.LoadableRoleMapper;
 import org.folio.roles.repository.LoadablePermissionRepository;
 import org.springframework.stereotype.Service;
@@ -18,6 +21,7 @@ public class LoadablePermissionService {
 
   private final LoadablePermissionRepository repository;
   private final LoadableRoleMapper mapper;
+  private final LoadableRoleCapabilityAssignmentHelper assignmentHelper;
 
   @Transactional(readOnly = true)
   public List<LoadablePermission> findAllByPermissions(Collection<String> permissionNames) {
@@ -37,5 +41,14 @@ public class LoadablePermissionService {
     var saved = repository.saveAll(entities);
 
     return mapper.toPermission(saved);
+  }
+
+  public void assignCapabilitiesAndSets(Collection<LoadablePermissionKey> permissionKeys) {
+    if (isEmpty(permissionKeys)) {
+      return;
+    }
+
+    var permissions = repository.findAllById(permissionKeys);
+    assignmentHelper.assignCapabilitiesAndSetsForPermissions(permissions);
   }
 }

--- a/src/main/java/org/folio/roles/service/loadablerole/LoadableRoleCapabilityAssignmentHelper.java
+++ b/src/main/java/org/folio/roles/service/loadablerole/LoadableRoleCapabilityAssignmentHelper.java
@@ -93,7 +93,7 @@ public class LoadableRoleCapabilityAssignmentHelper {
     var capabilities = capabilityService.findByPermissionNames(permsByName.keySet());
 
     if (isNotEmpty(capabilities)) {
-      roleCapabilityService.create(roleId, mapItems(capabilities, Capability::getId), false);
+      roleCapabilityService.create(roleId, mapItems(capabilities, Capability::getId), true);
 
       for (Capability cap : capabilities) {
         var perm = permsByName.get(cap.getPermission());
@@ -108,7 +108,7 @@ public class LoadableRoleCapabilityAssignmentHelper {
     var capabilitySets = capabilitySetService.findByPermissionNames(permsByName.keySet());
 
     if (isNotEmpty(capabilitySets)) {
-      roleCapabilitySetService.create(roleId, mapItems(capabilitySets, CapabilitySet::getId), false);
+      roleCapabilitySetService.create(roleId, mapItems(capabilitySets, CapabilitySet::getId), true);
 
       for (CapabilitySet set : capabilitySets) {
         var perm = permsByName.get(set.getPermission());

--- a/src/main/java/org/folio/roles/service/loadablerole/LoadableRoleService.java
+++ b/src/main/java/org/folio/roles/service/loadablerole/LoadableRoleService.java
@@ -34,6 +34,7 @@ import org.folio.roles.mapper.LoadableRoleMapper;
 import org.folio.roles.repository.LoadableRoleRepository;
 import org.folio.roles.service.ServiceUtils.UpdatePair;
 import org.folio.spring.data.OffsetRequest;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -47,6 +48,7 @@ public class LoadableRoleService {
   private final LoadableRoleMapper mapper;
   private final KeycloakRoleService keycloakService;
   private final LoadableRoleCapabilityAssignmentHelper assignmentHelper;
+  private final ApplicationEventPublisher applicationEventPublisher;
 
   @Transactional(readOnly = true)
   public LoadableRoles find(String query, Integer limit, Integer offset) {
@@ -219,6 +221,7 @@ public class LoadableRoleService {
       }
 
       var result = repository.saveAllAndFlush(entities);
+      publishUnresolvedPermissionsCreatedEvent(flattenPermissions(result));
       log.info("Loadable roles created: {}", () -> toIdNames(result));
 
       return result;
@@ -236,18 +239,21 @@ public class LoadableRoleService {
     }
 
     var changedRoles = new ArrayList<LoadableRoleEntity>();
+    var allCreatedPermissions = new LinkedHashSet<LoadablePermissionEntity>();
     for (var pair : updatePairs) {
       var incoming = pair.newItem();
       var existing = pair.oldItem();
 
       var nameDescriptionUpdated = updateNameAndDescription(incoming, existing);
-      var permsUpdated = updatePermissions(incoming, existing);
-      if (nameDescriptionUpdated || permsUpdated) {
+      var permissionsUpdate = updatePermissions(incoming, existing);
+      allCreatedPermissions.addAll(permissionsUpdate.createdPermissions());
+      if (nameDescriptionUpdated || permissionsUpdate.hasChanges()) {
         changedRoles.add(existing);
       }
     }
 
     repository.saveAllAndFlush(changedRoles);
+    publishUnresolvedPermissionsCreatedEvent(allCreatedPermissions);
     log.info("Loadable roles updated: {}", () -> toIdNames(changedRoles));
   }
 
@@ -268,7 +274,7 @@ public class LoadableRoleService {
     return modified;
   }
 
-  private boolean updatePermissions(LoadableRoleEntity source, LoadableRoleEntity target) {
+  private UpdatePermissionsResult updatePermissions(LoadableRoleEntity source, LoadableRoleEntity target) {
     var existingPerms = target.getPermissions();
     var incomingPerms = source.getPermissions();
 
@@ -284,7 +290,7 @@ public class LoadableRoleService {
     assignmentHelper.removeCapabilitiesAndSetsForPermissions(deleted);
     deleted.forEach(target::removePermission);
 
-    return isNotEmpty(created) || isNotEmpty(deleted);
+    return new UpdatePermissionsResult(created, deleted);
   }
 
   private void deleteAll(Collection<LoadableRoleEntity> entities) {
@@ -321,5 +327,36 @@ public class LoadableRoleService {
 
   private static List<String> toNames(Collection<LoadablePermissionEntity> perms) {
     return mapItems(perms, LoadablePermissionEntity::getPermissionName);
+  }
+
+  private static List<LoadablePermissionEntity> flattenPermissions(Collection<LoadableRoleEntity> roles) {
+    return roles.stream()
+      .flatMap(role -> role.getPermissions().stream())
+      .toList();
+  }
+
+  private void publishUnresolvedPermissionsCreatedEvent(Collection<LoadablePermissionEntity> permissions) {
+    if (isEmpty(permissions)) {
+      return;
+    }
+
+    var unresolvedPermissionKeys = permissions.stream()
+      .filter(permission -> permission.getCapabilityId() == null && permission.getCapabilitySetId() == null)
+      .map(LoadablePermissionEntity::getId)
+      .toList();
+    if (isEmpty(unresolvedPermissionKeys)) {
+      return;
+    }
+
+    log.debug("Publishing unresolved loadable permissions event: permissionKeys = {}", unresolvedPermissionKeys);
+    applicationEventPublisher.publishEvent(new UnresolvedLoadablePermissionsCreatedEvent(unresolvedPermissionKeys));
+  }
+
+  private record UpdatePermissionsResult(Collection<LoadablePermissionEntity> createdPermissions,
+                                         Collection<LoadablePermissionEntity> deletedPermissions) {
+
+    private boolean hasChanges() {
+      return isNotEmpty(createdPermissions) || isNotEmpty(deletedPermissions);
+    }
   }
 }

--- a/src/main/java/org/folio/roles/service/loadablerole/UnresolvedLoadablePermissionsCreatedEvent.java
+++ b/src/main/java/org/folio/roles/service/loadablerole/UnresolvedLoadablePermissionsCreatedEvent.java
@@ -1,0 +1,12 @@
+package org.folio.roles.service.loadablerole;
+
+import java.util.Collection;
+import org.folio.roles.domain.entity.key.LoadablePermissionKey;
+
+/**
+ * Published after the loadable-role transaction commits for newly created permissions that still have neither a
+ * capability nor a capability set. {@link UnresolvedLoadablePermissionsCreatedEventHandler} uses these permission
+ * keys to perform capability assignment in a new transaction.
+ */
+public record UnresolvedLoadablePermissionsCreatedEvent(Collection<LoadablePermissionKey> unresolvedPermissionKeys) {
+}

--- a/src/main/java/org/folio/roles/service/loadablerole/UnresolvedLoadablePermissionsCreatedEventHandler.java
+++ b/src/main/java/org/folio/roles/service/loadablerole/UnresolvedLoadablePermissionsCreatedEventHandler.java
@@ -1,0 +1,23 @@
+package org.folio.roles.service.loadablerole;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Service
+@Log4j2
+@RequiredArgsConstructor
+public class UnresolvedLoadablePermissionsCreatedEventHandler {
+
+  private final LoadablePermissionService loadablePermissionService;
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  @TransactionalEventListener
+  public void handle(UnresolvedLoadablePermissionsCreatedEvent event) {
+    log.debug("Handling unresolved loadable permissions event: permissionKeys = {}", event.unresolvedPermissionKeys());
+    loadablePermissionService.assignCapabilitiesAndSets(event.unresolvedPermissionKeys());
+  }
+}

--- a/src/test/java/org/folio/roles/it/LoadableRoleProcessingIT.java
+++ b/src/test/java/org/folio/roles/it/LoadableRoleProcessingIT.java
@@ -275,7 +275,7 @@ class LoadableRoleProcessingIT extends BaseIntegrationTest {
 
   @Test
   @KeycloakRealms("/json/keycloak/role-loadable-processing-realm.json")
-  void upsertLoadableRole_positive_whenCapabilityEventCommitsBeforeLoadableRoleCommit() throws Exception {
+  void upsertLoadableRole_positive_handlesCapabilityAssignmentRaceCondition() throws Exception {
     var permissionName = "notes.collection.get";
     var roleName = "Race Condition Role";
     var role = new LoadableRole()
@@ -294,7 +294,7 @@ class LoadableRoleProcessingIT extends BaseIntegrationTest {
     }).when(assignmentHelper).assignCapabilitiesAndSetsForPermissions(anyCollection());
 
     try (var executor = Executors.newSingleThreadExecutor()) {
-      var upsertFuture = executor.submit(() -> {
+      final var upsertFuture = executor.submit(() -> {
         doPut("/loadable-roles", role);
         return null;
       });

--- a/src/test/java/org/folio/roles/it/LoadableRoleProcessingIT.java
+++ b/src/test/java/org/folio/roles/it/LoadableRoleProcessingIT.java
@@ -13,6 +13,8 @@ import static org.folio.roles.utils.TestValues.readValue;
 import static org.folio.spring.integration.XOkapiHeaders.TENANT;
 import static org.folio.spring.integration.XOkapiHeaders.USER_ID;
 import static org.folio.test.TestUtils.parseResponse;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.doAnswer;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
 import static org.springframework.test.context.jdbc.SqlMergeMode.MergeMode.MERGE;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -20,6 +22,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import lombok.extern.log4j.Log4j2;
 import org.assertj.core.api.ThrowingConsumer;
@@ -35,6 +40,8 @@ import org.folio.roles.domain.dto.CapabilitySets;
 import org.folio.roles.domain.dto.LoadablePermission;
 import org.folio.roles.domain.dto.LoadableRole;
 import org.folio.roles.domain.dto.LoadableRoles;
+import org.folio.roles.integration.kafka.KafkaMessageListener;
+import org.folio.roles.service.loadablerole.LoadableRoleCapabilityAssignmentHelper;
 import org.folio.test.extensions.KeycloakRealms;
 import org.folio.test.types.IntegrationTest;
 import org.junit.jupiter.api.AfterAll;
@@ -45,6 +52,7 @@ import org.keycloak.admin.client.Keycloak;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlMergeMode;
 import org.springframework.test.jdbc.JdbcTestUtils;
@@ -68,6 +76,9 @@ class LoadableRoleProcessingIT extends BaseIntegrationTest {
   @Autowired private KafkaTemplate<String, Object> kafkaTemplate;
   @Autowired private JdbcTemplate jdbcTemplate;
   @Autowired private Keycloak keycloak;
+  @Autowired private KafkaMessageListener kafkaMessageListener;
+
+  @MockitoSpyBean private LoadableRoleCapabilityAssignmentHelper assignmentHelper;
 
   @BeforeAll
   static void beforeAll() {
@@ -260,6 +271,57 @@ class LoadableRoleProcessingIT extends BaseIntegrationTest {
         .orElseThrow();
       assertThat(matchingPermission.getCapabilityId()).isNotNull();
     });
+  }
+
+  @Test
+  @KeycloakRealms("/json/keycloak/role-loadable-processing-realm.json")
+  void upsertLoadableRole_positive_whenCapabilityEventCommitsBeforeLoadableRoleCommit() throws Exception {
+    var permissionName = "notes.collection.get";
+    var roleName = "Race Condition Role";
+    var role = new LoadableRole()
+      .name(roleName)
+      .description("Role used to reproduce the capability assignment race")
+      .permissions(List.of(new LoadablePermission().permissionName(permissionName)));
+
+    var helperCompletedInsideTransaction = new CountDownLatch(1);
+    var allowLoadableRoleCommit = new CountDownLatch(1);
+
+    doAnswer(invocation -> {
+      var result = invocation.callRealMethod();
+      helperCompletedInsideTransaction.countDown();
+      assertThat(allowLoadableRoleCommit.await(10, TimeUnit.SECONDS)).isTrue();
+      return result;
+    }).when(assignmentHelper).assignCapabilitiesAndSetsForPermissions(anyCollection());
+
+    try (var executor = Executors.newSingleThreadExecutor()) {
+      var upsertFuture = executor.submit(() -> {
+        doPut("/loadable-roles", role);
+        return null;
+      });
+
+      assertThat(helperCompletedInsideTransaction.await(10, TimeUnit.SECONDS)).isTrue();
+
+      var capabilityEvent = readValue("json/kafka-events/be-notes-capability-event.json", ResourceEvent.class);
+      kafkaMessageListener.handleCapabilityEvent(capabilityEvent);
+
+      allowLoadableRoleCommit.countDown();
+      upsertFuture.get(10, TimeUnit.SECONDS);
+    }
+
+    assertThat(unassignedCapabilityCountForPermissionLike(permissionName)).isZero();
+
+    var fetchedRole = getLoadableRoleByName(roleName);
+    var matchingPermission = fetchedRole.getPermissions().stream()
+      .filter(permission -> permissionName.equals(permission.getPermissionName()))
+      .findFirst()
+      .orElseThrow();
+    assertThat(matchingPermission.getCapabilityId()).isNotNull();
+
+    var roleCapabilities = parseResponse(doGet("/roles/{id}/capabilities", fetchedRole.getId()).andReturn(),
+      Capabilities.class);
+    assertThat(roleCapabilities.getCapabilities())
+      .extracting(Capability::getPermission)
+      .contains(permissionName);
   }
 
   @Test

--- a/src/test/java/org/folio/roles/service/loadablerole/LoadablePermissionServiceTest.java
+++ b/src/test/java/org/folio/roles/service/loadablerole/LoadablePermissionServiceTest.java
@@ -6,9 +6,14 @@ import static org.folio.roles.support.LoadablePermissionUtils.loadablePermission
 import static org.folio.roles.support.LoadablePermissionUtils.loadablePermissionEntities;
 import static org.folio.roles.support.LoadablePermissionUtils.loadablePermissionEntity;
 import static org.folio.roles.support.LoadablePermissionUtils.loadablePermissions;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
+import java.util.Set;
 import org.folio.roles.domain.dto.LoadablePermission;
+import org.folio.roles.domain.entity.key.LoadablePermissionKey;
 import org.folio.roles.mapper.LoadableRoleMapper;
 import org.folio.roles.repository.LoadablePermissionRepository;
 import org.folio.roles.support.TestUtils;
@@ -29,6 +34,7 @@ class LoadablePermissionServiceTest {
   @InjectMocks private LoadablePermissionService service;
   @Mock private LoadablePermissionRepository repository;
   @Mock private LoadableRoleMapper mapper;
+  @Mock private LoadableRoleCapabilityAssignmentHelper assignmentHelper;
 
   @AfterEach
   void tearDown() {
@@ -75,5 +81,28 @@ class LoadablePermissionServiceTest {
     var actual = service.saveAll(perms);
 
     assertThat(actual).isEqualTo(perms);
+  }
+
+  @Test
+  void assignCapabilitiesAndSets_positive() {
+    var permissions = loadablePermissions(2);
+    var permissionEntities = loadablePermissionEntities(permissions);
+    var permissionKeys = mapItems(permissionEntities, entity -> LoadablePermissionKey.of(entity.getRoleId(),
+      entity.getPermissionName()));
+
+    when(repository.findAllById(permissionKeys)).thenReturn(permissionEntities);
+    when(assignmentHelper.assignCapabilitiesAndSetsForPermissions(permissionEntities)).thenReturn(
+      Set.of(permissionEntities.getFirst()));
+
+    service.assignCapabilitiesAndSets(permissionKeys);
+
+    verify(assignmentHelper).assignCapabilitiesAndSetsForPermissions(permissionEntities);
+  }
+
+  @Test
+  void assignCapabilitiesAndSets_positive_emptyInput() {
+    service.assignCapabilitiesAndSets(List.of());
+
+    verifyNoInteractions(repository, assignmentHelper);
   }
 }

--- a/src/test/java/org/folio/roles/service/loadablerole/LoadableRoleCapabilityAssignmentHelperTest.java
+++ b/src/test/java/org/folio/roles/service/loadablerole/LoadableRoleCapabilityAssignmentHelperTest.java
@@ -193,14 +193,14 @@ class LoadableRoleCapabilityAssignmentHelperTest {
       capabilityService.findByPermissionNames(Set.of(perm1.getPermissionName(), perm2.getPermissionName())))
       .thenReturn(cap != null ? List.of(cap) : emptyList());
     if (cap != null) {
-      when(roleCapabilityService.create(perm1.getRoleId(), List.of(cap.getId()), false))
+      when(roleCapabilityService.create(perm1.getRoleId(), List.of(cap.getId()), true))
         .thenReturn(empty()); // response is not used, can return empty()
     }
 
     when(capabilitySetService.findByPermissionNames(Set.of(perm1.getPermissionName(), perm2.getPermissionName())))
       .thenReturn(capSet != null ? List.of(capSet) : emptyList());
     if (capSet != null) {
-      when(roleCapabilitySetService.create(perm1.getRoleId(), List.of(capSet.getId()), false))
+      when(roleCapabilitySetService.create(perm1.getRoleId(), List.of(capSet.getId()), true))
         .thenReturn(empty()); // response is not used, can return empty()
     }
   }

--- a/src/test/java/org/folio/roles/service/loadablerole/LoadableRoleServiceTest.java
+++ b/src/test/java/org/folio/roles/service/loadablerole/LoadableRoleServiceTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
+import org.folio.roles.domain.entity.LoadablePermissionEntity;
 import org.folio.roles.domain.entity.type.EntityRoleType;
 import org.folio.roles.exception.ServiceException;
 import org.folio.roles.integration.keyclock.KeycloakRoleService;
@@ -33,6 +34,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 
 @UnitTest
@@ -45,6 +47,7 @@ class LoadableRoleServiceTest {
   @Mock private LoadableRoleMapper mapper;
   @Mock private KeycloakRoleService keycloakService;
   @Mock private LoadableRoleCapabilityAssignmentHelper capabilityAssignmentHelper;
+  @Mock private ApplicationEventPublisher applicationEventPublisher;
 
   @AfterEach
   void tearDown() {
@@ -184,6 +187,9 @@ class LoadableRoleServiceTest {
     void positive() {
       var role = loadableRole();
       var roleEntity = loadableRoleEntity(role);
+      var unresolvedPermission = new LoadablePermissionEntity();
+      unresolvedPermission.setPermissionName("unresolved.permission");
+      roleEntity.addPermission(unresolvedPermission);
       var createdRegularRole = regularRole(role);
       var regularRole = copy(createdRegularRole).id(null);
 
@@ -203,6 +209,8 @@ class LoadableRoleServiceTest {
       var actual = service.upsertDefaultLoadableRole(role);
 
       assertThat(actual).isEqualTo(role);
+      verify(applicationEventPublisher).publishEvent(
+        new UnresolvedLoadablePermissionsCreatedEvent(List.of(unresolvedPermission.getId())));
     }
 
     @Test

--- a/src/test/java/org/folio/roles/service/loadablerole/UnresolvedLoadablePermissionsCreatedEventHandlerTest.java
+++ b/src/test/java/org/folio/roles/service/loadablerole/UnresolvedLoadablePermissionsCreatedEventHandlerTest.java
@@ -1,0 +1,30 @@
+package org.folio.roles.service.loadablerole;
+
+import static java.util.UUID.randomUUID;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import org.folio.roles.domain.entity.key.LoadablePermissionKey;
+import org.folio.test.types.UnitTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class UnresolvedLoadablePermissionsCreatedEventHandlerTest {
+
+  @InjectMocks private UnresolvedLoadablePermissionsCreatedEventHandler handler;
+  @Mock private LoadablePermissionService loadablePermissionService;
+
+  @Test
+  void handle_positive() {
+    var permissionKey = LoadablePermissionKey.of(randomUUID(), "permission.test");
+
+    handler.handle(new UnresolvedLoadablePermissionsCreatedEvent(List.of(permissionKey)));
+
+    verify(loadablePermissionService).assignCapabilitiesAndSets(List.of(permissionKey));
+  }
+}


### PR DESCRIPTION
### **Purpose**
Fix for [MODROLESKC-347](https://folio-org.atlassian.net/browse/MODROLESKC-347)

Before the fix - permissions with missing capability IDs present:
<img width="2656" height="1202" alt="image" src="https://github.com/user-attachments/assets/48972330-b0f1-430e-be5c-3f2a9128759b" />


After the fix - permissions with missing capability IDs not present:
<img width="2660" height="1240" alt="image" src="https://github.com/user-attachments/assets/b822b19b-63a3-4361-9a12-1812109bba8a" />

### **Approach**

Followed TDD. Created a failing test `upsertLoadableRole_positive_handlesCapabilityAssignmentRaceCondition` to mimic the bug. This test is passing after the changes.

**Root cause:** There was a race during tenant init between loadable-role creation and Kafka-driven capability assignment. Both flows could miss each other and a default-role permission stayed unassigned.

**Fix:** Add a post-commit reconciliation step on the loadable-role side. After commit, we emit an event for newly created permissions that are still unresolved, and a new transaction reloads them and assign the missing capabilities. The helper is also made idempotent so that this operation is safe.

**Scenarios:**

1. Loadable role commits first: when the capability event runs later, LoadableRoleCapabilityAssignmentProcessor can see the committed permission row and assign the capability.
2. Capability commits first: when the loadable role is created later, LoadableRoleService sees the capability during its normal in-transaction lookup and assigns it immediately.
3. Both initial checks miss each other: the original in-transaction assignment finds nothing, and the processor also finds nothing; the new UnresolvedLoadablePermissionsCreatedEventHandler fixes it after commit.

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
