### PR TITLE
MODROLESKC-418: Enforce Role Name Character Constraint on Internal Write Paths

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 * Add `dedup` query parameter and `direct` flag for `GET /roles/{id}/capabilities`, add performance indexes (MODROLESKC-408)
 * Retry capability events on unique-constraint violations and isolate per-role capability assignment in separate transactions, so a concurrent assignment no longer loses sibling roles' capabilities (MODROLESKC-414)
 * Migrate duplicate capability/capability-set `modperms_circulation_requests_queue_reorder_collection.execute` to `.create` after permission mapping change (MODROLESKC-416)
+* Enforce Role Name Character Constraint on Internal Write Paths (MODROLESKC-418)
 
 ## Version `v4.0.0` (16.04.2025)
 * Added endpoint to create or update default roles via REST API (MODROLESKC-301)

--- a/src/main/java/org/folio/roles/service/loadablerole/LoadableRoleService.java
+++ b/src/main/java/org/folio/roles/service/loadablerole/LoadableRoleService.java
@@ -3,6 +3,7 @@ package org.folio.roles.service.loadablerole;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.groupingBy;
+import static org.apache.commons.collections4.CollectionUtils.emptyIfNull;
 import static org.apache.commons.collections4.CollectionUtils.isEmpty;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.folio.common.utils.CollectionUtils.mapItems;
@@ -13,6 +14,8 @@ import static org.folio.roles.service.ServiceUtils.comparatorById;
 import static org.folio.roles.service.ServiceUtils.merge;
 import static org.folio.roles.service.ServiceUtils.mergeInBatch;
 import static org.folio.roles.service.ServiceUtils.nothing;
+import static org.folio.roles.utils.RoleNameUtils.FORBIDDEN_NAME_CHARACTER;
+import static org.folio.roles.utils.RoleNameUtils.hasForbiddenCharacters;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -28,11 +31,13 @@ import org.folio.roles.domain.dto.RoleType;
 import org.folio.roles.domain.entity.LoadablePermissionEntity;
 import org.folio.roles.domain.entity.LoadableRoleEntity;
 import org.folio.roles.domain.entity.type.EntityRoleType;
+import org.folio.roles.exception.RequestValidationException;
 import org.folio.roles.exception.ServiceException;
 import org.folio.roles.integration.keyclock.KeycloakRoleService;
 import org.folio.roles.mapper.LoadableRoleMapper;
 import org.folio.roles.repository.LoadableRoleRepository;
 import org.folio.roles.service.ServiceUtils.UpdatePair;
