### PR TITLE
docs: document default role provisioning feature

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -5,6 +5,7 @@ This module provides the following features:
 | Feature | Description | Status |
 |---------|-------------|--------|
 | [Capability Event Migration Guard](features/capability-event-migration-guard.md) | Detects active Liquibase migrations before processing Kafka capability events and retries with back-off until the schema is ready | Active |
+| [Default Role Provisioning](features/default-role-provisioning.md) | Creates or updates default roles via `/loadable-roles` and backfills permission links as matching capability data becomes available | Active |
 | [User Permissions Cache](features/user-permissions-cache.md) | Caches user permission lookups with tenant-scoped eviction on role/capability changes | Active |
 | [Capability Event Deduplication](features/capability-event-deduplication.md) | De-duplicates capabilities by generated name and merges single-endpoint PUT/PATCH pairs for the same path | Active |
 | [Entitled User Permission Filtering](features/entitled-user-permission-filtering.md) | Filters user permissions to only those from applications currently entitled for the tenant when `entitledOnly=true` | Active |

--- a/docs/features/default-role-provisioning.md
+++ b/docs/features/default-role-provisioning.md
@@ -1,0 +1,37 @@
+---
+feature_id: default-role-provisioning
+title: Default Role Provisioning
+updated: 2026-05-13
+---
+
+# Default Role Provisioning
+
+## What it does
+`PUT /loadable-roles` creates or updates a default role from a loadable-role payload and returns the stored role representation. Submitted permissions are linked to matching capabilities or capability sets immediately when those records already exist, and unresolved permissions are completed later as matching capability data becomes available.
+
+## Why it exists
+Default roles are not managed through the generic `/roles` API in this module. This feature provides the supported path for provisioning default roles while still allowing role setup to succeed before all referenced capabilities or capability sets have been registered.
+
+## Entry point(s)
+| Method | Path | Description |
+|--------|------|-------------|
+| PUT | /loadable-roles | Creates or updates a default role from a loadable-role payload |
+
+## Business rules and constraints
+- The request body uses the `loadableRole` schema. `name` is required, and when permissions are supplied each permission entry must include `permissionName`.
+- The service always stores the role as type `DEFAULT`, regardless of the incoming `type` value.
+- If the submitted `id` or `name` matches an existing role, the existing role ID is reused and the role is updated instead of creating a second default role.
+- On update, the stored permission set is reconciled against the submitted list: newly submitted permissions are added, and previously stored permissions omitted from the request are removed.
+- If matching capabilities or capability sets already exist for submitted permissions, they are linked during the upsert request.
+- If matching capability data does not exist yet, the request can still succeed; unresolved permissions are retried after commit and are also repaired when later capability events are processed.
+- Default roles cannot be created, updated, or deleted through the `/roles` API; that API rejects default-role requests with `400 Bad Request`.
+
+## Error behavior
+- Request validation failures and malformed request bodies return `400 Bad Request`.
+- Service-level failures wrapped as `ServiceException` are returned as `400 Bad Request`.
+- Uncaught exceptions fall back to `500 Internal Server Error`.
+
+## Dependencies and interactions
+- Keycloak role record: a successful upsert creates or updates the corresponding role in Keycloak. For newly created default roles, the Keycloak role ID becomes the persisted role ID; if the database write then fails, the service deletes the newly created Keycloak role as rollback.
+- Capability and capability-set records: during the upsert request, submitted permission names are matched against existing capabilities and capability sets. Matches create role-to-capability or role-to-capability-set links immediately and populate stored `capabilityId` or `capabilitySetId` values for the affected loadable permissions.
+- Kafka capability events: if a submitted permission is still unresolved when the request commits, later capability `CREATE` and `UPDATE` events consumed from the `mgr-tenant-entitlements.capability` topic pattern are used to backfill the missing role-capability links for matching permissions.


### PR DESCRIPTION
### **Purpose**
This change adds feature documentation for default role provisioning through `PUT /loadable-roles`. It documents the externally observable behavior of the endpoint, including how default roles are created or updated and how permission links are resolved over time. No Jira ticket is associated with this docs-only change.

### **Approach**
- add `docs/features/default-role-provisioning.md` for the default-role upsert flow
- update `docs/features.md` to index the new feature document
- describe the behavior, constraints, error handling, and concrete integrations involved in the flow

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.