### PR TITLE
MODROLESKC-347 make loadable role capability assignment idempotent

### DIFF
--- a/src/main/java/org/folio/roles/service/loadablerole/LoadableRoleCapabilityAssignmentProcessor.java
+++ b/src/main/java/org/folio/roles/service/loadablerole/LoadableRoleCapabilityAssignmentProcessor.java
@@ -130,7 +130,7 @@ public class LoadableRoleCapabilityAssignmentProcessor {
 
       var capabilityIds = selectCapabilityIdsByRolePermissions(capabilityByPerm, rolePermissions);
 
-      roleCapabilityService.create(roleId, capabilityIds, false);
+      roleCapabilityService.create(roleId, capabilityIds, true);
 
       rolePermissions.forEach(assignCapabilityId(capabilityByPerm));
 
@@ -143,7 +143,7 @@ public class LoadableRoleCapabilityAssignmentProcessor {
     return (roleId, rolePermissions) -> {
       var rolePermission = getSingleLoadablePermission(roleId, rolePermissions);
 
-      roleCapabilitySetService.create(roleId, List.of(capabilitySet.getId()), false);
+      roleCapabilitySetService.create(roleId, List.of(capabilitySet.getId()), true);
 
       rolePermission.setCapabilitySetId(capabilitySet.getId());
       service.save(rolePermission);

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -13,7 +13,7 @@ appender.console.type = Console
 appender.console.name = STDOUT
 
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{HH:mm:ss} [$${folio:requestid}] [$${folio:tenantid}] [$${folio:userid}] [$${folio:moduleid}] %-5p %-20.20C{1} %m%n
+appender.console.layout.pattern = %d{HH:mm:ss} [$${folio:requestId}] [$${folio:tenantId}] [$${folio:userId}] [$${folio:moduleId}] %-5p %-20.20C{1} %m%n
 
 rootLogger.level = info
 rootLogger.appenderRefs = info

--- a/src/test/java/org/folio/roles/it/LoadableRoleProcessingIT.java
+++ b/src/test/java/org/folio/roles/it/LoadableRoleProcessingIT.java
@@ -13,6 +13,7 @@ import static org.folio.roles.utils.TestValues.readValue;
 import static org.folio.spring.integration.XOkapiHeaders.TENANT;
 import static org.folio.spring.integration.XOkapiHeaders.USER_ID;
 import static org.folio.test.TestUtils.parseResponse;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.doAnswer;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
@@ -22,6 +23,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -42,6 +44,7 @@ import org.folio.roles.domain.dto.LoadableRole;
 import org.folio.roles.domain.dto.LoadableRoles;
 import org.folio.roles.integration.kafka.KafkaMessageListener;
 import org.folio.roles.service.loadablerole.LoadableRoleCapabilityAssignmentHelper;
+import org.folio.roles.service.loadablerole.LoadableRoleCapabilityAssignmentProcessor;
 import org.folio.test.extensions.KeycloakRealms;
 import org.folio.test.types.IntegrationTest;
 import org.junit.jupiter.api.AfterAll;
@@ -79,6 +82,7 @@ class LoadableRoleProcessingIT extends BaseIntegrationTest {
   @Autowired private KafkaMessageListener kafkaMessageListener;
 
   @MockitoSpyBean private LoadableRoleCapabilityAssignmentHelper assignmentHelper;
+  @MockitoSpyBean private LoadableRoleCapabilityAssignmentProcessor assignmentProcessor;
 
   @BeforeAll
   static void beforeAll() {
@@ -326,6 +330,85 @@ class LoadableRoleProcessingIT extends BaseIntegrationTest {
 
   @Test
   @KeycloakRealms("/json/keycloak/role-loadable-processing-realm.json")
+  void handleCapabilityEvent_positive_whenOneMatchingRoleAlreadyHasCapabilityAndAnotherDoesNot() throws Exception {
+    var permissionName = "notes.collection.get";
+    var firstRoleName = "Initially Unresolved Role";
+    var secondRoleName = "Assigned While Event Blocked Role";
+
+    // Step 1: Create the first role having permission "notes.collection.get".
+    // Because the capability does not exist for this permission, the "capabilityId" should be null for this role
+    // in the DB.
+    var firstRole = new LoadableRole()
+      .name(firstRoleName)
+      .description("Role created before capability exists")
+      .permissions(List.of(new LoadablePermission().permissionName(permissionName)));
+
+    doPut("/loadable-roles", firstRole);
+
+    var createdFirstRole = getLoadableRoleByName(firstRoleName);
+    assertThat(findPermission(createdFirstRole, permissionName).getCapabilityId()).isNull();
+
+    // Step 2: Create the capability now. However, pause handleCapabilitiesCreatedEvent(...) after the capability
+    // event reaches the listener to simulate the race condition.
+    var processorEntered = new CountDownLatch(1);
+    var allowProcessorToContinue = new CountDownLatch(1);
+
+    doAnswer(invocation -> {
+      processorEntered.countDown();
+      assertThat(allowProcessorToContinue.await(10, TimeUnit.SECONDS)).isTrue();
+      return invocation.callRealMethod();
+    }).when(assignmentProcessor).handleCapabilitiesCreatedEvent(any());
+
+    try (var executor = Executors.newSingleThreadExecutor()) {
+      var capabilityEvent = readValue("json/kafka-events/be-notes-capability-event.json", ResourceEvent.class);
+      final var createCapabilityFuture = executor.submit(() -> {
+        kafkaMessageListener.handleCapabilityEvent(capabilityEvent);
+        return null;
+      });
+
+      assertThat(processorEntered.await(10, TimeUnit.SECONDS)).isTrue();
+
+      // Step 3: While the listener is blocked, creating another loadable role for the same permission.
+      // This should resolve immediately because the capability now exists and the normal save path can see it.
+      var secondRole = new LoadableRole()
+        .name(secondRoleName)
+        .description("Role created while capability assignment processor is blocked")
+        .permissions(List.of(new LoadablePermission().permissionName(permissionName)));
+      doPut("/loadable-roles", secondRole);
+
+      var capabilityId = getExistingCapabilities().get(permissionName).getId();
+      assertThat(capabilityId).isNotNull();
+
+      var unresolvedFirstRole = getLoadableRoleByName(firstRoleName);
+      var assignedSecondRole = getLoadableRoleByName(secondRoleName);
+
+      // Before unblocking the listener, only the second role should be assigned.
+      assertThat(findPermission(unresolvedFirstRole, permissionName).getCapabilityId()).isNull();
+      assertThat(findPermission(assignedSecondRole, permissionName).getCapabilityId()).isEqualTo(capabilityId);
+      assertThat(unassignedCapabilityCountForRoleAndPermission(unresolvedFirstRole.getId(), permissionName))
+        .isEqualTo(1);
+      assertThat(roleCapabilityCount(unresolvedFirstRole.getId(), capabilityId)).isZero();
+      assertThat(roleCapabilityCount(assignedSecondRole.getId(), capabilityId)).isEqualTo(1);
+
+      // Step 4: Now, unpause the listener.
+      // Once the listener continues, it should repair the first role without disturbing the second one.
+      allowProcessorToContinue.countDown();
+      createCapabilityFuture.get(10, TimeUnit.SECONDS);
+
+      await().untilAsserted(() -> {
+        var resolvedFirstRole = getLoadableRoleByName(firstRoleName);
+        var resolvedSecondRole = getLoadableRoleByName(secondRoleName);
+
+        assertThat(findPermission(resolvedFirstRole, permissionName).getCapabilityId()).isEqualTo(capabilityId);
+        assertThat(findPermission(resolvedSecondRole, permissionName).getCapabilityId()).isEqualTo(capabilityId);
+        assertThat(roleCapabilityCount(resolvedFirstRole.getId(), capabilityId)).isEqualTo(1);
+        assertThat(roleCapabilityCount(resolvedSecondRole.getId(), capabilityId)).isEqualTo(1);
+      });
+    }
+  }
+
+  @Test
+  @KeycloakRealms("/json/keycloak/role-loadable-processing-realm.json")
   void upsertLoadableRole_positive_populateRoleWithExistingCapabilitySet() throws Exception {
     sendCapabilityEvent("json/kafka-events/be-notes-capability-event.json");
 
@@ -404,6 +487,16 @@ class LoadableRoleProcessingIT extends BaseIntegrationTest {
       format("folio_permission LIKE '%%%s%%' and capability_id IS NULL", permission));
   }
 
+  private int unassignedCapabilityCountForRoleAndPermission(UUID roleId, String permission) {
+    return JdbcTestUtils.countRowsInTableWhere(jdbcTemplate, ROLE_LOADABLE_PERMISSION_TABLE,
+      format("role_loadable_id = '%s' and folio_permission = '%s' and capability_id IS NULL", roleId, permission));
+  }
+
+  private int roleCapabilityCount(UUID roleId, Object capabilityId) {
+    return JdbcTestUtils.countRowsInTableWhere(jdbcTemplate, "test_mod_roles_keycloak.role_capability",
+      format("role_id = '%s' and capability_id = '%s'", roleId, capabilityId));
+  }
+
   private void sendCapabilityEvent(String file) {
     var capabilityEvent = readValue(file, ResourceEvent.class);
     kafkaTemplate.send(FOLIO_IT_CAPABILITIES_TOPIC, capabilityEvent);
@@ -458,6 +551,13 @@ class LoadableRoleProcessingIT extends BaseIntegrationTest {
     return permissions.stream()
       .filter(p -> stream(permissionMask).anyMatch(mask -> p.getPermissionName().contains(mask)))
       .toList();
+  }
+
+  private static LoadablePermission findPermission(LoadableRole role, String permissionName) {
+    return role.getPermissions().stream()
+      .filter(permission -> permissionName.equals(permission.getPermissionName()))
+      .findFirst()
+      .orElseThrow();
   }
 
   private static LoadableRole getLoadableRoleByName(String name) throws Exception {

--- a/src/test/java/org/folio/roles/service/loadablerole/LoadableRoleCapabilityAssignmentProcessorTest.java
+++ b/src/test/java/org/folio/roles/service/loadablerole/LoadableRoleCapabilityAssignmentProcessorTest.java
@@ -71,7 +71,7 @@ class LoadableRoleCapabilityAssignmentProcessorTest {
     when(service.findAllByPermissions(List.of(permission))).thenReturn(perms);
 
     perms.forEach(perm -> {
-      when(roleCapabilityService.create(perm.getRoleId(), List.of(capabilityId), false)).thenReturn(null);
+      when(roleCapabilityService.create(perm.getRoleId(), List.of(capabilityId), true)).thenReturn(null);
 
       var permsWithCapabilityId = List.of(copy(perm).capabilityId(capabilityId));
       when(service.saveAll(permsWithCapabilityId)).thenReturn(permsWithCapabilityId);
@@ -82,7 +82,7 @@ class LoadableRoleCapabilityAssignmentProcessorTest {
     processor.handleCapabilitiesCreatedEvent(event);
 
     var firstLoadablePermission = perms.get(0);
-    verify(roleCapabilityService).create(firstLoadablePermission.getRoleId(), List.of(capabilityId), false);
+    verify(roleCapabilityService).create(firstLoadablePermission.getRoleId(), List.of(capabilityId), true);
     verify(service).saveAll(List.of(copy(firstLoadablePermission).capabilityId(capabilityId)));
   }
 
@@ -112,7 +112,7 @@ class LoadableRoleCapabilityAssignmentProcessorTest {
     when(service.findAllByPermissions(List.of(permission))).thenReturn(perms);
 
     perms.forEach(perm -> {
-      when(roleCapabilityService.create(perm.getRoleId(), List.of(capabilityId), false)).thenReturn(null);
+      when(roleCapabilityService.create(perm.getRoleId(), List.of(capabilityId), true)).thenReturn(null);
 
       var permsWithCapabilityId = List.of(copy(perm).capabilityId(capabilityId));
       when(service.saveAll(permsWithCapabilityId)).thenReturn(permsWithCapabilityId);
@@ -123,7 +123,7 @@ class LoadableRoleCapabilityAssignmentProcessorTest {
     processor.handleCapabilitiesUpdateEvent(event);
 
     var firstLoadablePermission = perms.getFirst();
-    verify(roleCapabilityService).create(firstLoadablePermission.getRoleId(), List.of(capabilityId), false);
+    verify(roleCapabilityService).create(firstLoadablePermission.getRoleId(), List.of(capabilityId), true);
     verify(service).saveAll(List.of(copy(firstLoadablePermission).capabilityId(capabilityId)));
   }
 
@@ -153,7 +153,7 @@ class LoadableRoleCapabilityAssignmentProcessorTest {
     when(capabilityService.findByNames(List.of(capabilitySet.getName()))).thenReturn(List.of(capability));
     when(service.findAllByPermissions(List.of(capability.getPermission()))).thenReturn(perms);
     perms.forEach(perm -> {
-      when(roleCapabilitySetService.create(perm.getRoleId(), List.of(capabilitySet.getId()), false)).thenReturn(null);
+      when(roleCapabilitySetService.create(perm.getRoleId(), List.of(capabilitySet.getId()), true)).thenReturn(null);
 
       var permWithCapabilitySetId = copy(perm).capabilitySetId(capabilitySet.getId());
       when(service.save(permWithCapabilitySetId)).thenReturn(permWithCapabilitySetId);
@@ -164,7 +164,7 @@ class LoadableRoleCapabilityAssignmentProcessorTest {
     processor.handleCapabilitySetCreatedEvent(event);
 
     var firstLoadablePermission = perms.get(0);
-    verify(roleCapabilitySetService).create(firstLoadablePermission.getRoleId(), List.of(CAPABILITY_SET_ID), false);
+    verify(roleCapabilitySetService).create(firstLoadablePermission.getRoleId(), List.of(CAPABILITY_SET_ID), true);
     verify(service).save(copy(firstLoadablePermission).capabilitySetId(CAPABILITY_SET_ID));
   }
 


### PR DESCRIPTION
### **Purpose**
Fix for [MODROLESKC-347](https://folio-org.atlassian.net/browse/MODROLESKC-347)

### **Approach**
Provide a brief technical summary of the changes.

The [original raise condition fix](https://github.com/folio-org/mod-roles-keycloak/pull/354) is still valid.
However, Identified an additional race condition during QA testing. 

1. A first loadable role is created for permission "foo" before the capability exists, so its capability_id stays null in the `role_loadable_permission` table.
2. The capability "foo" is then created & committed to DB which triggers `handleCapabilitiesCreatedEvent(...)` `AFTER_COMMIT` hook.
3. Before `handleCapabilitiesCreatedEvent(..)` finishes, a second loadable role is created for "foo"; because the capability already exists, `capability_id` is immediately assigned to this role.
4. When `handleCapabilitiesCreatedEvent(..)` resumes, it tries to assign the same capability again to the already-assigned second role
Previously the processor called `roleCapabilityService.create(..., false)` and `roleCapabilitySetService.create(..., false)`, so the duplicate assignment threw `EntityExistsException` and stopped processing. As a result, the first unresolved role could remain with capability_id = null.

A test `handleCapabilityEvent_positive_whenOneMatchingRoleAlreadyHasCapabilityAndAnotherDoesNot ` has been created to simulate this scenario. This test was failing before & is passing after the change.

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key. -> NEWS.md is already updated as part of [previous PR](https://github.com/folio-org/mod-roles-keycloak/pull/354)
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
