### PR TITLE
MODROLESKC-408: add dedup param for roles/capabilities API and performance indexes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * Fix race condition that could leave default loadable-role permissions without assigned capabilities during tenant initialization (MODROLESKC-347)
 * Delete the Log4j configuration so the logging settings are automatically inherited from `folio-spring-base`. (EUREKA-889)
 * Upgrade dependencies for Kafka 4.2 compatibility in mod-roles-keycloak (MODROLESKC-411)
+* Add `dedup` query parameter and `direct` flag for `GET /roles/{id}/capabilities`, add performance indexes (MODROLESKC-408)
 
 ## Version `v4.0.0` (16.04.2025)
 * Added endpoint to create or update default roles via REST API (MODROLESKC-301)

--- a/src/main/java/org/folio/roles/controller/RoleCapabilityController.java
+++ b/src/main/java/org/folio/roles/controller/RoleCapabilityController.java
@@ -1,6 +1,7 @@
 package org.folio.roles.controller;
 
-import static java.lang.Boolean.TRUE;
+import static org.apache.commons.lang3.BooleanUtils.isNotFalse;
+import static org.apache.commons.lang3.BooleanUtils.isTrue;
 import static org.springframework.http.HttpStatus.CREATED;
 
 import java.util.UUID;
@@ -35,11 +36,11 @@ public class RoleCapabilityController implements RoleCapabilityApi {
   }
 
   @Override
