### PR TITLE
MODROLESKC-414: (Cypress/Snapshot envs) Missing permissions for system user roles

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * Delete the Log4j configuration so the logging settings are automatically inherited from `folio-spring-base`. (EUREKA-889)
 * Upgrade dependencies for Kafka 4.2 compatibility in mod-roles-keycloak (MODROLESKC-411)
 * Add `dedup` query parameter and `direct` flag for `GET /roles/{id}/capabilities`, add performance indexes (MODROLESKC-408)
+* Retry capability events on unique-constraint violations and isolate per-role capability assignment in separate transactions, so a concurrent assignment no longer loses sibling roles' capabilities (MODROLESKC-414)
 
 ## Version `v4.0.0` (16.04.2025)
 * Added endpoint to create or update default roles via REST API (MODROLESKC-301)

--- a/src/main/java/org/folio/roles/integration/kafka/configuration/KafkaConfiguration.java
+++ b/src/main/java/org/folio/roles/integration/kafka/configuration/KafkaConfiguration.java
@@ -4,6 +4,7 @@ import static org.apache.kafka.clients.consumer.ConsumerConfig.AUTO_OFFSET_RESET
 import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
 
+import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -38,6 +39,8 @@ import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 @EnableKafkaConsumer
 @RequiredArgsConstructor
 public class KafkaConfiguration implements KafkaListenerConfigurer {
+
+  private static final String UNIQUE_VIOLATION_SQL_STATE = "23505";
 
   private final KafkaProperties kafkaProperties;
   private final CapabilityEventRetryConfiguration retryConfiguration;
@@ -94,12 +97,34 @@ public class KafkaConfiguration implements KafkaListenerConfigurer {
       return getFixedBackOff();
     }
 
+    if (isUniqueConstraintViolation(exception)) {
+      log.warn("Unique constraint violation during capability event processing (concurrent assignment), "
+        + "retrying Kafka event", exception);
+      return getFixedBackOff();
+    }
+
     log.warn("Non-retryable error, skipping message", exception);
     return new FixedBackOff(0L, 0L);
   }
 
   private FixedBackOff getFixedBackOff() {
     return new FixedBackOff(retryConfiguration.getRetryDelay().toMillis(), retryConfiguration.getRetryAttempts());
+  }
+
+  /**
+   * Detects unique-constraint violations (SQLState 23505) anywhere in the cause chain. They occur when a capability
+   * event races with a concurrent entitlement flow inserting the same role-capability assignment; event processing
+   * is idempotent, so the event must be retried, not skipped.
+   */
+  private static boolean isUniqueConstraintViolation(Exception exception) {
+    for (Throwable current = exception; current != null && current.getCause() != current;
+         current = current.getCause()) {
+      if (current instanceof SQLException sqlException
+        && UNIQUE_VIOLATION_SQL_STATE.equals(sqlException.getSQLState())) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/src/main/java/org/folio/roles/service/loadablerole/LoadableRoleCapabilityAssignmentProcessor.java
+++ b/src/main/java/org/folio/roles/service/loadablerole/LoadableRoleCapabilityAssignmentProcessor.java
@@ -4,6 +4,7 @@ import static java.util.stream.Collectors.groupingBy;
 import static org.folio.common.utils.CollectionUtils.mapItems;
 import static org.folio.roles.utils.CollectionUtils.findOne;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -27,9 +28,12 @@ import org.folio.roles.service.capability.RoleCapabilitySetService;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.scope.FolioExecutionContextSetter;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @Log4j2
 @Service
@@ -41,6 +45,7 @@ public class LoadableRoleCapabilityAssignmentProcessor {
   private final CapabilityService capabilityService;
   private final RoleCapabilityService roleCapabilityService;
   private final RoleCapabilitySetService roleCapabilitySetService;
+  private final PlatformTransactionManager transactionManager;
 
   @TransactionalEventListener(condition = "#event.type == T(org.folio.roles.domain.model.event.DomainEventType).CREATE")
   public void handleCapabilitiesCreatedEvent(CapabilityEvent event) {
@@ -158,14 +163,31 @@ public class LoadableRoleCapabilityAssignmentProcessor {
     return findOne(capabilityService.findByNames(List.of(capabilitySetName))).orElse(null);
   }
 
-  private static void applyActionToRoles(Supplier<Map<UUID, List<LoadablePermission>>> rolesWithPermissionsSupplier,
+  private void applyActionToRoles(Supplier<Map<UUID, List<LoadablePermission>>> rolesWithPermissionsSupplier,
     BiConsumer<UUID, List<LoadablePermission>> action, FolioExecutionContext context) {
     try (var ignored = new FolioExecutionContextSetter(context)) {
       var roleIdWithPermissions = rolesWithPermissionsSupplier.get();
 
       log.debug("Action will be applied to the following roles/permissions: {}", roleIdWithPermissions);
 
-      roleIdWithPermissions.forEach(action);
+      // each role is processed in its own transaction, so that a failure for one role (e.g. a concurrent
+      // entitlement flow assigning the same capability) does not roll back sibling roles' assignments
+      var transactionTemplate = new TransactionTemplate(transactionManager);
+      transactionTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+
+      var failures = new ArrayList<RuntimeException>();
+      roleIdWithPermissions.forEach((roleId, rolePermissions) -> {
+        try {
+          transactionTemplate.executeWithoutResult(status -> action.accept(roleId, rolePermissions));
+        } catch (RuntimeException exception) {
+          log.warn("Failed to apply action to loadable role: roleId = {}", roleId, exception);
+          failures.add(exception);
+        }
+      });
+
+      if (!failures.isEmpty()) {
+        throw failures.getFirst();
+      }
     }
   }
 

--- a/src/test/java/org/folio/roles/integration/kafka/configuration/KafkaConfigurationErrorDetectionTest.java
+++ b/src/test/java/org/folio/roles/integration/kafka/configuration/KafkaConfigurationErrorDetectionTest.java
@@ -2,10 +2,14 @@ package org.folio.roles.integration.kafka.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import jakarta.persistence.PersistenceException;
+import jakarta.persistence.RollbackException;
+import java.sql.SQLException;
 import java.time.Duration;
 import java.util.Optional;
 import org.folio.spring.exception.LiquibaseMigrationException;
 import org.folio.test.types.UnitTest;
+import org.hibernate.exception.ConstraintViolationException;
 import org.hibernate.exception.SQLGrammarException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -13,7 +17,9 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 import org.springframework.boot.kafka.autoconfigure.KafkaProperties;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.InvalidDataAccessResourceUsageException;
+import org.springframework.transaction.TransactionSystemException;
 import org.springframework.util.backoff.BackOff;
 import org.springframework.util.backoff.FixedBackOff;
 
@@ -100,6 +106,85 @@ class KafkaConfigurationErrorDetectionTest {
     var fixedBackOff = (FixedBackOff) backOff;
     assertThat(fixedBackOff.getInterval()).isEqualTo(retryDelay.toMillis());
     assertThat(fixedBackOff.getMaxAttempts()).isEqualTo(retryAttempts);
+  }
+
+  @Test
+  void getBackOff_positive_uniqueConstraintViolationIsRetryable() throws Exception {
+    // given
+    var retryDelay = Duration.ofMillis(500);
+    var retryAttempts = 10L;
+    var retryConfig = createRetryConfiguration(retryDelay, retryAttempts);
+    var kafkaConfig = new KafkaConfiguration(new KafkaProperties(), retryConfig, null);
+    var psqlException = new PSQLException("ERROR: duplicate key value violates unique constraint "
+      + "\"pk_role_capability\"", PSQLState.UNIQUE_VIOLATION);
+    var constraintViolation = new ConstraintViolationException("could not execute statement", psqlException,
+      "pk_role_capability");
+    var exception = new DataIntegrityViolationException("could not execute statement", constraintViolation);
+
+    // when
+    var backOff = invokeGetBackOff(kafkaConfig, exception);
+
+    // then
+    assertThat(backOff).isInstanceOf(FixedBackOff.class);
+    var fixedBackOff = (FixedBackOff) backOff;
+    assertThat(fixedBackOff.getInterval()).isEqualTo(retryDelay.toMillis());
+    assertThat(fixedBackOff.getMaxAttempts()).isEqualTo(retryAttempts);
+  }
+
+  @Test
+  void getBackOff_positive_uniqueConstraintViolationAtCommitIsRetryable() throws Exception {
+    // given
+    var retryDelay = Duration.ofMillis(500);
+    var retryAttempts = 10L;
+    var retryConfig = createRetryConfiguration(retryDelay, retryAttempts);
+    var kafkaConfig = new KafkaConfiguration(new KafkaProperties(), retryConfig, null);
+    var psqlException = new PSQLException("ERROR: duplicate key value violates unique constraint "
+      + "\"pk_role_capability\"", PSQLState.UNIQUE_VIOLATION);
+    var constraintViolation = new ConstraintViolationException("could not execute statement", psqlException,
+      "pk_role_capability");
+    var persistenceException = new PersistenceException("could not execute statement", constraintViolation);
+    var rollbackException = new RollbackException("Error while committing the transaction", persistenceException);
+    var exception = new TransactionSystemException("Could not commit JPA transaction", rollbackException);
+
+    // when
+    var backOff = invokeGetBackOff(kafkaConfig, exception);
+
+    // then
+    assertThat(backOff).isInstanceOf(FixedBackOff.class);
+    var fixedBackOff = (FixedBackOff) backOff;
+    assertThat(fixedBackOff.getInterval()).isEqualTo(retryDelay.toMillis());
+    assertThat(fixedBackOff.getMaxAttempts()).isEqualTo(retryAttempts);
+  }
+
+  @Test
+  void getBackOff_negative_notNullViolationIsNotRetryable() throws Exception {
+    // given
+    var retryConfig = createRetryConfiguration(Duration.ofMillis(500), 10L);
+    var kafkaConfig = new KafkaConfiguration(new KafkaProperties(), retryConfig, null);
+    var sqlException = new SQLException("ERROR: null value in column \"name\" violates not-null constraint", "23502");
+    var exception = new DataIntegrityViolationException("could not execute statement", sqlException);
+
+    // when
+    var backOff = invokeGetBackOff(kafkaConfig, exception);
+
+    // then
+    assertThat(backOff).isInstanceOf(FixedBackOff.class);
+    assertThat(((FixedBackOff) backOff).getMaxAttempts()).isZero();
+  }
+
+  @Test
+  void getBackOff_negative_noSqlExceptionInChain() throws Exception {
+    // given
+    var retryConfig = createRetryConfiguration(Duration.ofMillis(500), 10L);
+    var kafkaConfig = new KafkaConfiguration(new KafkaProperties(), retryConfig, null);
+    var exception = new IllegalStateException("Unexpected error");
+
+    // when
+    var backOff = invokeGetBackOff(kafkaConfig, exception);
+
+    // then
+    assertThat(backOff).isInstanceOf(FixedBackOff.class);
+    assertThat(((FixedBackOff) backOff).getMaxAttempts()).isZero();
   }
 
   private InvalidDataAccessResourceUsageException createException(String errorMessage) {

--- a/src/test/java/org/folio/roles/it/LoadableRoleProcessingIT.java
+++ b/src/test/java/org/folio/roles/it/LoadableRoleProcessingIT.java
@@ -15,6 +15,7 @@ import static org.folio.spring.integration.XOkapiHeaders.USER_ID;
 import static org.folio.test.TestUtils.parseResponse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.doAnswer;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
 import static org.springframework.test.context.jdbc.SqlMergeMode.MergeMode.MERGE;
@@ -27,6 +28,7 @@ import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import lombok.extern.log4j.Log4j2;
 import org.assertj.core.api.ThrowingConsumer;
@@ -45,6 +47,7 @@ import org.folio.roles.domain.dto.LoadableRoles;
 import org.folio.roles.integration.kafka.KafkaMessageListener;
 import org.folio.roles.service.loadablerole.LoadableRoleCapabilityAssignmentHelper;
 import org.folio.roles.service.loadablerole.LoadableRoleCapabilityAssignmentProcessor;
+import org.folio.roles.service.permission.RolePermissionService;
 import org.folio.test.extensions.KeycloakRealms;
 import org.folio.test.types.IntegrationTest;
 import org.junit.jupiter.api.AfterAll;
@@ -83,6 +86,7 @@ class LoadableRoleProcessingIT extends BaseIntegrationTest {
 
   @MockitoSpyBean private LoadableRoleCapabilityAssignmentHelper assignmentHelper;
   @MockitoSpyBean private LoadableRoleCapabilityAssignmentProcessor assignmentProcessor;
+  @MockitoSpyBean private RolePermissionService rolePermissionService;
 
   @BeforeAll
   static void beforeAll() {
@@ -405,6 +409,64 @@ class LoadableRoleProcessingIT extends BaseIntegrationTest {
         assertThat(roleCapabilityCount(resolvedSecondRole.getId(), capabilityId)).isEqualTo(1);
       });
     }
+  }
+
+  @Test
+  @KeycloakRealms("/json/keycloak/role-loadable-processing-realm.json")
+  void handleCapabilityEvent_positive_allRolesAssignedAfterUniqueViolationRetry() throws Exception {
+    var permissionName = "notes.collection.get";
+    var firstRoleName = "Unique Violation First Role";
+
+    // Step 1: Create two roles having permission "notes.collection.get" before the capability exists,
+    // so both have unresolved (null) capability ids, mirroring parallel entitlement.
+    doPut("/loadable-roles", new LoadableRole()
+      .name(firstRoleName)
+      .description("First role competing for the capability")
+      .permissions(List.of(new LoadablePermission().permissionName(permissionName))));
+
+    var secondRoleName = "Unique Violation Second Role";
+    doPut("/loadable-roles", new LoadableRole()
+      .name(secondRoleName)
+      .description("Second role competing for the capability")
+      .permissions(List.of(new LoadablePermission().permissionName(permissionName))));
+
+    // Step 2: For the first role processed by the capability event, insert the same role-capability row through
+    // a separate committed connection right inside the check-then-insert window (createPermissions runs between
+    // the duplicate check and the insert). This simulates a concurrent entitlement flow winning the race and
+    // makes the event transaction fail with a unique-constraint violation on commit.
+    var conflictInserted = new AtomicBoolean();
+    doAnswer(invocation -> {
+      if (conflictInserted.compareAndSet(false, true)) {
+        UUID roleId = invocation.getArgument(0);
+        // a separate thread gets its own auto-committed connection instead of joining the event transaction
+        var conflictingInsert = new Thread(() -> {
+          var capabilityId = jdbcTemplate.queryForObject(
+            "select id from test_mod_roles_keycloak.capability where folio_permission = ?", UUID.class,
+            permissionName);
+          jdbcTemplate.update("insert into test_mod_roles_keycloak.role_capability (role_id, capability_id) "
+            + "values (?, ?)", roleId, capabilityId);
+        });
+        conflictingInsert.start();
+        conflictingInsert.join();
+      }
+      return invocation.callRealMethod();
+    }).when(rolePermissionService).createPermissions(any(), anyList());
+
+    // Step 3: Send the event through the broker, so that the Kafka error handler applies its retry policy.
+    // The first delivery fails with the unique-constraint violation and must be redelivered, not skipped;
+    // the redelivery assigns the capability to both roles idempotently.
+    sendCapabilityEvent("json/kafka-events/be-notes-capability-event.json");
+
+    await().untilAsserted(() -> {
+      var capabilityId = getExistingCapabilities().get(permissionName).getId();
+      var firstRole = getLoadableRoleByName(firstRoleName);
+      var secondRole = getLoadableRoleByName(secondRoleName);
+
+      assertThat(findPermission(firstRole, permissionName).getCapabilityId()).isEqualTo(capabilityId);
+      assertThat(findPermission(secondRole, permissionName).getCapabilityId()).isEqualTo(capabilityId);
+      assertThat(roleCapabilityCount(firstRole.getId(), capabilityId)).isEqualTo(1);
+      assertThat(roleCapabilityCount(secondRole.getId(), capabilityId)).isEqualTo(1);
+    });
   }
 
   @Test

--- a/src/test/java/org/folio/roles/service/loadablerole/LoadableRoleCapabilityAssignmentProcessorTest.java
+++ b/src/test/java/org/folio/roles/service/loadablerole/LoadableRoleCapabilityAssignmentProcessorTest.java
@@ -8,8 +8,12 @@ import static org.folio.roles.support.CapabilitySetUtils.CAPABILITY_SET_ID;
 import static org.folio.roles.support.CapabilitySetUtils.capabilitySet;
 import static org.folio.roles.support.CapabilitySetUtils.extendedCapabilitySet;
 import static org.folio.roles.support.CapabilityUtils.capability;
+import static org.folio.roles.support.LoadablePermissionUtils.loadablePermission;
 import static org.folio.roles.support.LoadablePermissionUtils.loadablePermissions;
 import static org.folio.roles.support.TestUtils.copy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -34,6 +38,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.SimpleTransactionStatus;
 
 @UnitTest
 @ExtendWith(MockitoExtension.class)
@@ -45,6 +52,7 @@ class LoadableRoleCapabilityAssignmentProcessorTest {
   @Mock private CapabilityService capabilityService;
   @Mock private RoleCapabilityService roleCapabilityService;
   @Mock private RoleCapabilitySetService roleCapabilitySetService;
+  @Mock private PlatformTransactionManager transactionManager;
   private FolioExecutionContext context;
 
   @BeforeEach
@@ -60,6 +68,8 @@ class LoadableRoleCapabilityAssignmentProcessorTest {
   @Test
   void handleCapabilitiesCreatedEvent_positive() {
     var permission = "permission1";
+    when(transactionManager.getTransaction(any())).thenReturn(new SimpleTransactionStatus());
+    doNothing().when(transactionManager).commit(any());
     var capabilityId = randomUUID();
 
     var perms = loadablePermissions(5);
@@ -87,6 +97,35 @@ class LoadableRoleCapabilityAssignmentProcessorTest {
   }
 
   @Test
+  void handleCapabilitiesCreatedEvent_positive_siblingRoleAssignedWhenOneRoleFails() {
+    var permission = "permission1";
+    var failedPerm = loadablePermission(randomUUID(), permission);
+    failedPerm.setCapabilityId(null);
+    var siblingPerm = loadablePermission(randomUUID(), permission);
+    siblingPerm.setCapabilityId(null);
+
+    when(service.findAllByPermissions(List.of(permission))).thenReturn(List.of(failedPerm, siblingPerm));
+    when(transactionManager.getTransaction(any())).thenReturn(new SimpleTransactionStatus());
+
+    var capabilityId = randomUUID();
+    var duplicateKey = new DataIntegrityViolationException("duplicate key value violates unique constraint");
+    when(roleCapabilityService.create(failedPerm.getRoleId(), List.of(capabilityId), true)).thenThrow(duplicateKey);
+    when(roleCapabilityService.create(siblingPerm.getRoleId(), List.of(capabilityId), true)).thenReturn(null);
+    var savedSiblingPerms = List.of(copy(siblingPerm).capabilityId(capabilityId));
+    when(service.saveAll(savedSiblingPerms)).thenReturn(savedSiblingPerms);
+
+    var capability = capability(capabilityId, permission);
+    var event = (CapabilityEvent) CapabilityEvent.created(capability).withContext(context);
+
+    assertThatThrownBy(() -> processor.handleCapabilitiesCreatedEvent(event)).isSameAs(duplicateKey);
+
+    verify(service).saveAll(savedSiblingPerms);
+    verify(transactionManager, times(2)).getTransaction(any());
+    verify(transactionManager).commit(any());
+    verify(transactionManager).rollback(any());
+  }
+
+  @Test
   void handleCapabilitiesCreatedEvent_positive_loadablePermissionsNotFound() {
     var permission = "permission1";
     var capability = capability(randomUUID(), permission);
@@ -101,6 +140,8 @@ class LoadableRoleCapabilityAssignmentProcessorTest {
   @Test
   void handleCapabilitiesUpdateEvent_positive() {
     var permission = "permission1";
+    when(transactionManager.getTransaction(any())).thenReturn(new SimpleTransactionStatus());
+    doNothing().when(transactionManager).commit(any());
     var capabilityId = randomUUID();
 
     var perms = loadablePermissions(5);
@@ -152,6 +193,8 @@ class LoadableRoleCapabilityAssignmentProcessorTest {
 
     when(capabilityService.findByNames(List.of(capabilitySet.getName()))).thenReturn(List.of(capability));
     when(service.findAllByPermissions(List.of(capability.getPermission()))).thenReturn(perms);
+    when(transactionManager.getTransaction(any())).thenReturn(new SimpleTransactionStatus());
+    doNothing().when(transactionManager).commit(any());
     perms.forEach(perm -> {
       when(roleCapabilitySetService.create(perm.getRoleId(), List.of(capabilitySet.getId()), true)).thenReturn(null);
 


### PR DESCRIPTION
## Purpose

After a full environment rebuild (all applications entitled in parallel), some capabilities were intermittently missing from default system-user loadable roles (`default-system-role-<module>`) and stayed missing until the next rebuild. This is the residual race left after MODROLESKC-347: two writers concurrently insert the same `role_capability` row, the capability-event transaction fails with a unique-constraint violation, rolls back the assignments it had already made for sibling roles, and the event is then permanently skipped.

US: [MODROLESKC-414](https://folio-org.atlassian.net/browse/MODROLESKC-414)

## Approach

The capability-event processor assigns a new capability to every matching loadable role in a single transaction. When a concurrent entitlement flow commits the same `(role, capability)` row first, the processor's insert hits the `role_capability` primary-key violation (SQLState 23505), the whole transaction rolls back — discarding sibling roles' already-performed assignments — and the Kafka error handler classifies the failure as non-retryable and skips the record. Since redelivery of a capability event is idempotent (existing capabilities take the update path and `safeCreate=true` skips already-assigned roles), the fix is to retry on unique-constraint violations instead of skipping, and to isolate each role's assignment in its own transaction so one role's conflict no longer discards the others' work.

- Introduced `isUniqueConstraintViolation` in `KafkaConfiguration`, which walks the exception cause chain for a `java.sql.SQLException` with SQLState `23505`; `getBackOff` now returns the configured retry back-off for such errors instead of the terminal `FixedBackOff(0L, 0L)`. Anchoring on the SQL state (rather than a specific wrapper type) covers both the in-transaction flush failure and the commit-time `TransactionSystemException` shape without importing the PostgreSQL driver.
- Changed `LoadableRoleCapabilityAssignmentProcessor.applyActionToRoles` to run each role's assignment in its own `REQUIRES_NEW` transaction via a `TransactionTemplate`, injecting `PlatformTransactionManager`. Per-role failures are collected and the first is rethrown after all roles are attempted, so already-committed sibling assignments survive while the Kafka error handler still sees the original exception and retries the failed role.

## Pre-Review Checklist

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Dependent module build verification** — Ran manually when library changes impact downstream modules.
  > Actions → Verify Dependent Modules → Run workflow → select branch → Run.
- [ ] **Breaking Changes (if any)** — Handled if changes affect integration with other services.
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