+import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.data.OffsetRequest;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
@@ -49,6 +54,7 @@ public class LoadableRoleService {
   private final KeycloakRoleService keycloakService;
   private final LoadableRoleCapabilityAssignmentHelper assignmentHelper;
   private final ApplicationEventPublisher applicationEventPublisher;
+  private final FolioExecutionContext folioExecutionContext;
 
   @Transactional(readOnly = true)
   public LoadableRoles find(String query, Integer limit, Integer offset) {
@@ -82,6 +88,7 @@ public class LoadableRoleService {
 
   @Transactional
   public LoadableRole save(LoadableRole role) {
+    validateRoleName(role);
     var entity = mapper.toRoleEntity(role);
 
     var saved = saveOrUpdate(entity);
@@ -90,12 +97,18 @@ public class LoadableRoleService {
 
   @Transactional
   public void saveAll(List<LoadableRole> roles) {
+    for (var role : emptyIfNull(roles)) {
+      validateRoleName(role);
+    }
+
     toStream(roles).collect(groupingBy(LoadableRole::getType))
       .forEach(this::saveAllByType);
   }
 
   @Transactional
   public LoadableRole upsertDefaultLoadableRole(LoadableRole loadableRole) {
+    validateRoleName(loadableRole);
+    
     prepareLoadableRole(loadableRole);
     var incoming = mapper.toRoleEntity(loadableRole);
     var existing = findAllDefaultRolesNotLoadedFromFiles();
@@ -117,6 +130,16 @@ public class LoadableRoleService {
       keycloakService.deleteById(id);
     } catch (Exception exception) {
       log.debug("Failed to delete Role in Keycloak: id = {}", id, exception);
+    }
+  }
+
+  private void validateRoleName(LoadableRole role) {
+    var name = role.getName();
+    if (hasForbiddenCharacters(name)) {
+      log.warn("Role name contains a forbidden character: name = {}, tenant = {}",
+        name, folioExecutionContext.getTenantId());
+      throw new RequestValidationException(
+        "Role name must not contain '" + FORBIDDEN_NAME_CHARACTER + "' character", "name", name);
     }
   }
 

--- a/src/main/java/org/folio/roles/service/reference/RolesDataLoader.java
+++ b/src/main/java/org/folio/roles/service/reference/RolesDataLoader.java
@@ -1,9 +1,13 @@
 package org.folio.roles.service.reference;
 
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
-import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+import static org.apache.commons.collections4.CollectionUtils.emptyIfNull;
+import static org.apache.commons.lang3.ObjectUtils.getIfNull;
 import static org.folio.common.utils.CollectionUtils.toStream;
 import static org.folio.roles.domain.dto.RoleType.DEFAULT;
+import static org.folio.roles.utils.RoleNameUtils.FORBIDDEN_NAME_CHARACTER;
+import static org.folio.roles.utils.RoleNameUtils.hasForbiddenCharacters;
 
 import java.util.List;
 import java.util.Set;
@@ -18,6 +22,8 @@ import org.folio.roles.domain.model.PlainLoadableRole;
 import org.folio.roles.domain.model.PlainLoadableRoles;
 import org.folio.roles.service.loadablerole.LoadableRoleService;
 import org.folio.roles.utils.ResourceHelper;
+import org.folio.roles.utils.ResourceHelper.SourcedResource;
+import org.folio.spring.FolioExecutionContext;
 import org.springframework.stereotype.Component;
 
 @Log4j2
@@ -29,16 +35,36 @@ public class RolesDataLoader implements ReferenceDataLoader {
 
   private final LoadableRoleService service;
   private final ResourceHelper resourceHelper;
+  private final FolioExecutionContext folioExecutionContext;
 
   @Override
   public void loadReferenceData() {
-    var incoming = resourceHelper.readObjectsFromDirectory(ROLES_DATA_DIR, PlainLoadableRoles.class)
-      .flatMap(roles -> toStream(roles.getRoles()))
-      .map(role -> role.type(defaultIfNull(role.getType(), DEFAULT)))
+    var sourcedRoles =
+      resourceHelper.readSourcedObjectsFromDirectory(ROLES_DATA_DIR, PlainLoadableRoles.class).toList();
+
+    sourcedRoles.forEach(this::validateRoleNames);
+
+    var incoming = sourcedRoles.stream()
+      .flatMap(sourced -> toStream(sourced.value().getRoles()))
+      .map(role -> role.type(getIfNull(role.getType(), DEFAULT)))
       .map(this::convertToLoadableRole)
       .toList();
 
     service.saveAll(incoming);
+  }
+
+  private void validateRoleNames(SourcedResource<PlainLoadableRoles> sourced) {
+    for (var role : emptyIfNull(sourced.value().getRoles())) {
+      var name = role.getName();
+      
+      if (hasForbiddenCharacters(name)) {
+        log.error("Role name contains a forbidden character: name = {}, source = {}, tenant = {}",
+          name, sourced.source(), folioExecutionContext.getTenantId());
+
+        throw new IllegalArgumentException(format("Role name must not contain '%s': name = %s, source = %s",
+          FORBIDDEN_NAME_CHARACTER, name, sourced.source()));
+      }
+    }
   }
 
   private LoadableRole convertToLoadableRole(PlainLoadableRole plainRole) {

--- a/src/main/java/org/folio/roles/utils/ResourceHelper.java
+++ b/src/main/java/org/folio/roles/utils/ResourceHelper.java
@@ -28,8 +28,30 @@ public class ResourceHelper {
    * @return list of deserialized data
    */
   public <T> Stream<T> readObjectsFromDirectory(String resourceDir, Class<T> resourceType) {
+    return readSourced(resourceDir, resourceType)
+      .map(SourcedResource::value);
+  }
+
+  /**
+   * Loads json data from the specified directory and deserializes it to the specified type, keeping the path of the
+   * file each object was read from.
+   *
+   * @param resourceDir  directory to load json data from
+   * @param resourceType type of data
+   * @param <T>          type of data
+   * @return list of deserialized data paired with the source file path
+   */
+  public <T> Stream<SourcedResource<T>> readSourcedObjectsFromDirectory(String resourceDir, Class<T> resourceType) {
+    return readSourced(resourceDir, resourceType);
+  }
+
+  private <T> Stream<SourcedResource<T>> readSourced(String resourceDir, Class<T> resourceType) {
     return stream(getResources(resourceDir))
-      .map(res -> deserializeResource(res, resourceType));
+      .map(res -> new SourcedResource<>(sourceOf(resourceDir, res), deserializeResource(res, resourceType)));
+  }
+
+  private static String sourceOf(String resourceDir, Resource res) {
+    return resourceDir + "/" + res.getFilename();
   }
 
   private <T> T deserializeResource(Resource res, Class<T> resourceType) {
@@ -49,4 +71,13 @@ public class ResourceHelper {
       throw new IllegalStateException("Failed to load data for path: " + resourceDir, e);
     }
   }
+
+  /**
+   * Deserialized object together with the path of the file it was read from.
+   *
+   * @param source path of the file the value was read from
+   * @param value  deserialized value
+   * @param <T>    type of the deserialized value
+   */
+  public record SourcedResource<T>(String source, T value) {}
 }

--- a/src/main/java/org/folio/roles/utils/RoleNameUtils.java
+++ b/src/main/java/org/folio/roles/utils/RoleNameUtils.java
@@ -1,0 +1,33 @@
+package org.folio.roles.utils;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class RoleNameUtils {
+
+  /**
+   * Character that must never appear in a role name.
+   *
+   * <p>Keycloak serializes role-policy associations using this character as a delimiter between a client id and a
+   * role name. On import the same split is applied to every entry, so a realm role containing it is misread as a
+   * client role reference and the import fails.</p>
+   */
+  public static final String FORBIDDEN_NAME_CHARACTER = "/";
+
+  /**
+   * Role name pattern. Must be kept in sync with the {@code name} property in
+   * {@code swagger.api/schemas/role/role.json}.
+   */
+  public static final String ROLE_NAME_PATTERN = "^[^/]+$";
+
+  /**
+   * Checks if the given role name contains characters that are not allowed in a role name.
+   *
+   * @param roleName - role name to check
+   * @return true if the name contains a forbidden character, false otherwise
+   */
+  public static boolean hasForbiddenCharacters(String roleName) {
+    return roleName != null && roleName.contains(FORBIDDEN_NAME_CHARACTER);
+  }
+}

--- a/src/main/resources/swagger.api/schemas/role/role.json
+++ b/src/main/resources/swagger.api/schemas/role/role.json
@@ -10,8 +10,11 @@
       "format": "uuid"
     },
     "name": {
-      "description": "A human-readable name/label for this role",
-      "type": "string"
+      "description": "A human-readable name/label for this role. Must not contain a '/' character",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 255,
+      "pattern": "^[^/]+$"
     },
     "description": {
       "description": "Free form description of the role",

--- a/src/test/java/org/folio/roles/it/LoadableRoleProcessingIT.java
+++ b/src/test/java/org/folio/roles/it/LoadableRoleProcessingIT.java
@@ -13,6 +13,7 @@ import static org.folio.roles.utils.TestValues.readValue;
 import static org.folio.spring.integration.XOkapiHeaders.TENANT;
 import static org.folio.spring.integration.XOkapiHeaders.USER_ID;
 import static org.folio.test.TestUtils.parseResponse;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -20,6 +21,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
 import static org.springframework.test.context.jdbc.SqlMergeMode.MergeMode.MERGE;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.List;
@@ -213,6 +215,28 @@ class LoadableRoleProcessingIT extends BaseIntegrationTest {
     assertThat(createdRole.getDescription()).isEqualTo(role.getDescription());
     assertThat(createdRole.getPermissions()).hasSize(1);
     assertThat(createdRole.getPermissions().getFirst().getPermissionName()).isEqualTo("test.permission");
+  }
+
+  @Test
+  @KeycloakRealms("/json/keycloak/role-loadable-processing-realm.json")
+  void upsertLoadableRole_negative_roleNameContainsForbiddenCharacter() throws Exception {
+    var invalidName = "Circulation/Manager";
+    var role = new LoadableRole()
+      .name(invalidName)
+      .description("Role with a forbidden character in the name")
+      .permissions(List.of(new LoadablePermission().permissionName("test.permission")));
+
+    attemptPut("/loadable-roles", role)
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.errors[0].code", is("validation_error")))
+      .andExpect(jsonPath("$.errors[0].parameters[0].key", is("name")))
+      .andExpect(jsonPath("$.errors[0].parameters[0].value", is(invalidName)));
+
+    var loadableRoles = parseResponse(doGet(get("/loadable-roles")
+      .header(TENANT, TENANT_ID)
+      .header(USER_ID, USER_ID_HEADER)).andReturn(), LoadableRoles.class);
+
+    assertThat(loadableRoles.getLoadableRoles()).noneMatch(r -> invalidName.equals(r.getName()));
   }
 
   @Test

--- a/src/test/java/org/folio/roles/it/ReferenceRoleLoadingIT.java
+++ b/src/test/java/org/folio/roles/it/ReferenceRoleLoadingIT.java
@@ -1,6 +1,6 @@
 package org.folio.roles.it;
 
-import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+import static org.apache.commons.lang3.ObjectUtils.getIfNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.common.utils.CollectionUtils.toStream;
 import static org.folio.roles.domain.dto.RoleType.DEFAULT;
@@ -25,6 +25,7 @@ import org.folio.roles.domain.dto.LoadableRoles;
 import org.folio.roles.domain.model.PlainLoadableRoles;
 import org.folio.roles.service.reference.PoliciesDataLoader;
 import org.folio.roles.utils.ResourceHelper;
+import org.folio.roles.utils.ResourceHelper.SourcedResource;
 import org.folio.tenant.domain.dto.Parameter;
 import org.folio.tenant.domain.dto.TenantAttributes;
 import org.folio.test.extensions.KeycloakRealms;
@@ -48,10 +49,10 @@ class ReferenceRoleLoadingIT extends BaseIntegrationTest {
   private PoliciesDataLoader policiesDataLoader;
   @MockitoBean
   private ResourceHelper resourceHelper;
-  private PlainLoadableRoles circAdminRole;
-  private PlainLoadableRoles circObserverRole;
-  private PlainLoadableRoles circStaffRole;
-  private PlainLoadableRoles circStudentRole;
+  private SourcedResource<PlainLoadableRoles> circAdminRole;
+  private SourcedResource<PlainLoadableRoles> circObserverRole;
+  private SourcedResource<PlainLoadableRoles> circStaffRole;
+  private SourcedResource<PlainLoadableRoles> circStudentRole;
   @Autowired private Keycloak keycloak;
 
   @BeforeEach
@@ -72,7 +73,7 @@ class ReferenceRoleLoadingIT extends BaseIntegrationTest {
   @Test
   @KeycloakRealms("classpath:json/keycloak/test-realm-ref-data.json")
   void defaultRolesInitialized_positive() throws Exception {
-    when(resourceHelper.readObjectsFromDirectory(anyString(), eq(PlainLoadableRoles.class)))
+    when(resourceHelper.readSourcedObjectsFromDirectory(anyString(), eq(PlainLoadableRoles.class)))
       .thenReturn(Stream.of(circObserverRole, circStaffRole, circStudentRole));
 
     enableTenant(TENANT_ID, TENANT_ATTR);
@@ -89,7 +90,7 @@ class ReferenceRoleLoadingIT extends BaseIntegrationTest {
   @Test
   @KeycloakRealms("classpath:json/keycloak/test-realm-ref-data.json")
   void defaultRolesUpgraded_positive_rolesAddedAndDeleted() throws Exception {
-    when(resourceHelper.readObjectsFromDirectory(anyString(), eq(PlainLoadableRoles.class)))
+    when(resourceHelper.readSourcedObjectsFromDirectory(anyString(), eq(PlainLoadableRoles.class)))
       .thenReturn(Stream.of(circObserverRole, circStaffRole, circStudentRole))
       .thenReturn(Stream.of(circAdminRole, circObserverRole, circStaffRole)); // admin added, student removed
 
@@ -139,7 +140,7 @@ class ReferenceRoleLoadingIT extends BaseIntegrationTest {
   @Test
   @KeycloakRealms("classpath:json/keycloak/test-realm-ref-data.json")
   void defaultRolesUpgraded_positive_roleNameAndDescriptionChanged() throws Exception {
-    when(resourceHelper.readObjectsFromDirectory(anyString(), eq(PlainLoadableRoles.class)))
+    when(resourceHelper.readSourcedObjectsFromDirectory(anyString(), eq(PlainLoadableRoles.class)))
       .thenReturn(Stream.of(circObserverRole, circStaffRole, circStudentRole))
       .thenReturn(Stream.of(circObserverRole, circStaffRole, circStudentRole));
 
@@ -164,7 +165,7 @@ class ReferenceRoleLoadingIT extends BaseIntegrationTest {
   @Test
   @KeycloakRealms("classpath:json/keycloak/test-realm-ref-data.json")
   void defaultRolesUpgraded_positive_permissionsChanged() throws Exception {
-    when(resourceHelper.readObjectsFromDirectory(anyString(), eq(PlainLoadableRoles.class)))
+    when(resourceHelper.readSourcedObjectsFromDirectory(anyString(), eq(PlainLoadableRoles.class)))
       .thenReturn(Stream.of(circObserverRole, circStaffRole, circStudentRole))
       .thenReturn(Stream.of(circObserverRole, circStaffRole, circStudentRole));
 
@@ -186,16 +187,18 @@ class ReferenceRoleLoadingIT extends BaseIntegrationTest {
     );
   }
 
-  private void changeNameAndDescription(PlainLoadableRoles roleToChange, List<LoadableRole> existingRoles) {
-    var role = roleToChange.getRoles().getFirst();
+  private void changeNameAndDescription(SourcedResource<PlainLoadableRoles> roleToChange,
+    List<LoadableRole> existingRoles) {
+    var role = roleToChange.value().getRoles().getFirst();
     var roleId = findRoleIdByName(existingRoles, role.getName());
     role.setId(roleId);
     role.setName(role.getName() + " updated");
     role.setDescription(role.getDescription() + " updated");
   }
 
-  private void changePermissions(PlainLoadableRoles roleToChange, List<LoadableRole> existingRoles) {
-    var role = roleToChange.getRoles().getFirst();
+  private void changePermissions(SourcedResource<PlainLoadableRoles> roleToChange,
+    List<LoadableRole> existingRoles) {
+    var role = roleToChange.value().getRoles().getFirst();
     var roleId = findRoleIdByName(existingRoles, role.getName());
     role.setId(roleId);
 
@@ -210,11 +213,11 @@ class ReferenceRoleLoadingIT extends BaseIntegrationTest {
       .findFirst().map(LoadableRole::getId).orElse(null);
   }
 
-  private static ThrowingConsumer<LoadableRole> roleMatches(PlainLoadableRoles expectedPlainRole) {
+  private static ThrowingConsumer<LoadableRole> roleMatches(SourcedResource<PlainLoadableRoles> expectedPlainRole) {
     return role -> {
-      var expected = expectedPlainRole.getRoles().getFirst();
+      var expected = expectedPlainRole.value().getRoles().getFirst();
       assertThat(role.getId()).isNotNull();
-      assertThat(role.getType()).isEqualTo(defaultIfNull(expected.getType(), DEFAULT));
+      assertThat(role.getType()).isEqualTo(getIfNull(expected.getType(), DEFAULT));
       assertThat(role.getName()).isEqualTo(expected.getName());
       assertThat(role.getDescription()).isEqualTo(expected.getDescription());
       assertThat(role.getMetadata()).isNotNull();
@@ -235,11 +238,12 @@ class ReferenceRoleLoadingIT extends BaseIntegrationTest {
     };
   }
 
-  private static PlainLoadableRoles readRole(String filename) {
-    return readValue("json/reference-data/roles/" + filename, PlainLoadableRoles.class);
+  private static SourcedResource<PlainLoadableRoles> readRole(String filename) {
+    return new SourcedResource<>("reference-data/roles/" + filename,
+      readValue("json/reference-data/roles/" + filename, PlainLoadableRoles.class));
   }
 
-  private static String name(PlainLoadableRoles loadableRole) {
-    return loadableRole.getRoles().getFirst().getName();
+  private static String name(SourcedResource<PlainLoadableRoles> loadableRole) {
+    return loadableRole.value().getRoles().getFirst().getName();
   }
 }

--- a/src/test/java/org/folio/roles/it/RoleKeycloakIT.java
+++ b/src/test/java/org/folio/roles/it/RoleKeycloakIT.java
@@ -159,7 +159,7 @@ class RoleKeycloakIT extends BaseIntegrationTest {
       assertNotNull(find(roles.getRoles(),
         role -> ROLE_2.getName().equals(role.getName()) && ROLE_2.getDescription().equals(role.getDescription())));
 
-      var role1Metadata = roles.getRoles().get(0).getMetadata();
+      var role1Metadata = roles.getRoles().getFirst().getMetadata();
       assertNotNull(role1Metadata.getCreatedByUserId());
       assertNotNull(role1Metadata.getCreatedDate());
       assertNotNull(role1Metadata.getUpdatedByUserId());
@@ -179,6 +179,61 @@ class RoleKeycloakIT extends BaseIntegrationTest {
         .header(USER_ID, USER_ID_HEADER)
         .contentType(APPLICATION_JSON))
       .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void createRole_negative_roleNameContainsForbiddenCharacter() throws Exception {
+    var invalidName = "Circulation/Administrator";
+
+    mockMvc.perform(post("/roles")
+        .content(asJsonString(new Role().name(invalidName).description("test description")))
+        .header(TENANT, TENANT_ID)
+        .header(USER_ID, USER_ID_HEADER)
+        .contentType(APPLICATION_JSON))
+      .andExpect(status().isBadRequest())
+      .andExpect(content().contentType(APPLICATION_JSON))
+      .andExpect(jsonPath("$.errors[0].code", is("validation_error")))
+      .andExpect(jsonPath("$.errors[0].parameters[0].key", is("name")))
+      .andExpect(jsonPath("$.errors[0].parameters[0].value", is(invalidName)));
+
+    var roles = parseResponse(doGet("/roles").andReturn(), Roles.class);
+    assertThat(roles.getRoles()).noneMatch(role -> invalidName.equals(role.getName()));
+  }
+
+  @Test
+  void createRoles_negative_roleNameContainsForbiddenCharacter() throws Exception {
+    var invalidRole = new Role().name("Circulation/Administrator").description("invalid");
+
+    mockMvc.perform(post("/roles/batch")
+        .content(asJsonString(new RolesRequest().addRolesItem(ROLE_1).addRolesItem(invalidRole)))
+        .header(TENANT, TENANT_ID)
+        .header(USER_ID, USER_ID_HEADER)
+        .contentType(APPLICATION_JSON))
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.errors[0].code", is("validation_error")));
+
+    var roles = parseResponse(doGet("/roles").andReturn(), Roles.class);
+    assertThat(roles.getRoles()).isEmpty();
+  }
+
+  @Test
+  @Sql("classpath:/sql/populate-role.sql")
+  void updateRole_negative_roleNameContainsForbiddenCharacter() throws Exception {
+    var invalidName = "Circulation/Administrator";
+    var roleForUpdate = new Role().id(ROLE_1.getId()).name(invalidName).description("updated description");
+
+    mockMvc.perform(put("/roles/{id}", ROLE_1.getId())
+        .header(TENANT, TENANT_ID)
+        .header(USER_ID, USER_ID_HEADER)
+        .content(asJsonString(roleForUpdate))
+        .contentType(APPLICATION_JSON))
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.errors[0].code", is("validation_error")))
+      .andExpect(jsonPath("$.errors[0].parameters[0].key", is("name")));
+
+    var actual = parseResponse(doGet("/roles/{id}", ROLE_1.getId()).andReturn(), Role.class);
+    assertEquals(ROLE_1.getName(), actual.getName());
+    assertEquals(ROLE_1.getDescription(), actual.getDescription());
   }
 
   @Test

--- a/src/test/java/org/folio/roles/service/loadablerole/LoadableRoleServiceTest.java
+++ b/src/test/java/org/folio/roles/service/loadablerole/LoadableRoleServiceTest.java
@@ -287,7 +287,8 @@ class LoadableRoleServiceTest {
 
       when(folioExecutionContext.getTenantId()).thenReturn(TENANT_ID);
 
-      assertThatThrownBy(() -> service.saveAll(List.of(validRole, invalidRole)))
+      var args = List.of(validRole, invalidRole);
+      assertThatThrownBy(() -> service.saveAll(args))
         .isInstanceOf(RequestValidationException.class)
         .hasMessage("Role name must not contain '/' character");
 

--- a/src/test/java/org/folio/roles/service/loadablerole/LoadableRoleServiceTest.java
+++ b/src/test/java/org/folio/roles/service/loadablerole/LoadableRoleServiceTest.java
@@ -8,6 +8,7 @@ import static org.folio.roles.support.LoadableRoleUtils.loadableRole;
 import static org.folio.roles.support.LoadableRoleUtils.loadableRoleEntity;
 import static org.folio.roles.support.LoadableRoleUtils.regularRole;
 import static org.folio.roles.support.RoleUtils.role;
+import static org.folio.roles.support.TestConstants.TENANT_ID;
 import static org.folio.roles.support.TestUtils.copy;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
@@ -19,11 +20,13 @@ import java.util.Optional;
 import java.util.stream.Stream;
 import org.folio.roles.domain.entity.LoadablePermissionEntity;
 import org.folio.roles.domain.entity.type.EntityRoleType;
+import org.folio.roles.exception.RequestValidationException;
 import org.folio.roles.exception.ServiceException;
 import org.folio.roles.integration.keyclock.KeycloakRoleService;
 import org.folio.roles.mapper.LoadableRoleMapper;
 import org.folio.roles.repository.LoadableRoleRepository;
 import org.folio.roles.support.TestUtils;
+import org.folio.spring.FolioExecutionContext;
 import org.folio.test.types.UnitTest;
 import org.instancio.junit.InstancioExtension;
 import org.junit.jupiter.api.AfterEach;
@@ -48,6 +51,7 @@ class LoadableRoleServiceTest {
   @Mock private KeycloakRoleService keycloakService;
   @Mock private LoadableRoleCapabilityAssignmentHelper capabilityAssignmentHelper;
   @Mock private ApplicationEventPublisher applicationEventPublisher;
+  @Mock private FolioExecutionContext folioExecutionContext;
 
   @AfterEach
   void tearDown() {
@@ -235,6 +239,59 @@ class LoadableRoleServiceTest {
           assertThat(se.getKey()).isEqualTo("cause");
           assertThat(se.getValue()).isEqualTo("Keycloak error");
         });
+    }
+  }
+
+  @Nested
+  @DisplayName("roleNameValidation")
+  class RoleNameValidation {
+
+    private static final String INVALID_NAME = "Circulation/Manager";
+
+    @Test
+    void upsertDefaultLoadableRole_negative_nameContainsForbiddenCharacter() {
+      var role = copy(loadableRole()).name(INVALID_NAME);
+
+      when(folioExecutionContext.getTenantId()).thenReturn(TENANT_ID);
+
+      assertThatThrownBy(() -> service.upsertDefaultLoadableRole(role))
+        .isInstanceOf(RequestValidationException.class)
+        .hasMessage("Role name must not contain '/' character")
+        .satisfies(throwable -> {
+          var rve = (RequestValidationException) throwable;
+
+          assertThat(rve.getKey()).isEqualTo("name");
+          assertThat(rve.getValue()).isEqualTo(INVALID_NAME);
+        });
+
+      verifyNoInteractions(repository, mapper, keycloakService);
+    }
+
+    @Test
+    void save_negative_nameContainsForbiddenCharacter() {
+      var role = copy(loadableRole()).name(INVALID_NAME);
+
+      when(folioExecutionContext.getTenantId()).thenReturn(TENANT_ID);
+
+      assertThatThrownBy(() -> service.save(role))
+        .isInstanceOf(RequestValidationException.class)
+        .hasMessage("Role name must not contain '/' character");
+
+      verifyNoInteractions(repository, mapper, keycloakService);
+    }
+
+    @Test
+    void saveAll_negative_nameContainsForbiddenCharacter() {
+      var validRole = loadableRole();
+      var invalidRole = copy(loadableRole()).name(INVALID_NAME);
+
+      when(folioExecutionContext.getTenantId()).thenReturn(TENANT_ID);
+
+      assertThatThrownBy(() -> service.saveAll(List.of(validRole, invalidRole)))
+        .isInstanceOf(RequestValidationException.class)
+        .hasMessage("Role name must not contain '/' character");
+
+      verifyNoInteractions(repository, mapper, keycloakService);
     }
   }
 }

--- a/src/test/java/org/folio/roles/service/reference/ReferenceDataRoleNamesTest.java
+++ b/src/test/java/org/folio/roles/service/reference/ReferenceDataRoleNamesTest.java
@@ -1,0 +1,52 @@
+package org.folio.roles.service.reference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.folio.roles.domain.model.PlainLoadableRoles;
+import org.folio.roles.utils.JsonHelper;
+import org.folio.roles.utils.ResourceHelper;
+import org.folio.roles.utils.ResourceHelper.SourcedResource;
+import org.folio.roles.utils.RoleNameUtils;
+import org.folio.test.TestUtils;
+import org.folio.test.types.UnitTest;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards the bundled reference data against role names that Keycloak cannot round-trip through realm
+ * export/import. See {@link RoleNameUtils#FORBIDDEN_NAME_CHARACTER}.
+ */
+@UnitTest
+class ReferenceDataRoleNamesTest {
+
+  private static final String ROLES_DATA_DIR = "reference-data/roles";
+
+  private final ResourceHelper resourceHelper = new ResourceHelper(new JsonHelper(TestUtils.OBJECT_MAPPER));
+
+  @Test
+  void bundledRoleNames_positive_noForbiddenCharacters() {
+    var roles = resourceHelper.readSourcedObjectsFromDirectory(ROLES_DATA_DIR, PlainLoadableRoles.class).toList();
+
+    assertThat(roles).isNotEmpty();
+    assertThat(roles).allSatisfy(sourced -> assertThat(sourced.value().getRoles())
+      .as("role names in %s", sourced.source())
+      .noneMatch(role -> RoleNameUtils.hasForbiddenCharacters(role.getName())));
+  }
+
+  @Test
+  void bundledRoleNames_positive_matchApiSchemaPattern() {
+    var roles = resourceHelper.readSourcedObjectsFromDirectory(ROLES_DATA_DIR, PlainLoadableRoles.class).toList();
+
+    assertThat(roles).allSatisfy(sourced -> assertThat(sourced.value().getRoles())
+      .as("role names in %s", sourced.source())
+      .allMatch(role -> role.getName().matches(RoleNameUtils.ROLE_NAME_PATTERN)));
+  }
+
+  @Test
+  void bundledRoleNames_positive_withinDatabaseColumnLength() {
+    var roles = resourceHelper.readSourcedObjectsFromDirectory(ROLES_DATA_DIR, PlainLoadableRoles.class).toList();
+
+    assertThat(roles).extracting(SourcedResource::value)
+      .flatExtracting(PlainLoadableRoles::getRoles)
+      .allSatisfy(role -> assertThat(role.getName()).isNotEmpty().hasSizeLessThanOrEqualTo(255));
+  }
+}

--- a/src/test/java/org/folio/roles/service/reference/ReferenceDataRoleNamesTest.java
+++ b/src/test/java/org/folio/roles/service/reference/ReferenceDataRoleNamesTest.java
@@ -26,8 +26,7 @@ class ReferenceDataRoleNamesTest {
   void bundledRoleNames_positive_noForbiddenCharacters() {
     var roles = resourceHelper.readSourcedObjectsFromDirectory(ROLES_DATA_DIR, PlainLoadableRoles.class).toList();
 
-    assertThat(roles).isNotEmpty();
-    assertThat(roles).allSatisfy(sourced -> assertThat(sourced.value().getRoles())
+    assertThat(roles).isNotEmpty().allSatisfy(sourced -> assertThat(sourced.value().getRoles())
       .as("role names in %s", sourced.source())
       .noneMatch(role -> RoleNameUtils.hasForbiddenCharacters(role.getName())));
   }
@@ -36,8 +35,7 @@ class ReferenceDataRoleNamesTest {
   void bundledRoleNames_positive_matchApiSchemaPattern() {
     var roles = resourceHelper.readSourcedObjectsFromDirectory(ROLES_DATA_DIR, PlainLoadableRoles.class).toList();
 
-    assertThat(roles).isNotEmpty();
-    assertThat(roles).allSatisfy(sourced -> assertThat(sourced.value().getRoles())
+    assertThat(roles).isNotEmpty().allSatisfy(sourced -> assertThat(sourced.value().getRoles())
       .as("role names in %s", sourced.source())
       .allMatch(role -> role.getName().matches(RoleNameUtils.ROLE_NAME_PATTERN)));
   }

--- a/src/test/java/org/folio/roles/service/reference/ReferenceDataRoleNamesTest.java
+++ b/src/test/java/org/folio/roles/service/reference/ReferenceDataRoleNamesTest.java
@@ -36,6 +36,7 @@ class ReferenceDataRoleNamesTest {
   void bundledRoleNames_positive_matchApiSchemaPattern() {
     var roles = resourceHelper.readSourcedObjectsFromDirectory(ROLES_DATA_DIR, PlainLoadableRoles.class).toList();
 
+    assertThat(roles).isNotEmpty();
     assertThat(roles).allSatisfy(sourced -> assertThat(sourced.value().getRoles())
       .as("role names in %s", sourced.source())
       .allMatch(role -> role.getName().matches(RoleNameUtils.ROLE_NAME_PATTERN)));

--- a/src/test/java/org/folio/roles/service/reference/RolesDataLoaderTest.java
+++ b/src/test/java/org/folio/roles/service/reference/RolesDataLoaderTest.java
@@ -5,7 +5,9 @@ import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.folio.common.utils.CollectionUtils.mapItems;
 import static org.folio.roles.domain.dto.RoleType.DEFAULT;
+import static org.folio.roles.support.TestConstants.TENANT_ID;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -19,6 +21,8 @@ import org.folio.roles.domain.model.PlainLoadableRoles;
 import org.folio.roles.service.loadablerole.LoadableRoleService;
 import org.folio.roles.support.TestUtils;
 import org.folio.roles.utils.ResourceHelper;
+import org.folio.roles.utils.ResourceHelper.SourcedResource;
+import org.folio.spring.FolioExecutionContext;
 import org.folio.test.types.UnitTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -31,9 +35,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class RolesDataLoaderTest {
 
+  private static final String ROLES_DIR = "reference-data/roles";
+
   @InjectMocks private RolesDataLoader rolesDataLoader;
   @Mock private LoadableRoleService roleService;
   @Mock private ResourceHelper resourceHelper;
+  @Mock private FolioExecutionContext folioExecutionContext;
 
   @AfterEach
   void tearDown() {
@@ -43,10 +50,10 @@ class RolesDataLoaderTest {
   @Test
   void loadReferenceData_positive_ifCreate() {
     var role = new PlainLoadableRole().name("role1");
-    var roles = new PlainLoadableRoles().roles(List.of(role));
+    var roles = sourced("role1.json", role);
     var loadableRole = new LoadableRole().name(role.getName()).type(DEFAULT).permissions(emptyList());
 
-    when(resourceHelper.readObjectsFromDirectory("reference-data/roles", PlainLoadableRoles.class))
+    when(resourceHelper.readSourcedObjectsFromDirectory(ROLES_DIR, PlainLoadableRoles.class))
       .thenReturn(Stream.of(roles));
     when(roleService.findByIdOrName(role.getId(), role.getName())).thenReturn(Optional.empty());
     doNothing().when(roleService).saveAll(List.of(loadableRole));
@@ -59,7 +66,7 @@ class RolesDataLoaderTest {
     var role = new PlainLoadableRole().id(randomUUID())
       .name("role1").description("description1")
       .permissions(Set.of("permission1", "permission2"));
-    var roles = new PlainLoadableRoles().roles(List.of(role));
+    var roles = sourced("role1.json", role);
     var loadableRole = new LoadableRole().id(role.getId()).type(DEFAULT)
       .name(role.getName()).description(role.getDescription())
       .permissions(mapItems(role.getPermissions(), perm -> new LoadablePermission(perm).roleId(role.getId())));
@@ -67,7 +74,7 @@ class RolesDataLoaderTest {
     var existingLoadableRole = new LoadableRole().id(role.getId())
       .name(role.getName()).type(DEFAULT).permissions(emptyList());
 
-    when(resourceHelper.readObjectsFromDirectory("reference-data/roles", PlainLoadableRoles.class))
+    when(resourceHelper.readSourcedObjectsFromDirectory(ROLES_DIR, PlainLoadableRoles.class))
       .thenReturn(Stream.of(roles));
     when(roleService.findByIdOrName(role.getId(), role.getName())).thenReturn(Optional.of(existingLoadableRole));
     doNothing().when(roleService).saveAll(List.of(loadableRole));
@@ -77,10 +84,31 @@ class RolesDataLoaderTest {
 
   @Test
   void loadReferenceData_negative_ifReadError() {
-    when(resourceHelper.readObjectsFromDirectory("reference-data/roles", PlainLoadableRoles.class))
+    when(resourceHelper.readSourcedObjectsFromDirectory(ROLES_DIR, PlainLoadableRoles.class))
       .thenThrow(new IllegalStateException("Failed to deserialize data"));
 
     assertThatThrownBy(() -> rolesDataLoader.loadReferenceData()).isInstanceOf(IllegalStateException.class)
       .hasMessage("Failed to deserialize data");
+  }
+
+  @Test
+  void loadReferenceData_negative_roleNameContainsForbiddenCharacter() {
+    var validRole = new PlainLoadableRole().name("role1");
+    var invalidRole = new PlainLoadableRole().name("Circulation/Administrator");
+
+    when(resourceHelper.readSourcedObjectsFromDirectory(ROLES_DIR, PlainLoadableRoles.class))
+      .thenReturn(Stream.of(sourced("role1.json", validRole), sourced("circ-admin-role.json", invalidRole)));
+    when(folioExecutionContext.getTenantId()).thenReturn(TENANT_ID);
+
+    assertThatThrownBy(() -> rolesDataLoader.loadReferenceData())
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Role name must not contain '/': name = Circulation/Administrator, "
+        + "source = reference-data/roles/circ-admin-role.json");
+
+    verifyNoInteractions(roleService);
+  }
+
+  private static SourcedResource<PlainLoadableRoles> sourced(String fileName, PlainLoadableRole role) {
+    return new SourcedResource<>(ROLES_DIR + "/" + fileName, new PlainLoadableRoles().roles(List.of(role)));
   }
 }

--- a/src/test/java/org/folio/roles/utils/ResourceHelperTest.java
+++ b/src/test/java/org/folio/roles/utils/ResourceHelperTest.java
@@ -19,12 +19,13 @@ class ResourceHelperTest {
   void readSourcedObjectsFromDirectory_positive() {
     var actual = resourceHelper.readSourcedObjectsFromDirectory(ROLES_DIR, PlainLoadableRoles.class).toList();
 
-    assertThat(actual).isNotEmpty();
-    assertThat(actual).allSatisfy(sourced -> {
-      assertThat(sourced.source()).startsWith(ROLES_DIR + "/").endsWith(".json");
-      assertThat(sourced.value().getRoles()).isNotEmpty();
-    });
-    assertThat(actual).extracting(SourcedResource::source)
+    assertThat(actual)
+      .isNotEmpty()
+      .allSatisfy(sourced -> {
+        assertThat(sourced.source()).startsWith(ROLES_DIR + "/").endsWith(".json");
+        assertThat(sourced.value().getRoles()).isNotEmpty();
+      })
+      .extracting(SourcedResource::source)
       .contains(ROLES_DIR + "/circ-admin-role.json");
   }
 

--- a/src/test/java/org/folio/roles/utils/ResourceHelperTest.java
+++ b/src/test/java/org/folio/roles/utils/ResourceHelperTest.java
@@ -1,0 +1,39 @@
+package org.folio.roles.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.folio.roles.domain.model.PlainLoadableRoles;
+import org.folio.roles.utils.ResourceHelper.SourcedResource;
+import org.folio.test.TestUtils;
+import org.folio.test.types.UnitTest;
+import org.junit.jupiter.api.Test;
+
+@UnitTest
+class ResourceHelperTest {
+
+  private static final String ROLES_DIR = "json/reference-data/roles";
+
+  private final ResourceHelper resourceHelper = new ResourceHelper(new JsonHelper(TestUtils.OBJECT_MAPPER));
+
+  @Test
+  void readSourcedObjectsFromDirectory_positive() {
+    var actual = resourceHelper.readSourcedObjectsFromDirectory(ROLES_DIR, PlainLoadableRoles.class).toList();
+
+    assertThat(actual).isNotEmpty();
+    assertThat(actual).allSatisfy(sourced -> {
+      assertThat(sourced.source()).startsWith(ROLES_DIR + "/").endsWith(".json");
+      assertThat(sourced.value().getRoles()).isNotEmpty();
+    });
+    assertThat(actual).extracting(SourcedResource::source)
+      .contains(ROLES_DIR + "/circ-admin-role.json");
+  }
+
+  @Test
+  void readObjectsFromDirectory_positive_returnsSameValuesWithoutSource() {
+    var sourced = resourceHelper.readSourcedObjectsFromDirectory(ROLES_DIR, PlainLoadableRoles.class).toList();
+
+    var actual = resourceHelper.readObjectsFromDirectory(ROLES_DIR, PlainLoadableRoles.class).toList();
+
+    assertThat(actual).isEqualTo(sourced.stream().map(SourcedResource::value).toList());
+  }
+}

--- a/src/test/java/org/folio/roles/utils/RoleNameUtilsTest.java
+++ b/src/test/java/org/folio/roles/utils/RoleNameUtilsTest.java
@@ -2,6 +2,7 @@ package org.folio.roles.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.regex.Pattern;
 import org.folio.test.types.UnitTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -50,9 +51,10 @@ class RoleNameUtilsTest {
 
   @Test
   void roleNamePattern_positive_matchesForbiddenCharacterCheck() {
-    assertThat("Circulation Administrator".matches(RoleNameUtils.ROLE_NAME_PATTERN)).isTrue();
-    assertThat("Circulation/Administrator".matches(RoleNameUtils.ROLE_NAME_PATTERN)).isFalse();
-    assertThat("".matches(RoleNameUtils.ROLE_NAME_PATTERN)).isFalse();
-    assertThat("Circulation/Administrator\n".matches(RoleNameUtils.ROLE_NAME_PATTERN)).isFalse();
+    var pattern = Pattern.compile(RoleNameUtils.ROLE_NAME_PATTERN);
+    assertThat("Circulation Administrator").matches(pattern);
+    assertThat("Circulation/Administrator").doesNotMatch(pattern);
+    assertThat("").doesNotMatch(pattern);
+    assertThat("Circulation/Administrator\n").doesNotMatch(pattern);
   }
 }

--- a/src/test/java/org/folio/roles/utils/RoleNameUtilsTest.java
+++ b/src/test/java/org/folio/roles/utils/RoleNameUtilsTest.java
@@ -1,0 +1,58 @@
+package org.folio.roles.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.folio.test.types.UnitTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@UnitTest
+class RoleNameUtilsTest {
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+    "Circulation/Administrator",
+    "/",
+    "/leading",
+    "trailing/",
+    "a/b/c",
+    "3d61e5e0a06e0c8bdd7f6dd0f1e8bb61f28e6b1c/suffix"
+  })
+  void hasForbiddenCharacters_positive_nameContainsSlash(String roleName) {
+    var actual = RoleNameUtils.hasForbiddenCharacters(roleName);
+
+    assertThat(actual).isTrue();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+    "Circulation Administrator",
+    "Cataloger basic-view.v1~2",
+    "My Role - v1.0~a",
+    "3d61e5e0a06e0c8bdd7f6dd0f1e8bb61f28e6b1c",
+    "role\\with\\backslash"
+  })
+  void hasForbiddenCharacters_negative_compliantName(String roleName) {
+    var actual = RoleNameUtils.hasForbiddenCharacters(roleName);
+
+    assertThat(actual).isFalse();
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  void hasForbiddenCharacters_negative_nullOrEmptyName(String roleName) {
+    var actual = RoleNameUtils.hasForbiddenCharacters(roleName);
+
+    assertThat(actual).isFalse();
+  }
+
+  @Test
+  void roleNamePattern_positive_matchesForbiddenCharacterCheck() {
+    assertThat("Circulation Administrator".matches(RoleNameUtils.ROLE_NAME_PATTERN)).isTrue();
+    assertThat("Circulation/Administrator".matches(RoleNameUtils.ROLE_NAME_PATTERN)).isFalse();
+    assertThat("".matches(RoleNameUtils.ROLE_NAME_PATTERN)).isFalse();
+    assertThat("Circulation/Administrator\n".matches(RoleNameUtils.ROLE_NAME_PATTERN)).isFalse();
+  }
+}


### PR DESCRIPTION
### Purpose

A `/` in a role name breaks Keycloak realm export/import. Keycloak writes role-policy references as `clientId/roleName` for client roles and as a bare name for realm roles, then splits every entry on the first `/` when importing — so a realm role containing the character is misread as a client-role reference and the import fails. There is no way to escape it, so the character must never reach the database. Two paths in this module write roles without going through the roles service, and both are closed here.

US: [MODROLESKC-418](https://folio-org.atlassian.net/browse/MODROLESKC-418)

### Approach

The restriction is defined once and enforced at three points: the API schema, the reference-data loader during tenant initialization, and the loadable-role service just before it persists. The loader fails fast, so a bad name in a bundled file stops the tenant from being initialized rather than half-seeding it, and both internal checks log enough context to trace where the name came from.

**Implementation details:**

- Restricted the role `name` in the API schema (`schemas/role/role.json`) to exclude `/`, with a 1–255 length bound matching the `role.name` column. Bean validation is generated from the schema, so role create, batch create, update and loadable-role upsert are all now rejected at the request boundary with a field-level error.
- Defined the restriction in a single place, `RoleNameUtils`, so the schema and the two internal checks cannot drift apart.
- Made `RolesDataLoader` validate every bundled role file before it converts or writes anything. A non-compliant name aborts tenant initialization, and the error identifies both the role and the file it came from.
- Added the same check to `LoadableRoleService`, immediately before it writes, covering callers that reach the service without passing through the REST layer.
- Extended `ResourceHelper` to keep track of which file each role was read from. The filename was previously discarded during deserialization, so the loader had no way to report it.
- Included the tenant identifier in both rejection log messages.

### Pre-Review Checklist

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Dependent module build verification** — Ran manually when library changes impact downstream modules.
  > Actions → Verify Dependent Modules → Run workflow → select branch → Run.
- [x] **Breaking Changes (if any)** — Handled if changes affect integration with other services.
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