-  public ResponseEntity<Capabilities> findCapabilitiesByRoleId(UUID id, Boolean expand, Boolean includeDummy,
-    Integer limit, Integer offset) {
+  public ResponseEntity<Capabilities> findCapabilitiesByRoleId(UUID id, Boolean expand, Boolean dedup,
+    Boolean includeDummy, Integer limit, Integer offset) {
     roleEntityService.getById(id);
-    var pageResult = capabilityService.findByRoleId(id, TRUE.equals(expand),
-      TRUE.equals(includeDummy), limit, offset);
+    var pageResult = capabilityService.findByRoleId(
+      id, isTrue(expand), isTrue(includeDummy), isNotFalse(dedup), limit, offset);
     return ResponseEntity.ok(new Capabilities()
       .capabilities(pageResult.getRecords())
       .totalRecords(pageResult.getTotalRecords()));

--- a/src/main/java/org/folio/roles/mapper/entity/CapabilityEntityMapper.java
+++ b/src/main/java/org/folio/roles/mapper/entity/CapabilityEntityMapper.java
@@ -25,6 +25,7 @@ public interface CapabilityEntityMapper {
   EmbeddableEndpoint convert(Endpoint endpoint);
 
   @AuditableMapping
+  @Mapping(target = "direct", ignore = true)
   Capability convert(CapabilityEntity entity);
 
   List<Capability> convert(List<CapabilityEntity> entities);

--- a/src/main/java/org/folio/roles/repository/CapabilityRepository.java
+++ b/src/main/java/org/folio/roles/repository/CapabilityRepository.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import org.folio.roles.domain.entity.CapabilityEntity;
+import org.folio.roles.repository.projection.CapabilityDirectProjection;
 import org.folio.roles.repository.projection.UserPermissionApplicationProjection;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -187,6 +188,60 @@ public interface CapabilityRepository extends BaseCqlJpaRepository<CapabilityEnt
           INNER JOIN capability c ON csc.capability_id = c.id
       ) capability WHERE capability.dummy_capability = false""")
   Page<CapabilityEntity> findAllByRoleId(@Param("roleId") UUID roleId, Pageable pageable);
+
+  @Query(nativeQuery = true,
+    value = """
+      SELECT capability.id AS id, capability.name AS name, capability.is_direct AS direct FROM (
+        SELECT c.id, c.name, c.dummy_capability, true AS is_direct FROM capability c
+          INNER JOIN role_capability rc ON c.id = rc.capability_id AND rc.role_id = :roleId
+
+        UNION ALL
+
+        SELECT c.id, c.name, c.dummy_capability, false AS is_direct FROM capability_set cs
+          INNER JOIN role_capability_set rcs ON cs.id = rcs.capability_set_id AND rcs.role_id = :roleId
+          INNER JOIN capability_set_capability csc ON cs.id = csc.capability_set_id
+          INNER JOIN capability c ON csc.capability_id = c.id
+      ) capability""",
+    countQuery = """
+      SELECT COUNT(*) FROM (
+        SELECT c.id FROM capability c
+          INNER JOIN role_capability rc ON c.id = rc.capability_id AND rc.role_id = :roleId
+
+        UNION ALL
+
+        SELECT c.id FROM capability_set cs
+          INNER JOIN role_capability_set rcs ON cs.id = rcs.capability_set_id AND rcs.role_id = :roleId
+          INNER JOIN capability_set_capability csc ON cs.id = csc.capability_set_id
+          INNER JOIN capability c ON csc.capability_id = c.id
+      ) capability""")
+  Page<CapabilityDirectProjection> findAllByRoleIdNoDedupIncludeDummy(@Param("roleId") UUID roleId, Pageable pageable);
+
+  @Query(nativeQuery = true,
+    value = """
+      SELECT capability.id AS id, capability.name AS name, capability.is_direct AS direct FROM (
+        SELECT c.id, c.name, c.dummy_capability, true AS is_direct FROM capability c
+          INNER JOIN role_capability rc ON c.id = rc.capability_id AND rc.role_id = :roleId
+
+        UNION ALL
+
+        SELECT c.id, c.name, c.dummy_capability, false AS is_direct FROM capability_set cs
+          INNER JOIN role_capability_set rcs ON cs.id = rcs.capability_set_id AND rcs.role_id = :roleId
+          INNER JOIN capability_set_capability csc ON cs.id = csc.capability_set_id
+          INNER JOIN capability c ON csc.capability_id = c.id
+      ) capability WHERE capability.dummy_capability = false""",
+    countQuery = """
+      SELECT COUNT(*) FROM (
+        SELECT c.id, c.dummy_capability FROM capability c
+          INNER JOIN role_capability rc ON c.id = rc.capability_id AND rc.role_id = :roleId
+
+        UNION ALL
+
+        SELECT c.id, c.dummy_capability FROM capability_set cs
+          INNER JOIN role_capability_set rcs ON cs.id = rcs.capability_set_id AND rcs.role_id = :roleId
+          INNER JOIN capability_set_capability csc ON cs.id = csc.capability_set_id
+          INNER JOIN capability c ON csc.capability_id = c.id
+      ) capability WHERE capability.dummy_capability = false""")
+  Page<CapabilityDirectProjection> findAllByRoleIdNoDedup(@Param("roleId") UUID roleId, Pageable pageable);
 
   @Query("""
     select entity from CapabilityEntity entity where entity.name in :names

--- a/src/main/java/org/folio/roles/repository/RoleCapabilityRepository.java
+++ b/src/main/java/org/folio/roles/repository/RoleCapabilityRepository.java
@@ -1,6 +1,7 @@
 package org.folio.roles.repository;
 
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import org.folio.roles.domain.entity.RoleCapabilityEntity;
 import org.folio.roles.domain.entity.key.RoleCapabilityKey;
@@ -19,6 +20,9 @@ public interface RoleCapabilityRepository extends BaseCqlJpaRepository<RoleCapab
     inner join CapabilityEntity ce on ce.id = rce.capabilityId and ce.dummyCapability = false
     where rce.roleId = :roleId""")
   List<RoleCapabilityEntity> findAllByRoleId(UUID roleId);
+
+  @Query("select rce.capabilityId from RoleCapabilityEntity rce where rce.roleId = :roleId")
+  Set<UUID> findCapabilityIdsByRoleId(@Param("roleId") UUID roleId);
 
   @Query("""
     select rce from RoleCapabilityEntity rce

--- a/src/main/java/org/folio/roles/repository/projection/CapabilityDirectProjection.java
+++ b/src/main/java/org/folio/roles/repository/projection/CapabilityDirectProjection.java
@@ -1,0 +1,20 @@
+package org.folio.roles.repository.projection;
+
+import java.util.UUID;
+
+/**
+ * Projection for a role capability row tagged with its origin (direct assignment vs. capability set).
+ */
+public interface CapabilityDirectProjection {
+
+  /**
+   * Returns the capability identifier.
+   */
+  UUID getId();
+
+  /**
+   * Returns {@code true} if the capability was directly assigned to the role,
+   * {@code false} if it was inherited via a capability set.
+   */
+  Boolean getDirect();
+}

--- a/src/main/java/org/folio/roles/service/capability/CapabilityService.java
+++ b/src/main/java/org/folio/roles/service/capability/CapabilityService.java
@@ -2,6 +2,7 @@ package org.folio.roles.service.capability;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
+import static java.util.function.Function.identity;
 import static java.util.function.Predicate.not;
 import static java.util.stream.Collectors.groupingBy;
 import static org.apache.commons.collections4.CollectionUtils.isEmpty;
@@ -10,6 +11,7 @@ import static org.folio.common.utils.CollectionUtils.mapItems;
 import static org.folio.common.utils.CollectionUtils.toStream;
 import static org.folio.common.utils.Collectors.toLinkedHashMap;
 import static org.folio.integration.kafka.model.ResourceEventType.CREATE;
+import static org.folio.roles.domain.entity.CapabilityEntity.DEFAULT_CAPABILITY_SORT;
 import static org.folio.roles.utils.CollectionUtils.toSet;
 
 import jakarta.persistence.EntityNotFoundException;
@@ -35,11 +37,15 @@ import org.folio.roles.domain.model.event.CapabilityEvent;
 import org.folio.roles.integration.mte.MteEntitlementService;
 import org.folio.roles.mapper.entity.CapabilityEntityMapper;
 import org.folio.roles.repository.CapabilityRepository;
+import org.folio.roles.repository.RoleCapabilityRepository;
+import org.folio.roles.repository.projection.CapabilityDirectProjection;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.data.OffsetRequest;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Order;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -51,6 +57,7 @@ public class CapabilityService {
   public static final List<String> VISIBLE_PERMISSION_PREFIXES = List.of("ui-", "module", "plugin");
 
   private final CapabilityRepository capabilityRepository;
+  private final RoleCapabilityRepository roleCapabilityRepository;
   private final FolioExecutionContext folioExecutionContext;
   private final CapabilityEntityMapper capabilityEntityMapper;
   private final ApplicationEventPublisher applicationEventPublisher;
@@ -117,7 +124,7 @@ public class CapabilityService {
    */
   @Transactional(readOnly = true)
   public PageResult<Capability> find(String query, int limit, int offset) {
-    var offsetRequest = OffsetRequest.of(offset, limit, CapabilityEntity.DEFAULT_CAPABILITY_SORT);
+    var offsetRequest = OffsetRequest.of(offset, limit, DEFAULT_CAPABILITY_SORT);
     var capabilityEntities = capabilityRepository.findByQuery(query, offsetRequest);
     var capabilitiesPage = capabilityEntities.map(capabilityEntityMapper::convert);
     return PageResult.fromPage(capabilitiesPage);
@@ -135,7 +142,7 @@ public class CapabilityService {
    */
   @Transactional(readOnly = true)
   public PageResult<Capability> findByUserId(UUID userId, boolean expand, boolean includeDummy, int limit, int offset) {
-    var offsetRequest = OffsetRequest.of(offset, limit, CapabilityEntity.DEFAULT_CAPABILITY_SORT);
+    var offsetRequest = OffsetRequest.of(offset, limit, DEFAULT_CAPABILITY_SORT);
     var capabilityEntitiesPage = expand
       ? findAllCapabilityEntitiesByUserId(includeDummy, userId, offsetRequest)
       : findCapabilityEntitiesByUserId(includeDummy, userId, offsetRequest);
@@ -145,7 +152,7 @@ public class CapabilityService {
   }
 
   /**
-   * Retrieves capabilities by role id.
+   * Retrieves capabilities by role id (deduplicated).
    *
    * @param roleId - role identifier as {@link UUID} object
    * @param expand - defines if capability sets must be expanded
@@ -156,13 +163,74 @@ public class CapabilityService {
    */
   @Transactional(readOnly = true)
   public PageResult<Capability> findByRoleId(UUID roleId, boolean expand, boolean includeDummy, int limit, int offset) {
-    var offsetRequest = OffsetRequest.of(offset, limit, CapabilityEntity.DEFAULT_CAPABILITY_SORT);
-    var capabilityEntitiesPage = expand
-      ? findAllCapabilityEntitiesByRoleId(includeDummy, roleId, offsetRequest)
-      : findCapabilityEntitiesByRoleId(includeDummy, roleId, offsetRequest);
+    return findByRoleId(roleId, expand, includeDummy, true, limit, offset);
+  }
 
-    var capabilitiesPage = capabilityEntitiesPage.map(capabilityEntityMapper::convert);
+  /**
+   * Retrieves capabilities by role id.
+   *
+   * <p>Each returned {@link Capability} carries a {@code direct} flag indicating whether it was directly
+   * assigned to the role ({@code true}) or inherited via a capability set ({@code false}). When
+   * {@code dedup} is {@code false} and {@code expand} is {@code true}, a capability that is both directly
+   * assigned and present in a capability set is returned more than once, preserving each row's origin.</p>
+   *
+   * @param roleId - role identifier as {@link UUID} object
+   * @param expand - defines if capability sets must be expanded
+   * @param includeDummy - defines if capability set should include dummy capabilities
+   * @param dedup - defines if duplicate capabilities (direct + via capability set) must be deduplicated
+   * @param limit - a number of results in response
+   * @param offset - offset in pagination from first record
+   * @return {@link PageResult} object with found {@link Capability} relation descriptors
+   */
+  @Transactional(readOnly = true)
+  public PageResult<Capability> findByRoleId(UUID roleId, boolean expand, boolean includeDummy, boolean dedup,
+    int limit, int offset) {
+    if (!expand) {
+      var offsetRequest = OffsetRequest.of(offset, limit, DEFAULT_CAPABILITY_SORT);
+      var capabilitiesPage = findCapabilityEntitiesByRoleId(includeDummy, roleId, offsetRequest)
+        .map(capabilityEntityMapper::convert)
+        .map(capability -> capability.direct(true));
+      return PageResult.fromPage(capabilitiesPage);
+    }
+
+    return dedup
+      ? findExpandedCapabilitiesByRoleId(roleId, includeDummy, limit, offset)
+      : findExpandedCapabilitiesByRoleIdNoDedup(roleId, includeDummy, limit, offset);
+  }
+
+  private PageResult<Capability> findExpandedCapabilitiesByRoleId(UUID roleId, boolean includeDummy,
+    int limit, int offset) {
+    var offsetRequest = OffsetRequest.of(offset, limit, DEFAULT_CAPABILITY_SORT);
+    var capabilityEntitiesPage = findAllCapabilityEntitiesByRoleId(includeDummy, roleId, offsetRequest);
+    if (capabilityEntitiesPage.isEmpty()) {
+      return PageResult.of(capabilityEntitiesPage.getTotalElements(), emptyList());
+    }
+
+    var directCapabilityIds = roleCapabilityRepository.findCapabilityIdsByRoleId(roleId);
+    var capabilitiesPage = capabilityEntitiesPage
+      .map(capabilityEntityMapper::convert)
+      .map(capability -> capability.direct(directCapabilityIds.contains(capability.getId())));
     return PageResult.fromPage(capabilitiesPage);
+  }
+
+  private PageResult<Capability> findExpandedCapabilitiesByRoleIdNoDedup(UUID roleId, boolean includeDummy,
+    int limit, int offset) {
+    var sort = Sort.by(Order.asc("name"), Order.desc("direct"));
+    var offsetRequest = OffsetRequest.of(offset, limit, sort);
+    var rows = includeDummy
+      ? capabilityRepository.findAllByRoleIdNoDedupIncludeDummy(roleId, offsetRequest)
+      : capabilityRepository.findAllByRoleIdNoDedup(roleId, offsetRequest);
+
+    var capabIds = toStream(rows.getContent()).map(CapabilityDirectProjection::getId).distinct().toList();
+    var entitiesById = capabilityRepository.findAllById(capabIds)
+      .stream()
+      .collect(Collectors.toMap(CapabilityEntity::getId, identity()));
+
+    var capabilities = toStream(rows.getContent())
+      .filter(row -> entitiesById.containsKey(row.getId()))
+      .map(row -> capabilityEntityMapper.convert(entitiesById.get(row.getId())).direct(row.getDirect()))
+      .toList();
+    return PageResult.of(rows.getTotalElements(), capabilities);
   }
 
   /**
@@ -255,7 +323,7 @@ public class CapabilityService {
   @Transactional(readOnly = true)
   public PageResult<Capability> findByCapabilitySetId(UUID capabilitySetId,
     boolean includeDummy, int limit, int offset) {
-    var offsetRequest = OffsetRequest.of(offset, limit, CapabilityEntity.DEFAULT_CAPABILITY_SORT);
+    var offsetRequest = OffsetRequest.of(offset, limit, DEFAULT_CAPABILITY_SORT);
     capabilitySetService.get(capabilitySetId);
     var capabilityEntities = includeDummy
       ? capabilityRepository.findByCapabilitySetIdIncludeDummy(capabilitySetId, offsetRequest)

--- a/src/main/java/org/folio/roles/service/capability/CapabilityService.java
+++ b/src/main/java/org/folio/roles/service/capability/CapabilityService.java
@@ -162,6 +162,7 @@ public class CapabilityService {
    * @return {@link PageResult} object with found {@link Capability} relation descriptors
    */
   @Transactional(readOnly = true)
+  @SuppressWarnings("java:S6809") // both overloads are @Transactional(readOnly=true, REQUIRED); self-call is safe
   public PageResult<Capability> findByRoleId(UUID roleId, boolean expand, boolean includeDummy, int limit, int offset) {
     return findByRoleId(roleId, expand, includeDummy, true, limit, offset);
   }

--- a/src/main/resources/changelog/changelog-master.xml
+++ b/src/main/resources/changelog/changelog-master.xml
@@ -43,4 +43,7 @@
   <include file="changes/create-permission-migration-error-table.xml" relativeToChangelogFile="true"/>
   <include file="changes/fix-role-type-for-non-loadable-roles.xml" relativeToChangelogFile="true"/>
   <include file="changes/add-performance-indexes-user-permissions.xml" relativeToChangelogFile="true"/>
+  <include file="changes/add-permission-table-indexes.xml" relativeToChangelogFile="true"/>
+  <include file="changes/add-reverse-lookup-indexes.xml" relativeToChangelogFile="true"/>
+  <include file="changes/add-folio-permission-indexes.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changelog/changes/add-folio-permission-indexes.xml
+++ b/src/main/resources/changelog/changes/add-folio-permission-indexes.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+               http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+  <changeSet id="add-folio-permission-indexes" author="Yauhen Vavilkin">
+    <comment>
+      Add indexes on folio_permission columns used for permission-to-capability resolution
+      in Kafka event processing (CapabilityReplacementsService), loadable-role assembly, and parent
+      capability-set updates. The existing partial index idx_capability_dummy_false leads with `id`
+      and cannot serve lookups by folio_permission.
+    </comment>
+    <sql>
+      CREATE INDEX IF NOT EXISTS idx_capability_folio_permission     ON capability (folio_permission);
+      CREATE INDEX IF NOT EXISTS idx_capability_set_folio_permission ON capability_set (folio_permission);
+    </sql>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/changelog/changes/add-permission-table-indexes.xml
+++ b/src/main/resources/changelog/changes/add-permission-table-indexes.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+               http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+  <changeSet id="add-permission-table-indexes" author="Yauhen Vavilkin">
+    <comment>
+      Restore indexes on the permission table that were lost when it was recreated in
+      create-permission-table.xml. The btree index on `name` supports joins and lookups in
+      `findAllUserPermissionMappings`, `findAllFolioPermissions`, and `findByPermissionNameIn`.
+      The GIN index on `sub_permissions` is required for the `@>` containment operator used in
+      the recursive CTE in `getAllParentPermissions`.
+    </comment>
+    <sql>
+      CREATE INDEX IF NOT EXISTS idx_permission_name ON permission (name);
+      CREATE INDEX IF NOT EXISTS idx_permission_sub_permissions_gin ON permission USING gin (sub_permissions);
+    </sql>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/changelog/changes/add-reverse-lookup-indexes.xml
+++ b/src/main/resources/changelog/changes/add-reverse-lookup-indexes.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+               http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+  <changeSet id="add-reverse-lookup-indexes" author="Yauhen Vavilkin">
+    <comment>
+      Add FK-side (reverse-lookup) indexes on join and assignment tables. PostgreSQL does
+      not auto-index FK columns. All composite PKs lead with the owner column (user_id/role_id/
+      capability_set_id), so reverse lookups by capability_id/capability_set_id/role_id are
+      seq scans. These indexes are exercised per-capability in CapabilityReplacementsService and
+      CapabilityDuplicateMigrationService loops, and also accelerate FK cascade checks on deletion.
+    </comment>
+    <sql>
+      CREATE INDEX IF NOT EXISTS idx_csc_capability_id        ON capability_set_capability (capability_id);
+      CREATE INDEX IF NOT EXISTS idx_user_capability_cap_id   ON user_capability (capability_id);
+      CREATE INDEX IF NOT EXISTS idx_role_capability_cap_id   ON role_capability (capability_id);
+      CREATE INDEX IF NOT EXISTS idx_user_cap_set_cap_set_id  ON user_capability_set (capability_set_id);
+      CREATE INDEX IF NOT EXISTS idx_role_cap_set_cap_set_id  ON role_capability_set (capability_set_id);
+      CREATE INDEX IF NOT EXISTS idx_user_role_role_id        ON user_role (role_id);
+      CREATE INDEX IF NOT EXISTS idx_rlp_capability_id        ON role_loadable_permission (capability_id);
+      CREATE INDEX IF NOT EXISTS idx_rlp_capability_set_id    ON role_loadable_permission (capability_set_id);
+    </sql>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/swagger.api/mod-roles-keycloak.yaml
+++ b/src/main/resources/swagger.api/mod-roles-keycloak.yaml
@@ -305,6 +305,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/pathRoleId'
         - $ref: '#/components/parameters/expand-capabilities'
+        - $ref: '#/components/parameters/dedup-capabilities'
         - $ref: '#/components/parameters/includeDummy'
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/offset'
@@ -1307,6 +1308,16 @@ components:
       schema:
         type: boolean
         default: false
+    dedup-capabilities:
+      in: query
+      name: dedup
+      description: >-
+        Defines if duplicate capabilities (assigned both directly and via a capability set)
+        must be deduplicated. Only meaningful when expand=true.
+      required: false
+      schema:
+        type: boolean
+        default: true
     includeDummy:
       in: query
       name: includeDummy

--- a/src/main/resources/swagger.api/schemas/capability/capability.json
+++ b/src/main/resources/swagger.api/schemas/capability/capability.json
@@ -61,6 +61,11 @@
     "visible": {
       "description": "Is visible in UI",
       "type": "boolean"
+    },
+    "direct": {
+      "description": "Indicates whether the capability was directly assigned to the role (true) or inherited via a capability set (false). Populated only by GET /roles/{id}/capabilities.",
+      "type": "boolean",
+      "readOnly": true
     }
   },
   "required": [

--- a/src/test/java/org/folio/roles/controller/RoleCapabilityControllerTest.java
+++ b/src/test/java/org/folio/roles/controller/RoleCapabilityControllerTest.java
@@ -119,7 +119,7 @@ class RoleCapabilityControllerTest {
   @Test
   void findByRoleId_positive() throws Exception {
     var foundCapability = capability();
-    when(capabilityService.findByRoleId(ROLE_ID, false, false, 100, 20))
+    when(capabilityService.findByRoleId(ROLE_ID, false, false, true, 100, 20))
       .thenReturn(asSinglePage(foundCapability));
 
     mockMvc.perform(get("/roles/{id}/capabilities", ROLE_ID)
@@ -136,7 +136,7 @@ class RoleCapabilityControllerTest {
   void findByRoleId_positive_defaultPageParameters() throws Exception {
     var capability = capability();
     when(roleService.getById(ROLE_ID)).thenReturn(role());
-    when(capabilityService.findByRoleId(ROLE_ID, false, false, 10, 0)).thenReturn(asSinglePage(capability));
+    when(capabilityService.findByRoleId(ROLE_ID, false, false, true, 10, 0)).thenReturn(asSinglePage(capability));
 
     mockMvc.perform(get("/roles/{id}/capabilities", ROLE_ID)
         .contentType(APPLICATION_JSON)
@@ -144,14 +144,14 @@ class RoleCapabilityControllerTest {
       .andExpect(status().isOk())
       .andExpect(content().contentType(APPLICATION_JSON))
       .andExpect(content().json(asJsonString(capabilities(capability)), JsonCompareMode.STRICT));
-    verify(capabilityService).findByRoleId(ROLE_ID, false, false, 10, 0);
+    verify(capabilityService).findByRoleId(ROLE_ID, false, false, true, 10, 0);
   }
 
   @Test
   void findByRoleId_positive_expandCapabilities() throws Exception {
     var capability = capability();
     when(roleService.getById(ROLE_ID)).thenReturn(role());
-    when(capabilityService.findByRoleId(ROLE_ID, true, false, 10, 0)).thenReturn(asSinglePage(capability));
+    when(capabilityService.findByRoleId(ROLE_ID, true, false, true, 10, 0)).thenReturn(asSinglePage(capability));
 
     mockMvc.perform(get("/roles/{id}/capabilities", ROLE_ID)
         .queryParam("expand", "true")
@@ -160,14 +160,31 @@ class RoleCapabilityControllerTest {
       .andExpect(status().isOk())
       .andExpect(content().contentType(APPLICATION_JSON))
       .andExpect(content().json(asJsonString(capabilities(capability)), JsonCompareMode.STRICT));
-    verify(capabilityService).findByRoleId(ROLE_ID, true, false, 10, 0);
+    verify(capabilityService).findByRoleId(ROLE_ID, true, false, true, 10, 0);
+  }
+
+  @Test
+  void findByRoleId_positive_dedupFalse() throws Exception {
+    var capability = capability();
+    when(roleService.getById(ROLE_ID)).thenReturn(role());
+    when(capabilityService.findByRoleId(ROLE_ID, true, false, false, 10, 0)).thenReturn(asSinglePage(capability));
+
+    mockMvc.perform(get("/roles/{id}/capabilities", ROLE_ID)
+        .queryParam("expand", "true")
+        .queryParam("dedup", "false")
+        .contentType(APPLICATION_JSON)
+        .header(TENANT, TENANT_ID))
+      .andExpect(status().isOk())
+      .andExpect(content().contentType(APPLICATION_JSON))
+      .andExpect(content().json(asJsonString(capabilities(capability)), JsonCompareMode.STRICT));
+    verify(capabilityService).findByRoleId(ROLE_ID, true, false, false, 10, 0);
   }
 
   @Test
   void findByRoleId_positive_includeDummyCapabilities() throws Exception {
     var capability = capability();
     when(roleService.getById(ROLE_ID)).thenReturn(role());
-    when(capabilityService.findByRoleId(ROLE_ID, false, true, 10, 0)).thenReturn(asSinglePage(capability));
+    when(capabilityService.findByRoleId(ROLE_ID, false, true, true, 10, 0)).thenReturn(asSinglePage(capability));
 
     mockMvc.perform(get("/roles/{id}/capabilities", ROLE_ID)
         .queryParam("includeDummy", "true")
@@ -176,7 +193,7 @@ class RoleCapabilityControllerTest {
       .andExpect(status().isOk())
       .andExpect(content().contentType(APPLICATION_JSON))
       .andExpect(content().json(asJsonString(capabilities(capability)), JsonCompareMode.STRICT));
-    verify(capabilityService).findByRoleId(ROLE_ID, false, true, 10, 0);
+    verify(capabilityService).findByRoleId(ROLE_ID, false, true, true, 10, 0);
   }
 
   @Test

--- a/src/test/java/org/folio/roles/it/RoleCapabilityIT.java
+++ b/src/test/java/org/folio/roles/it/RoleCapabilityIT.java
@@ -31,6 +31,7 @@ import static org.folio.spring.integration.XOkapiHeaders.TENANT;
 import static org.folio.spring.integration.XOkapiHeaders.USER_ID;
 import static org.folio.test.TestUtils.asJsonString;
 import static org.folio.test.TestUtils.parseResponse;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
@@ -313,8 +314,8 @@ class RoleCapabilityIT extends BaseIntegrationTest {
       .header(TENANT, TENANT_ID)
       .header(USER_ID, USER_ID_HEADER))
       .andExpect(content().json(asJsonString(capabilities(
-        fooItemCapability(FOO_CREATE_CAPABILITY, CREATE, "foo.item.post", fooItemPostEndpoint()),
-        fooItemCapability(FOO_VIEW_CAPABILITY, VIEW, "foo.item.get", fooItemGetEndpoint())
+        fooItemCapability(FOO_CREATE_CAPABILITY, CREATE, "foo.item.post", fooItemPostEndpoint()).direct(true),
+        fooItemCapability(FOO_VIEW_CAPABILITY, VIEW, "foo.item.get", fooItemGetEndpoint()).direct(true)
       ))));
   }
 
@@ -334,10 +335,54 @@ class RoleCapabilityIT extends BaseIntegrationTest {
       .header(TENANT, TENANT_ID)
       .header(USER_ID, USER_ID_HEADER))
       .andExpect(content().json(asJsonString(capabilities(
-        capability(FOO_CREATE_CAPABILITY, FOO_RESOURCE, CREATE, "foo.item.post", fooItemPostEndpoint()),
-        capability(FOO_EDIT_CAPABILITY, FOO_RESOURCE, EDIT, "foo.item.put", fooItemPutEndpoint()),
-        capability(FOO_VIEW_CAPABILITY, FOO_RESOURCE, VIEW, "foo.item.get", fooItemGetEndpoint())
+        capability(FOO_CREATE_CAPABILITY, FOO_RESOURCE, CREATE, "foo.item.post", fooItemPostEndpoint()).direct(true),
+        capability(FOO_EDIT_CAPABILITY, FOO_RESOURCE, EDIT, "foo.item.put", fooItemPutEndpoint()).direct(false),
+        capability(FOO_VIEW_CAPABILITY, FOO_RESOURCE, VIEW, "foo.item.get", fooItemGetEndpoint()).direct(true)
       ))));
+  }
+
+  @Test
+  @KeycloakRealms("/json/keycloak/role-capability-fresh-realm.json")
+  @Sql(scripts = {
+    "classpath:/sql/populate-test-role.sql",
+    "classpath:/sql/populate-role-policy.sql",
+    "classpath:/sql/capabilities/populate-capabilities.sql",
+    "classpath:/sql/capabilities/populate-role-capability-relations.sql",
+    "classpath:/sql/capability-sets/populate-capability-sets.sql",
+    "classpath:/sql/capability-sets/populate-many-role-capability-set-relations.sql"
+  })
+  void findByRoleId_positive_expandCapabilitySetsNoDedup() throws Exception {
+    // Direct: FOO_CREATE, FOO_VIEW. Via sets foo_item.create -> {FOO_CREATE, FOO_VIEW},
+    // foo_item.edit -> {FOO_VIEW, FOO_EDIT}. dedup=false keeps every source row.
+    doGet(get("/roles/{id}/capabilities", ROLE_ID)
+      .queryParam("expand", "true")
+      .queryParam("dedup", "false")
+      .header(TENANT, TENANT_ID)
+      .header(USER_ID, USER_ID_HEADER))
+      .andExpect(jsonPath("$.totalRecords", is(6)))
+      .andExpect(jsonPath("$.capabilities.length()", is(6)))
+      .andExpect(jsonPath("$.capabilities[?(@.id=='" + FOO_CREATE_CAPABILITY + "' && @.direct==true)]", hasSize(1)))
+      .andExpect(jsonPath("$.capabilities[?(@.id=='" + FOO_CREATE_CAPABILITY + "' && @.direct==false)]", hasSize(1)))
+      .andExpect(jsonPath("$.capabilities[?(@.id=='" + FOO_EDIT_CAPABILITY + "' && @.direct==false)]", hasSize(1)))
+      .andExpect(jsonPath("$.capabilities[?(@.id=='" + FOO_VIEW_CAPABILITY + "' && @.direct==true)]", hasSize(1)))
+      .andExpect(jsonPath("$.capabilities[?(@.id=='" + FOO_VIEW_CAPABILITY + "' && @.direct==false)]", hasSize(2)));
+  }
+
+  @Test
+  @KeycloakRealms("/json/keycloak/role-capability-fresh-realm.json")
+  @Sql(scripts = {
+    "classpath:/sql/populate-test-role.sql",
+    "classpath:/sql/populate-role-policy.sql",
+    "classpath:/sql/capabilities/populate-capabilities.sql",
+    "classpath:/sql/capabilities/populate-role-capability-relations.sql"
+  })
+  void findByRoleId_negative_invalidDedupValue() throws Exception {
+    mockMvc.perform(get("/roles/{id}/capabilities", ROLE_ID)
+        .queryParam("dedup", "invalid")
+        .header(TENANT, TENANT_ID)
+        .header(USER_ID, USER_ID_HEADER))
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.errors[0].type", is("MethodArgumentTypeMismatchException")));
   }
 
   @Test

--- a/src/test/java/org/folio/roles/repository/CapabilityRepositoryIT.java
+++ b/src/test/java/org/folio/roles/repository/CapabilityRepositoryIT.java
@@ -18,10 +18,12 @@ import java.util.List;
 import java.util.UUID;
 import org.folio.roles.base.BaseRepositoryTest;
 import org.folio.roles.domain.entity.CapabilityEntity;
+import org.folio.roles.repository.projection.CapabilityDirectProjection;
 import org.folio.spring.data.OffsetRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Sort;
 
 class CapabilityRepositoryIT extends BaseRepositoryTest {
 
@@ -187,6 +189,40 @@ class CapabilityRepositoryIT extends BaseRepositoryTest {
     offsetRequest = OffsetRequest.of(0, 1, CapabilityEntity.DEFAULT_CAPABILITY_SORT);
     page = capabilityRepository.findAllByRoleIdIncludeDummy(roleId, offsetRequest);
     assertThat(page.getTotalElements()).isEqualTo(3);
+  }
+
+  @Test
+  void findAllByRoleIdNoDedup_positive_keepsDuplicatesAndTagsOrigin() {
+    var roleId = UUID.randomUUID();
+    var roleEntity = roleEntity();
+    roleEntity.setId(roleId);
+    // capability assigned both directly and via a capability set -> appears twice (direct + inherited)
+    var sharedCapability = capabilityEntity(null);
+    // dummy capability assigned directly only -> filtered unless includeDummy
+    var dummyCapability = capabilityEntity(null);
+    dummyCapability.setDummyCapability(true);
+    dummyCapability.setName("dummy_" + UUID.randomUUID());
+    sharedCapability = entityManager.persistAndFlush(sharedCapability);
+    dummyCapability = entityManager.persistAndFlush(dummyCapability);
+    entityManager.persistAndFlush(roleEntity);
+    entityManager.persistAndFlush(roleCapabilityEntity(roleId, sharedCapability.getId()));
+    entityManager.persistAndFlush(roleCapabilityEntity(roleId, dummyCapability.getId()));
+    var capabilitySetEntity = capabilitySetEntity(null, List.of(sharedCapability.getId()));
+    capabilitySetEntity = entityManager.persistAndFlush(capabilitySetEntity);
+    entityManager.persistAndFlush(roleCapabilitySetEntity(roleId, capabilitySetEntity.getId()));
+
+    var offsetRequest = OffsetRequest.of(0, 10,
+      Sort.by(Sort.Order.asc("name"), Sort.Order.desc("direct")));
+
+    var page = capabilityRepository.findAllByRoleIdNoDedup(roleId, offsetRequest);
+    assertThat(page.getTotalElements()).isEqualTo(2);
+    var sharedId = sharedCapability.getId();
+    assertThat(page.getContent()).extracting(CapabilityDirectProjection::getId).containsOnly(sharedId);
+    assertThat(page.getContent()).extracting(CapabilityDirectProjection::getDirect)
+      .containsExactly(true, false);
+
+    var pageWithDummy = capabilityRepository.findAllByRoleIdNoDedupIncludeDummy(roleId, offsetRequest);
+    assertThat(pageWithDummy.getTotalElements()).isEqualTo(3);
   }
 
   @Test

--- a/src/test/java/org/folio/roles/repository/RoleCapabilityRepositoryIT.java
+++ b/src/test/java/org/folio/roles/repository/RoleCapabilityRepositoryIT.java
@@ -103,7 +103,26 @@ class RoleCapabilityRepositoryIT extends BaseRepositoryTest {
     var offsetRequest = OffsetRequest.of(0, 2, RoleCapabilityEntity.DEFAULT_ROLE_CAPABILITY_SORT);
     var page = roleCapabilityRepository.findByRoleId(roleId, offsetRequest);
     assertThat(page.getTotalElements()).isEqualTo(1);
-    assertThat(page.getContent().get(0)).isEqualTo(roleCapabilityEntity);
+    assertThat(page.getContent().getFirst()).isEqualTo(roleCapabilityEntity);
+  }
+
+  @Test
+  void findCapabilityIdsByRoleId_positive_includesDummy() {
+    var capabilityEntity = capabilityEntity(null);
+    var dummyCapabilityEntity = capabilityEntity(null);
+    dummyCapabilityEntity.setDummyCapability(true);
+    dummyCapabilityEntity.setName("dummyCapability");
+    var roleId = UUID.randomUUID();
+    var roleEntity = roleEntity();
+    roleEntity.setId(roleId);
+    entityManager.persistAndFlush(capabilityEntity);
+    entityManager.persistAndFlush(dummyCapabilityEntity);
+    entityManager.persistAndFlush(roleEntity);
+    entityManager.persistAndFlush(roleCapabilityEntity(roleId, capabilityEntity.getId()));
+    entityManager.persistAndFlush(roleCapabilityEntity(roleId, dummyCapabilityEntity.getId()));
+
+    var capabilityIds = roleCapabilityRepository.findCapabilityIdsByRoleId(roleId);
+    assertThat(capabilityIds).containsExactlyInAnyOrder(capabilityEntity.getId(), dummyCapabilityEntity.getId());
   }
 
   @Test

--- a/src/test/java/org/folio/roles/service/capability/CapabilityServiceTest.java
+++ b/src/test/java/org/folio/roles/service/capability/CapabilityServiceTest.java
@@ -29,14 +29,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.folio.integration.kafka.model.ResourceEventType;
+import org.folio.roles.domain.dto.Capability;
+import org.folio.roles.domain.entity.CapabilityEntity;
 import org.folio.roles.domain.model.PageResult;
 import org.folio.roles.domain.model.event.CapabilityEvent;
 import org.folio.roles.integration.mte.MteEntitlementService;
 import org.folio.roles.mapper.entity.CapabilityEntityMapper;
 import org.folio.roles.repository.CapabilityRepository;
+import org.folio.roles.repository.RoleCapabilityRepository;
+import org.folio.roles.repository.projection.CapabilityDirectProjection;
 import org.folio.roles.service.capability.model.UserPermissionMappings;
 import org.folio.roles.support.TestUtils;
 import org.folio.roles.support.TestUtils.TestModRolesKeycloakModuleMetadata;
@@ -62,6 +67,7 @@ import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Sort;
 
 @UnitTest
 @ExtendWith({MockitoExtension.class, OutputCaptureExtension.class})
@@ -69,6 +75,7 @@ class CapabilityServiceTest {
 
   @InjectMocks private CapabilityService capabilityService;
   @Mock private CapabilityRepository capabilityRepository;
+  @Mock private RoleCapabilityRepository roleCapabilityRepository;
   @Mock private CapabilitySetService capabilitySetService;
   @Mock private CapabilityEntityMapper capabilityEntityMapper;
   @Mock private ApplicationEventPublisher applicationEventPublisher;
@@ -79,9 +86,9 @@ class CapabilityServiceTest {
   @BeforeEach
   void setUp() {
     var folioExecutionContext = new DefaultFolioExecutionContext(new TestModRolesKeycloakModuleMetadata(), emptyMap());
-    this.capabilityService = new CapabilityService(capabilityRepository, folioExecutionContext,
-      capabilityEntityMapper, applicationEventPublisher, userPermissionCacheService, mteEntitlementService,
-      capabilitySetService);
+    this.capabilityService = new CapabilityService(capabilityRepository, roleCapabilityRepository,
+      folioExecutionContext, capabilityEntityMapper, applicationEventPublisher, userPermissionCacheService,
+      mteEntitlementService, capabilitySetService);
   }
 
   @AfterEach
@@ -361,6 +368,8 @@ class CapabilityServiceTest {
   class FindByRoleId {
 
     private final OffsetRequest offsetRequest = OffsetRequest.of(0, 10, DEFAULT_CAPABILITY_SORT);
+    private final OffsetRequest noDedupOffsetRequest = OffsetRequest.of(0, 10,
+      Sort.by(Sort.Order.asc("name"), Sort.Order.desc("direct")));
 
     @Test
     void positive_expandIsFalseAndIncludeDummyIsFalse() {
@@ -373,7 +382,26 @@ class CapabilityServiceTest {
 
       var result = capabilityService.findByRoleId(ROLE_ID, false, false, 10, 0);
 
-      assertThat(result).isEqualTo(PageResult.of(100, List.of(capability)));
+      assertThat(result.getTotalRecords()).isEqualTo(100);
+      assertThat(result.getRecords()).containsExactly(capability);
+      assertThat(result.getRecords()).extracting(Capability::getDirect).containsExactly(true);
+      verify(capabilityRepository).findByRoleId(ROLE_ID, offsetRequest);
+    }
+
+    @Test
+    void positive_expandIsFalseAndDedupIsFalse() {
+      var capability = capability();
+      var capabilityEntity = capabilityEntity();
+      var capabilityEntityPage = new PageImpl<>(List.of(capabilityEntity), offsetRequest, 100);
+
+      when(capabilityRepository.findByRoleId(ROLE_ID, offsetRequest)).thenReturn(capabilityEntityPage);
+      when(capabilityEntityMapper.convert(capabilityEntity)).thenReturn(capability);
+
+      var result = capabilityService.findByRoleId(ROLE_ID, false, false, false, 10, 0);
+
+      assertThat(result.getTotalRecords()).isEqualTo(100);
+      assertThat(result.getRecords()).containsExactly(capability);
+      assertThat(result.getRecords()).extracting(Capability::getDirect).containsExactly(true);
       verify(capabilityRepository).findByRoleId(ROLE_ID, offsetRequest);
     }
 
@@ -388,7 +416,9 @@ class CapabilityServiceTest {
 
       var result = capabilityService.findByRoleId(ROLE_ID, false, true, 10, 0);
 
-      assertThat(result).isEqualTo(PageResult.of(100, List.of(capability)));
+      assertThat(result.getTotalRecords()).isEqualTo(100);
+      assertThat(result.getRecords()).containsExactly(capability);
+      assertThat(result.getRecords()).extracting(Capability::getDirect).containsExactly(true);
       verify(capabilityRepository).findByRoleIdIncludeDummy(ROLE_ID, offsetRequest);
     }
 
@@ -400,10 +430,13 @@ class CapabilityServiceTest {
 
       when(capabilityRepository.findAllByRoleId(ROLE_ID, offsetRequest)).thenReturn(capabilityEntityPage);
       when(capabilityEntityMapper.convert(capabilityEntity)).thenReturn(capability);
+      when(roleCapabilityRepository.findCapabilityIdsByRoleId(ROLE_ID)).thenReturn(Set.of(CAPABILITY_ID));
 
       var result = capabilityService.findByRoleId(ROLE_ID, true, false, 10, 0);
 
-      assertThat(result).isEqualTo(PageResult.of(100, List.of(capability)));
+      assertThat(result.getTotalRecords()).isEqualTo(100);
+      assertThat(result.getRecords()).containsExactly(capability);
+      assertThat(result.getRecords()).extracting(Capability::getDirect).containsExactly(true);
       verify(capabilityRepository).findAllByRoleId(ROLE_ID, offsetRequest);
     }
 
@@ -415,11 +448,97 @@ class CapabilityServiceTest {
 
       when(capabilityRepository.findAllByRoleIdIncludeDummy(ROLE_ID, offsetRequest)).thenReturn(capabilityEntityPage);
       when(capabilityEntityMapper.convert(capabilityEntity)).thenReturn(capability);
+      when(roleCapabilityRepository.findCapabilityIdsByRoleId(ROLE_ID)).thenReturn(emptySet());
 
       var result = capabilityService.findByRoleId(ROLE_ID, true, true, 10, 0);
 
-      assertThat(result).isEqualTo(PageResult.of(100, List.of(capability)));
+      assertThat(result.getTotalRecords()).isEqualTo(100);
+      assertThat(result.getRecords()).containsExactly(capability);
+      assertThat(result.getRecords()).extracting(Capability::getDirect).containsExactly(false);
       verify(capabilityRepository).findAllByRoleIdIncludeDummy(ROLE_ID, offsetRequest);
+    }
+
+    @Test
+    void positive_expandIsTrueAndEmptyPageSkipsDirectIdsLookup() {
+      var capabilityEntityPage = new PageImpl<CapabilityEntity>(List.of(), offsetRequest, 0);
+
+      when(capabilityRepository.findAllByRoleId(ROLE_ID, offsetRequest)).thenReturn(capabilityEntityPage);
+
+      var result = capabilityService.findByRoleId(ROLE_ID, true, false, 10, 0);
+
+      assertThat(result).isEqualTo(PageResult.empty());
+      verify(capabilityRepository).findAllByRoleId(ROLE_ID, offsetRequest);
+      verifyNoInteractions(roleCapabilityRepository);
+    }
+
+    @Test
+    void positive_expandIsTrueAndDedupIsFalse() {
+      var directCapability = capability();
+      var inheritedCapability = capability();
+      var capabilityEntity = capabilityEntity();
+      var directRow = Mockito.mock(CapabilityDirectProjection.class);
+      when(directRow.getId()).thenReturn(CAPABILITY_ID);
+      when(directRow.getDirect()).thenReturn(true);
+      var inheritedRow = Mockito.mock(CapabilityDirectProjection.class);
+      when(inheritedRow.getId()).thenReturn(CAPABILITY_ID);
+      when(inheritedRow.getDirect()).thenReturn(false);
+      var rowsPage = new PageImpl<>(List.of(directRow, inheritedRow), noDedupOffsetRequest, 2);
+
+      when(capabilityRepository.findAllByRoleIdNoDedup(ROLE_ID, noDedupOffsetRequest)).thenReturn(rowsPage);
+      when(capabilityRepository.findAllById(List.of(CAPABILITY_ID))).thenReturn(List.of(capabilityEntity));
+      when(capabilityEntityMapper.convert(capabilityEntity)).thenReturn(directCapability, inheritedCapability);
+
+      var result = capabilityService.findByRoleId(ROLE_ID, true, false, false, 10, 0);
+
+      assertThat(result.getTotalRecords()).isEqualTo(2);
+      assertThat(result.getRecords()).containsExactly(directCapability, inheritedCapability);
+      assertThat(result.getRecords()).extracting(Capability::getDirect).containsExactly(true, false);
+      verify(capabilityRepository).findAllByRoleIdNoDedup(ROLE_ID, noDedupOffsetRequest);
+    }
+
+    @Test
+    void positive_expandIsTrueAndDedupIsFalseAndIncludeDummyIsTrue() {
+      var capability = capability();
+      var capabilityEntity = capabilityEntity();
+      var directRow = Mockito.mock(CapabilityDirectProjection.class);
+      when(directRow.getId()).thenReturn(CAPABILITY_ID);
+      when(directRow.getDirect()).thenReturn(true);
+      var rowsPage = new PageImpl<>(List.of(directRow), noDedupOffsetRequest, 1);
+
+      when(capabilityRepository.findAllByRoleIdNoDedupIncludeDummy(ROLE_ID, noDedupOffsetRequest)).thenReturn(rowsPage);
+      when(capabilityRepository.findAllById(List.of(CAPABILITY_ID))).thenReturn(List.of(capabilityEntity));
+      when(capabilityEntityMapper.convert(capabilityEntity)).thenReturn(capability);
+
+      var result = capabilityService.findByRoleId(ROLE_ID, true, true, false, 10, 0);
+
+      assertThat(result.getTotalRecords()).isEqualTo(1);
+      assertThat(result.getRecords()).extracting(Capability::getDirect).containsExactly(true);
+      verify(capabilityRepository).findAllByRoleIdNoDedupIncludeDummy(ROLE_ID, noDedupOffsetRequest);
+    }
+
+    @Test
+    void positive_expandIsTrueAndDedupIsFalseSkipsRowsMissingFromHydration() {
+      var capabilityEntity = capabilityEntity();
+      var capability = capability();
+      var existingRow = Mockito.mock(CapabilityDirectProjection.class);
+      when(existingRow.getId()).thenReturn(CAPABILITY_ID);
+      when(existingRow.getDirect()).thenReturn(true);
+      var missingCapabilityId = UUID.randomUUID();
+      var missingRow = Mockito.mock(CapabilityDirectProjection.class);
+      when(missingRow.getId()).thenReturn(missingCapabilityId);
+      var rowsPage = new PageImpl<>(List.of(existingRow, missingRow), noDedupOffsetRequest, 2);
+
+      when(capabilityRepository.findAllByRoleIdNoDedup(ROLE_ID, noDedupOffsetRequest)).thenReturn(rowsPage);
+      when(capabilityRepository.findAllById(List.of(CAPABILITY_ID, missingCapabilityId)))
+        .thenReturn(List.of(capabilityEntity));
+      when(capabilityEntityMapper.convert(capabilityEntity)).thenReturn(capability);
+
+      var result = capabilityService.findByRoleId(ROLE_ID, true, false, false, 10, 0);
+
+      assertThat(result.getTotalRecords()).isEqualTo(2);
+      assertThat(result.getRecords()).containsExactly(capability);
+      assertThat(result.getRecords()).extracting(Capability::getDirect).containsExactly(true);
+      verify(capabilityRepository).findAllByRoleIdNoDedup(ROLE_ID, noDedupOffsetRequest);
     }
   }
 


### PR DESCRIPTION
### **Purpose**
Adds a `dedup` query parameter to `GET /roles/{id}/capabilities` so callers can opt out of deduplication when `expand=true` and receive each capability row tagged with a `direct` flag indicating whether it came from a direct assignment or via a capability set. The previous behaviour (dedup on by default) is preserved for all existing callers. Also adds several missing Postgres indexes on FK-side columns and `folio_permission` columns that were causing sequential scans in hot paths.

https://folio-org.atlassian.net/browse/MODROLESKC-408

### **Approach**
- Added `dedup` boolean query parameter (default `true`) to the OpenAPI spec for `GET /roles/{id}/capabilities` and wired it through `RoleCapabilityController` → `CapabilityService`.
- Added `direct` (read-only) field to `capability.json` schema; mapper ignores it during entity-to-DTO mapping; it is set explicitly in service logic.
- Introduced `CapabilityDirectProjection` interface so native queries can return `(id, is_direct)` pairs without hydrating full entities.
- Added two no-dedup repository queries (`findAllByRoleIdNoDedup`, `findAllByRoleIdNoDedupIncludeDummy`) that UNION direct and capability-set-sourced rows before paging.
- For the dedup path (`dedup=true, expand=true`): after the existing paginated query, fetches direct capability IDs from `role_capability` in a single additional query to set the `direct` flag per item.
- Three new Liquibase changesets:
  - `add-permission-table-indexes.xml`: btree on `permission.name` and GIN on `permission.sub_permissions` (restored indexes lost during table recreation).
  - `add-reverse-lookup-indexes.xml`: FK-side indexes on `capability_set_capability`, `user_capability`, `role_capability`, `user_capability_set`, `role_capability_set`, `user_role`, and `role_loadable_permission`.
  - `add-folio-permission-indexes.xml`: indexes on `capability.folio_permission` and `capability_set.folio_permission` for Kafka event processing and loadable-role assembly paths.

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.