### PR TITLE
MODROLESKC-411: Upgrade dependencies for Kafka 4.2 compatibility in mod-roles-keycloak

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 * Improve cleanup of keycloak records upon role removal (MODROLESKC-384)
 * Fix race condition that could leave default loadable-role permissions without assigned capabilities during tenant initialization (MODROLESKC-347)
 * Delete the Log4j configuration so the logging settings are automatically inherited from `folio-spring-base`. (EUREKA-889)
+* Upgrade dependencies for Kafka 4.2 compatibility in mod-roles-keycloak (MODROLESKC-411)
 
 ## Version `v4.0.0` (16.04.2025)
 * Added endpoint to create or update default roles via REST API (MODROLESKC-301)

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
     <folio-spring-support.version>10.0.0</folio-spring-support.version>
     <folio-java-checkstyle.version>1.2.0</folio-java-checkstyle.version>
     <applications-poc-tools.version>4.1.0-SNAPSHOT</applications-poc-tools.version>
+    <kafka.version>4.2.0</kafka.version> <!-- can be removed once Spring Boot migrates to this version -->
 
     <mod-roles-keycloak.yaml-file>${project.basedir}/src/main/resources/swagger.api/mod-roles-keycloak.yaml
     </mod-roles-keycloak.yaml-file>

--- a/src/main/java/org/folio/roles/integration/kafka/KafkaMessageListener.java
+++ b/src/main/java/org/folio/roles/integration/kafka/KafkaMessageListener.java
@@ -1,5 +1,6 @@
 package org.folio.roles.integration.kafka;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.folio.integration.kafka.model.ResourceEvent;
@@ -11,6 +12,7 @@ import org.folio.spring.liquibase.LiquibaseMigrationLockService;
 import org.folio.spring.scope.FolioExecutionContextSetter;
 import org.folio.spring.service.SystemUserScopedExecutionService;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Service;
 
 @Log4j2
@@ -40,7 +42,7 @@ public class KafkaMessageListener {
     groupId = "#{kafkaConsumerProperties.listener['capability'].groupId}",
     topicPattern = "#{kafkaConsumerProperties.listener['capability'].topicPattern}",
     filter = "tenantAwareMessageFilter")
-  public void handleCapabilityEvent(ResourceEvent<?> resourceEvent) {
+  public void handleCapabilityEvent(@Payload @Valid ResourceEvent<?> resourceEvent) {
     try (
       var ignored = new FolioExecutionContextSetter(executionContextBuilder.buildContext(resourceEvent.getTenant()))) {
       try {

--- a/src/main/java/org/folio/roles/integration/kafka/configuration/KafkaConfiguration.java
+++ b/src/main/java/org/folio/roles/integration/kafka/configuration/KafkaConfiguration.java
@@ -22,22 +22,26 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.dao.InvalidDataAccessResourceUsageException;
 import org.springframework.kafka.KafkaException.Level;
+import org.springframework.kafka.annotation.KafkaListenerConfigurer;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.config.KafkaListenerEndpointRegistrar;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.listener.DefaultErrorHandler;
 import org.springframework.kafka.support.serializer.JacksonJsonDeserializer;
 import org.springframework.util.backoff.BackOff;
 import org.springframework.util.backoff.FixedBackOff;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 
 @Log4j2
 @Configuration
 @EnableKafkaConsumer
 @RequiredArgsConstructor
-public class KafkaConfiguration {
+public class KafkaConfiguration implements KafkaListenerConfigurer {
 
   private final KafkaProperties kafkaProperties;
   private final CapabilityEventRetryConfiguration retryConfiguration;
+  private final LocalValidatorFactoryBean validator;
 
   @Bean
   public ConcurrentKafkaListenerContainerFactory<String, ResourceEvent<?>> kafkaListenerContainerFactory(
@@ -56,6 +60,11 @@ public class KafkaConfiguration {
     config.put(VALUE_DESERIALIZER_CLASS_CONFIG, deserializer);
     config.put(AUTO_OFFSET_RESET_CONFIG, "earliest");
     return new DefaultKafkaConsumerFactory<>(config, new StringDeserializer(), deserializer);
+  }
+
+  @Override
+  public void configureKafkaListeners(KafkaListenerEndpointRegistrar registrar) {
+    registrar.setValidator(this.validator);
   }
 
   private DefaultErrorHandler capabilityEventErrorHandler() {

--- a/src/test/java/org/folio/roles/integration/kafka/configuration/KafkaConfigurationErrorDetectionTest.java
+++ b/src/test/java/org/folio/roles/integration/kafka/configuration/KafkaConfigurationErrorDetectionTest.java
@@ -89,7 +89,7 @@ class KafkaConfigurationErrorDetectionTest {
     var retryDelay = Duration.ofMillis(500);
     var retryAttempts = 10L;
     var retryConfig = createRetryConfiguration(retryDelay, retryAttempts);
-    var kafkaConfig = new KafkaConfiguration(new KafkaProperties(), retryConfig);
+    var kafkaConfig = new KafkaConfiguration(new KafkaProperties(), retryConfig, null);
     var exception = new LiquibaseMigrationException("Migration in progress for tenant: test");
 
     // when


### PR DESCRIPTION
### **Purpose**
Upgrades the Kafka client to version 4.2.0 ahead of the Spring Boot managed version, and adds bean validation support for Kafka listener payloads.
US: [MODROLESKC-411](https://folio-org.atlassian.net/browse/MODROLESKC-411)

### **Approach**
The Kafka client version is pinned to `4.2.0` in `pom.xml` to override the Spring Boot-managed version. Alongside the upgrade, `KafkaListenerConfigurer` is introduced to wire bean validation into the Kafka listener lifecycle, and `@Payload @Valid` is added to the capability event listener method.

**Implementation details:**

- Pinned `kafka.version` to `4.2.0` in `pom.xml` to override the Spring Boot-managed version; can be removed once Spring Boot adopts this version natively.
- Changed `KafkaConfiguration` to implement `KafkaListenerConfigurer` and added `configureKafkaListeners` override that registers `LocalValidatorFactoryBean` with the `KafkaListenerEndpointRegistrar`.
- Added `@Payload @Valid` annotations to the `handleCapabilityEvent` parameter to enable bean validation on incoming `ResourceEvent` messages.

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.