### PR TITLE
NO-JIRA: add warn logging for Keycloak failures

### DIFF
--- a/src/main/java/org/folio/roles/integration/keyclock/KeycloakAuthorizationService.java
+++ b/src/main/java/org/folio/roles/integration/keyclock/KeycloakAuthorizationService.java
@@ -3,8 +3,8 @@ package org.folio.roles.integration.keyclock;
 import static jakarta.ws.rs.core.Response.Status.CONFLICT;
 import static jakarta.ws.rs.core.Response.Status.Family.SUCCESSFUL;
 import static java.lang.Integer.MAX_VALUE;
-import static java.lang.String.format;
 import static org.apache.commons.collections4.CollectionUtils.isEmpty;
+import static org.folio.roles.integration.keyclock.KeycloakResponseErrorHelper.errorDetails;
 
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.ws.rs.core.Response;
@@ -104,7 +104,11 @@ public class KeycloakAuthorizationService {
     var resourceRepresentation = resources.stream()
       .filter(resource -> Strings.CS.equals(staticPath, resource.getName()))
       .findFirst()
-      .orElseThrow(() -> new EntityNotFoundException("Keycloak resource is not found by static path: " + staticPath));
+      .orElseThrow(() -> {
+        var message = "Keycloak resource is not found by static path: " + staticPath;
+        log.warn(message);
+        return new EntityNotFoundException(message);
+      });
 
     log.debug("Keycloak resource found [value: {}]", () -> jsonHelper.asJsonStringSafe(resourceRepresentation));
     return resourceRepresentation;
@@ -159,9 +163,9 @@ public class KeycloakAuthorizationService {
       return;
     }
 
-    throw new ServiceException(format(
-      "Error during scope-based permission creation in Keycloak. Details: status = %s, message = %s",
-      statusInfo.getStatusCode(), statusInfo.getReasonPhrase()),
+    var details = errorDetails(response);
+    log.warn("Failed to create Keycloak permission [name: {}]. Details: {}", permission.getName(), details);
+    throw new ServiceException("Error during scope-based permission creation in Keycloak. Details: " + details,
       "permission", permission.getName());
   }
 }

--- a/src/main/java/org/folio/roles/integration/keyclock/KeycloakPolicyService.java
+++ b/src/main/java/org/folio/roles/integration/keyclock/KeycloakPolicyService.java
@@ -4,6 +4,7 @@ import static jakarta.ws.rs.core.Response.Status.Family.SUCCESSFUL;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static org.folio.common.utils.CollectionUtils.toStream;
+import static org.folio.roles.integration.keyclock.KeycloakResponseErrorHelper.errorDetails;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
@@ -183,8 +184,10 @@ public class KeycloakPolicyService {
       return;
     }
 
-    throw new KeycloakApiException(format(
-      "Error during policy creation in Keycloak. Details: id = %s, status = %s, message = %s", policy.getId(),
-      statusInfo.getStatusCode(), statusInfo.getReasonPhrase()), null, response.getStatus());
+    var details = errorDetails(response);
+    log.warn("Failed to create Keycloak policy [id: {}, name: {}]. Details: {}",
+      policy.getId(), policy.getName(), details);
+    throw new KeycloakApiException(format("Error during policy creation in Keycloak. Details: id = %s, %s",
+      policy.getId(), details), null, response.getStatus());
   }
 }

--- a/src/main/java/org/folio/roles/integration/keyclock/KeycloakResponseErrorHelper.java
+++ b/src/main/java/org/folio/roles/integration/keyclock/KeycloakResponseErrorHelper.java
@@ -3,12 +3,11 @@ package org.folio.roles.integration.keyclock;
 import static java.lang.String.format;
 
 import jakarta.ws.rs.core.Response;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
+import lombok.experimental.UtilityClass;
 import org.apache.commons.lang3.StringUtils;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
