### PR TITLE
MODROLESKC-416: migrate duplicate modperms capability

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,11 @@
 ## Version `v4.1.0` (IN PROGRESS)
-* Migrate duplicate capability/capability-set `modperms_circulation_requests_queue_reorder_collection.execute` to `.create` after permission mapping change (MODROLESKC-416)
 * Improve cleanup of keycloak records upon role removal (MODROLESKC-384)
 * Fix race condition that could leave default loadable-role permissions without assigned capabilities during tenant initialization (MODROLESKC-347)
 * Delete the Log4j configuration so the logging settings are automatically inherited from `folio-spring-base`. (EUREKA-889)
 * Upgrade dependencies for Kafka 4.2 compatibility in mod-roles-keycloak (MODROLESKC-411)
 * Add `dedup` query parameter and `direct` flag for `GET /roles/{id}/capabilities`, add performance indexes (MODROLESKC-408)
 * Retry capability events on unique-constraint violations and isolate per-role capability assignment in separate transactions, so a concurrent assignment no longer loses sibling roles' capabilities (MODROLESKC-414)
+* Migrate duplicate capability/capability-set `modperms_circulation_requests_queue_reorder_collection.execute` to `.create` after permission mapping change (MODROLESKC-416)
 
 ## Version `v4.0.0` (16.04.2025)
 * Added endpoint to create or update default roles via REST API (MODROLESKC-301)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## Version `v4.1.0` (IN PROGRESS)
+* Migrate duplicate capability/capability-set `modperms_circulation_requests_queue_reorder_collection.execute` to `.create` after permission mapping change (MODROLESKC-416)
 * Improve cleanup of keycloak records upon role removal (MODROLESKC-384)
 * Fix race condition that could leave default loadable-role permissions without assigned capabilities during tenant initialization (MODROLESKC-347)
 * Delete the Log4j configuration so the logging settings are automatically inherited from `folio-spring-base`. (EUREKA-889)

--- a/src/main/java/org/folio/roles/service/migration/CapabilitiesMergeService.java
+++ b/src/main/java/org/folio/roles/service/migration/CapabilitiesMergeService.java
@@ -27,6 +27,9 @@ public class CapabilitiesMergeService {
       capabilityDuplicateMigrationService.migrate(
         "organizations_acquisition_units_assignment.create",
         "ui-organizations_acqunits.execute");
+      capabilityDuplicateMigrationService.migrate(
+        "modperms_circulation_requests_queue_reorder_collection.execute",
+        "modperms_circulation_requests_queue_reorder_collection.create");
       log.info("Capability duplicates merge completed successfully");
     } catch (Exception e) {
       log.warn("Error during capability duplicates merge", e);

--- a/src/test/java/org/folio/roles/service/migration/CapabilitiesMergeServiceTest.java
+++ b/src/test/java/org/folio/roles/service/migration/CapabilitiesMergeServiceTest.java
@@ -25,6 +25,9 @@ class CapabilitiesMergeServiceTest {
     verify(capabilityDuplicateMigrationService).migrate(
       "organizations_acquisition_units_assignment.create",
       "ui-organizations_acqunits.execute");
+    verify(capabilityDuplicateMigrationService).migrate(
+      "modperms_circulation_requests_queue_reorder_collection.execute",
+      "modperms_circulation_requests_queue_reorder_collection.create");
   }
 
   @Test


### PR DESCRIPTION
## Purpose

Adds a tenant-update migration for the duplicated `modperms_circulation_requests_queue_reorder_collection` capability and capability set created by the `.collection.post` permission remapping. The migration moves existing assignments from the old `.execute` name to the new `.create` replacement during the next module update. This prevents existing role and user links from remaining attached to the dead capability after the mapping change.

https://folio-org.atlassian.net/browse/MODROLESKC-416

## Approach

- Added a new hardcoded duplicate migration in `CapabilitiesMergeService` from `modperms_circulation_requests_queue_reorder_collection.execute` to `modperms_circulation_requests_queue_reorder_collection.create`.
- Extended `CapabilitiesMergeServiceTest` to verify the new migration pair is invoked.
- Updated `NEWS.md` for MODROLESKC-416.

## Pre-Review Checklist

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes (if any)** — Handled if changes affect integration with other services.
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.