-final class KeycloakResponseErrorHelper {
+@UtilityClass
+public class KeycloakResponseErrorHelper {
 
   private static final int MAX_RESPONSE_BODY_LENGTH = 2048;
 

--- a/src/main/java/org/folio/roles/integration/keyclock/KeycloakResponseErrorHelper.java
+++ b/src/main/java/org/folio/roles/integration/keyclock/KeycloakResponseErrorHelper.java
@@ -1,0 +1,36 @@
+package org.folio.roles.integration.keyclock;
+
+import static java.lang.String.format;
+
+import jakarta.ws.rs.core.Response;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+final class KeycloakResponseErrorHelper {
+
+  private static final int MAX_RESPONSE_BODY_LENGTH = 2048;
+
+  static String errorDetails(Response response) {
+    var statusInfo = response.getStatusInfo();
+    var details = format("status = %s, message = %s", statusInfo.getStatusCode(), statusInfo.getReasonPhrase());
+    var responseBody = responseBody(response);
+    return responseBody == null ? details : details + ", responseBody = " + responseBody;
+  }
+
+  private static String responseBody(Response response) {
+    try {
+      if (!response.hasEntity()) {
+        return null;
+      }
+
+      var responseBody = response.readEntity(String.class);
+      return StringUtils.isBlank(responseBody)
+        ? null
+        : StringUtils.abbreviate(StringUtils.normalizeSpace(responseBody), MAX_RESPONSE_BODY_LENGTH);
+    } catch (RuntimeException exception) {
+      return format("unavailable: %s: %s", exception.getClass().getSimpleName(), exception.getMessage());
+    }
+  }
+}

--- a/src/main/java/org/folio/roles/service/loadablerole/LoadableRoleService.java
+++ b/src/main/java/org/folio/roles/service/loadablerole/LoadableRoleService.java
@@ -116,7 +116,7 @@ public class LoadableRoleService {
     try {
       keycloakService.deleteById(id);
     } catch (Exception exception) {
-      log.debug("Failed to delete Role in Keycloak: id = {}", id, exception);
+      log.warn("Failed to delete Role in Keycloak: id = {}", id, exception);
     }
   }
 

--- a/src/test/java/org/folio/roles/integration/keyclock/KeycloakAuthorizationServiceTest.java
+++ b/src/test/java/org/folio/roles/integration/keyclock/KeycloakAuthorizationServiceTest.java
@@ -58,9 +58,11 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 
 @UnitTest
-@ExtendWith(MockitoExtension.class)
+@ExtendWith({MockitoExtension.class, OutputCaptureExtension.class})
 class KeycloakAuthorizationServiceTest {
 
   private static final String SCOPE_ID = UUID.randomUUID().toString();
@@ -230,7 +232,7 @@ class KeycloakAuthorizationServiceTest {
     }
 
     @Test
-    void negative_permissionIsNotCreated() {
+    void negative_permissionIsNotCreated(CapturedOutput output) {
       when(authResourceProvider.createAuthorizationClient()).thenReturn(authorizationClient);
       when(authorizationClient.resources()).thenReturn(authResourcesClient);
       when(authorizationClient.permissions()).thenReturn(authPermissionsClient);
@@ -242,6 +244,10 @@ class KeycloakAuthorizationServiceTest {
       when(authResourcesClient.find(path, null, null, null, null, 0, MAX_VALUE)).thenReturn(resourceRepresentations);
       when(scopePermissionsClient.create(scopePermissionCaptor.capture())).thenReturn(response);
       when(response.getStatusInfo()).thenReturn(Status.INTERNAL_SERVER_ERROR);
+      when(response.hasEntity()).thenReturn(true);
+      when(response.readEntity(String.class)).thenReturn("""
+        {"error":"server_error","error_description":"Scope permission rejected"}
+        """);
 
       var policy = rolePolicy();
       var endpoints = List.of(endpoint("/foo/entities", GET));
@@ -249,9 +255,17 @@ class KeycloakAuthorizationServiceTest {
       assertThatThrownBy(() -> keycloakAuthService.createPermissions(policy, endpoints, PERMISSION_NAME_GENERATOR))
         .isInstanceOf(ServiceException.class)
         .hasMessage("Error during scope-based permission creation in Keycloak. "
-          + "Details: status = 500, message = Internal Server Error");
+          + "Details: status = 500, message = Internal Server Error, "
+          + "responseBody = {\"error\":\"server_error\",\"error_description\":\"Scope permission rejected\"}");
+
+      assertThat(output.getAll())
+        .contains("Failed to create Keycloak permission [name: GET access to /foo/entities]. Details: "
+          + "status = 500, message = Internal Server Error, "
+          + "responseBody = {\"error\":\"server_error\",\"error_description\":\"Scope permission rejected\"}");
 
       verify(response).close();
+      verify(response).hasEntity();
+      verify(response).readEntity(String.class);
       verify(jsonHelper).asJsonStringSafe(resourceRepresentation);
       assertThat(scopePermissionCaptor.getValue())
         .usingRecursiveComparison()

--- a/src/test/java/org/folio/roles/integration/keyclock/KeycloakPolicyServiceTest.java
+++ b/src/test/java/org/folio/roles/integration/keyclock/KeycloakPolicyServiceTest.java
@@ -45,9 +45,11 @@ import org.keycloak.admin.client.resource.PolicyResource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 
 @UnitTest
-@ExtendWith(MockitoExtension.class)
+@ExtendWith({MockitoExtension.class, OutputCaptureExtension.class})
 class KeycloakPolicyServiceTest {
 
   @InjectMocks private KeycloakPolicyService keycloakPolicyService;
@@ -167,21 +169,34 @@ class KeycloakPolicyServiceTest {
     }
 
     @Test
-    void positive_notAuthorizedException() {
+    void positive_notAuthorizedException(CapturedOutput output) {
       var timePolicy = timePolicy();
       var keycloakPolicy = keycloakTimePolicy();
       var response = mock(Response.class);
 
       when(response.getStatusInfo()).thenReturn(Status.UNAUTHORIZED);
+      when(response.hasEntity()).thenReturn(true);
+      when(response.readEntity(String.class)).thenReturn("""
+        {"error":"unauthorized","error_description":"Policy creation is not allowed"}
+        """);
       when(keycloakPolicyMapper.toKeycloakPolicy(timePolicy, PolicyMapperContext.empty())).thenReturn(keycloakPolicy);
       when(authClientProvider.getAuthorizationClient()).thenReturn(authorizationResource);
       when(authorizationResource.policies().create(keycloakPolicy)).thenReturn(response);
 
       assertThatThrownBy(() -> keycloakPolicyService.create(timePolicy))
         .isInstanceOf(KeycloakApiException.class)
-        .hasMessage("Error during policy creation in Keycloak. Details: id = %s, status = %s, message = %s",
-          POLICY_ID, 401, "Unauthorized");
+        .hasMessage("Error during policy creation in Keycloak. Details: id = %s, status = %s, message = %s, "
+          + "responseBody = %s", POLICY_ID, 401, "Unauthorized",
+          "{\"error\":\"unauthorized\",\"error_description\":\"Policy creation is not allowed\"}");
 
+      assertThat(output.getAll())
+        .contains("Failed to create Keycloak policy [id: " + POLICY_ID + ", name: Test time policy]. Details: "
+          + "status = 401, message = Unauthorized, "
+          + "responseBody = {\"error\":\"unauthorized\",\"error_description\":\"Policy creation is not allowed\"}");
+
+      verify(response).close();
+      verify(response).hasEntity();
+      verify(response).readEntity(String.class);
       verify(authorizationResource, atLeastOnce()).policies();
     }
   }

--- a/src/test/java/org/folio/roles/integration/keyclock/KeycloakResponseErrorHelperTest.java
+++ b/src/test/java/org/folio/roles/integration/keyclock/KeycloakResponseErrorHelperTest.java
@@ -1,0 +1,84 @@
+package org.folio.roles.integration.keyclock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import jakarta.ws.rs.ProcessingException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import org.folio.test.types.UnitTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class KeycloakResponseErrorHelperTest {
+
+  @Mock private Response response;
+
+  @Test
+  void errorDetails_positive_responseBodyIsPresent() {
+    when(response.getStatusInfo()).thenReturn(Status.INTERNAL_SERVER_ERROR);
+    when(response.hasEntity()).thenReturn(true);
+    when(response.readEntity(String.class)).thenReturn("""
+      {"error":"server_error", "error_description":"Permission rejected"}
+      """);
+
+    var result = KeycloakResponseErrorHelper.errorDetails(response);
+
+    assertThat(result).isEqualTo("status = 500, message = Internal Server Error, "
+      + "responseBody = {\"error\":\"server_error\", \"error_description\":\"Permission rejected\"}");
+    verify(response).getStatusInfo();
+    verify(response).hasEntity();
+    verify(response).readEntity(String.class);
+    verifyNoMoreInteractions(response);
+  }
+
+  @Test
+  void errorDetails_positive_responseBodyIsAbsent() {
+    when(response.getStatusInfo()).thenReturn(Status.UNAUTHORIZED);
+    when(response.hasEntity()).thenReturn(false);
+
+    var result = KeycloakResponseErrorHelper.errorDetails(response);
+
+    assertThat(result).isEqualTo("status = 401, message = Unauthorized");
+    verify(response).getStatusInfo();
+    verify(response).hasEntity();
+    verifyNoMoreInteractions(response);
+  }
+
+  @Test
+  void errorDetails_positive_responseBodyIsBlank() {
+    when(response.getStatusInfo()).thenReturn(Status.BAD_REQUEST);
+    when(response.hasEntity()).thenReturn(true);
+    when(response.readEntity(String.class)).thenReturn("  \n ");
+
+    var result = KeycloakResponseErrorHelper.errorDetails(response);
+
+    assertThat(result).isEqualTo("status = 400, message = Bad Request");
+    verify(response).getStatusInfo();
+    verify(response).hasEntity();
+    verify(response).readEntity(String.class);
+    verifyNoMoreInteractions(response);
+  }
+
+  @Test
+  void errorDetails_positive_responseBodyReadFails() {
+    when(response.getStatusInfo()).thenReturn(Status.INTERNAL_SERVER_ERROR);
+    when(response.hasEntity()).thenReturn(true);
+    when(response.readEntity(String.class)).thenThrow(new ProcessingException("stream closed"));
+
+    var result = KeycloakResponseErrorHelper.errorDetails(response);
+
+    assertThat(result).isEqualTo("status = 500, message = Internal Server Error, "
+      + "responseBody = unavailable: ProcessingException: stream closed");
+    verify(response).getStatusInfo();
+    verify(response).hasEntity();
+    verify(response).readEntity(String.class);
+    verifyNoMoreInteractions(response);
+  }
+}

--- a/src/test/java/org/folio/roles/service/loadablerole/LoadableRoleServiceTest.java
+++ b/src/test/java/org/folio/roles/service/loadablerole/LoadableRoleServiceTest.java
@@ -10,6 +10,7 @@ import static org.folio.roles.support.LoadableRoleUtils.regularRole;
 import static org.folio.roles.support.RoleUtils.role;
 import static org.folio.roles.support.TestUtils.copy;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -34,11 +35,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 
 @UnitTest
-@ExtendWith(MockitoExtension.class)
+@ExtendWith({MockitoExtension.class, OutputCaptureExtension.class})
 @ExtendWith(InstancioExtension.class)
 class LoadableRoleServiceTest {
 
@@ -176,6 +179,25 @@ class LoadableRoleServiceTest {
       service.cleanupDefaultRolesFromKeycloak();
 
       verifyNoInteractions(keycloakService);
+    }
+
+    @Test
+    void positive_keycloakDeleteFails_logsWarn(CapturedOutput output) {
+      var role = role();
+      var loadableRole = loadableRoleEntity(loadableRole());
+      var exception = new RuntimeException("Keycloak is unavailable");
+
+      when(repository.findAllByType(EntityRoleType.DEFAULT))
+        .thenReturn(Stream.of(loadableRole));
+      when(keycloakService.findByName(loadableRole.getName()))
+        .thenReturn(Optional.of(role));
+      doThrow(exception).when(keycloakService).deleteById(role.getId());
+
+      service.cleanupDefaultRolesFromKeycloak();
+
+      assertThat(output.getAll()).contains("Failed to delete Role in Keycloak: id = " + role.getId());
+      assertThat(output.getAll()).contains("Keycloak is unavailable");
+      verify(keycloakService).deleteById(role.getId());
     }
   }
 


### PR DESCRIPTION
### **Purpose**
These changes add warn-level logging for Keycloak permission and policy creation failures so missing resources and rejected writes are visible in service logs with actionable context.
They also propagate Keycloak response details into thrown exceptions to preserve the failure reason during error handling.
No Jira ticket.

### **Approach**
- add warn logs for missing Keycloak resources and failed permission or policy creation responses
- extract common response-detail formatting into `KeycloakResponseErrorHelper` and reuse it in exception messages
- raise the suppressed Keycloak role cleanup delete failure from `debug` to `warn`
- extend the Keycloak integration unit tests to assert that failure details are surfaced in exceptions and logs

---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.